### PR TITLE
Mention that git clone should be used for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ SourceKitten links and communicates with `sourcekitd.framework` to parse the Swi
 
 ![Test Status](https://travis-ci.org/jpsim/SourceKitten.svg?branch=master)
 
-## Command Line Usage
+## Installation
+Install the `sourcekitten` command line tool by running `git clone` for this repo followed by `make install` in the root directory. Make sure that Xcode 6.1 is set in `xcode-select` before running `make`.
 
-Install the `sourcekitten` command line tool by running `make install`, first making sure that Xcode 6.1 is set in `xcode-select`.
+
+## Command Line Usage
 
 By default, SourceKitten will use the copy of `sourcekitd.framework` under `/Applications/Xcode.app` (preferrably Xcode 6.1 or later).
 


### PR DESCRIPTION
Just ran into this small issue: downloaded the master branch as zip file. Didn't see that this project depends on git submodules, so installation failed.

We could also mention that ZIP download + using carthage to install dependencies works as well, but I think that would be overkill.