### PR TITLE
Increase robustness of file path handling.

### DIFF
--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -22,7 +22,7 @@ public struct File {
     :param: path File path.
     */
     public init?(path: String) {
-        self.path = path
+        self.path = (path as NSString).absolutePathRepresentation()
         if let contents = NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) as String? {
             self.contents = contents
         } else {


### PR DESCRIPTION
This makes relative paths absolute before handing them off to SourceKit,
which avoids XPC errors when invoking sourcekitten with relative file
paths.

Fixes #43