### PR TITLE
Add File lines convenience method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## master
+
+##### Breaking
+
+None.
+
+##### Enhancements
+
+* Add `lines` convenience property to `File`  
+  [Keith Smiley](https://github.com/keith)
+
+##### Bug Fixes
+
+None.
+
+
 ## 0.4.4
 
 ##### Breaking

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -16,6 +16,10 @@ public struct File {
     public let path: String?
     /// File contents.
     public let contents: String
+    /// File lines.
+    lazy public var lines: [Line] = {
+        return self.contents.lines()
+    }()
 
     /**
     Failable initializer by path. Fails if file contents could not be read as a UTF8 string.

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+public typealias Line = (index: Int, content: String)
+
 private let whitespaceAndNewlineCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
 
 extension NSString {
@@ -150,6 +152,18 @@ extension NSString {
 }
 
 extension String {
+    /**
+    Returns an array of Lines for each line in the file
+    */
+    internal func lines() -> [Line] {
+        var lines = [Line]()
+        var lineIndex = 1
+        enumerateLines { line, _ in
+            lines.append((lineIndex++, line))
+        }
+        return lines
+    }
+
     /**
     Returns true if self is an Objective-C header file.
     */


### PR DESCRIPTION
This adds a lines accessory to File. This can be useful if you want to iterate over all lines in the file multiple times.

This will be super useful in [SwiftLint](https://github.com/realm/SwiftLint) where the same file is being used over and over and the contents of that file are broken into these lines many times. If this PR looks good I'll submit one to SwiftLint with the necessary changes.

The one downside to this is the file needs to be a `var` since this property is lazy. I think that is preferred over setting the lines for every file since they won't always be used.