### PR TITLE
Fix a number of unsafe operations (mostly forced unwrapping)

### DIFF
--- a/sourcekitten/main.swift
+++ b/sourcekitten/main.swift
@@ -34,8 +34,8 @@ Print message to STDERR. Useful for UI messages without affecting STDOUT data.
 :param: message message to print.
 */
 func printSTDERR(message: String) {
-    let stderr = NSFileHandle.fileHandleWithStandardError()
     if let data = (message + "\n").dataUsingEncoding(NSUTF8StringEncoding) {
+        let stderr = NSFileHandle.fileHandleWithStandardError()
         stderr.writeData(data)
     }
 }


### PR DESCRIPTION
Swift is nice. I just searched for exclamation marks and made the program safer almost mechanically.
