### PR TITLE
Revert "[Travis] remove .travis.yml until it supports Xcode 6.3.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: objective-c
+osx_image: beta-xcode6.3
+git:
+  submodules: false
+branches:
+  only:
+    - master
+script: script/cibuild
+notifications:
+  email: false
+  slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An adorable little framework and command line tool for interacting with [SourceK
 
 SourceKitten links and communicates with `sourcekitd.framework` to parse the Swift AST, extract comment docs for Swift or Objective-C projects, get syntax data for a Swift file and lots more!
 
+![Test Status](https://travis-ci.org/jpsim/SourceKitten.svg?branch=master)
+
 ## Installation
 
 Install the `sourcekitten` command line tool by running `git clone` for this repo followed by `make install` in the root directory. Make sure that Xcode 6.3 is set in `xcode-select` before running `make`.


### PR DESCRIPTION
This reverts commit 425c950350c9086b0527129e64ae9b0cbe0e6d74.