### PR TITLE
don't automatically pass in `-dry-run` when running xcodebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ None.
   [JP Simard](https://github.com/jpsim)
   [#27](https://github.com/jpsim/SourceKitten/issues/27)
 
+* Fixed issues where USR wasn't accurate because dependencies couldn't be
+  resolved.  
+  [JP Simard](https://github.com/jpsim)
+
 
 ## 0.3.0
 

--- a/Source/SourceKittenFramework/ClangTranslationUnit.swift
+++ b/Source/SourceKittenFramework/ClangTranslationUnit.swift
@@ -51,7 +51,7 @@ public struct ClangTranslationUnit {
     :param: path                Path to run `xcodebuild` from. Uses current path by default.
     */
     public init?(headerFiles: [String], xcodeBuildArguments: [String], inPath path: String = NSFileManager.defaultManager().currentDirectoryPath) {
-        let xcodeBuildOutput = runXcodeBuildDryRun(xcodeBuildArguments, inPath: path) ?? ""
+        let xcodeBuildOutput = runXcodeBuild(xcodeBuildArguments + ["-dry-run"], inPath: path) ?? ""
         if let clangArguments = parseCompilerArguments(xcodeBuildOutput, language: .ObjC, moduleName: nil) {
             self.init(headerFiles: headerFiles, compilerArguments: clangArguments)
             return

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -38,7 +38,7 @@ public struct Module {
     :param: path                Path to run `xcodebuild` from. Uses current path by default.
     */
     public init?(xcodeBuildArguments: [String], name: String? = nil, inPath path: String = NSFileManager.defaultManager().currentDirectoryPath) {
-        let xcodeBuildOutput = runXcodeBuildDryRun(xcodeBuildArguments, inPath: path) ?? ""
+        let xcodeBuildOutput = runXcodeBuild(xcodeBuildArguments, inPath: path) ?? ""
         if let arguments = parseCompilerArguments(xcodeBuildOutput, language: .Swift, moduleName: name ?? moduleNameFromArguments(xcodeBuildArguments)) {
             if let moduleName = moduleNameFromArguments(arguments) {
                 self.init(name: moduleName, compilerArguments: arguments)
@@ -75,20 +75,20 @@ extension Module: Printable {
 }
 
 /**
-Run `xcodebuild clean build -dry-run` along with any passed in build arguments.
+Run `xcodebuild clean build` along with any passed in build arguments.
 
 :param: arguments Arguments to pass to `xcodebuild`.
 :param: path      Path to run `xcodebuild` from.
 
 :returns: `xcodebuild`'s STDERR+STDOUT output combined.
 */
-internal func runXcodeBuildDryRun(arguments: [String], inPath path: String) -> String? {
-    fputs("Running xcodebuild -dry-run\n", stderr)
+internal func runXcodeBuild(arguments: [String], inPath path: String) -> String? {
+    fputs("Running xcodebuild\n", stderr)
 
     let task = NSTask()
     task.launchPath = "/usr/bin/xcodebuild"
     task.currentDirectoryPath = path
-    task.arguments = arguments + ["clean", "build", "-dry-run", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"]
+    task.arguments = arguments + ["clean", "build", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"]
 
     let pipe = NSPipe()
     task.standardOutput = pipe


### PR DESCRIPTION
Until we find a way to index an Xcode project programmatically, or to avoid relying on sending `cursor.info` requests to get docs, we'll have to default to actually building the scheme being documented.

I also updated the xcodebuild argument filtering based on trial and error, comparing the arguments from `xcodebuild` to what Xcode sends to SourceKit.