### PR TITLE
Make File lines a immutable property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## master
+
+##### Breaking
+
+None.
+
+##### Enhancements
+
+* Update `File` `lines` convenience property to be immutable.  
+  [Keith Smiley](https://github.com/keith)
+
+##### Bug Fixes
+
+None.
+
+
 ## 0.4.5
 
 ##### Breaking

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -16,9 +16,7 @@ public struct File {
     /// File contents.
     public let contents: String
     /// File lines.
-    lazy public var lines: [Line] = {
-        return self.contents.lines()
-    }()
+    public let lines: [Line]
 
     /**
     Failable initializer by path. Fails if file contents could not be read as a UTF8 string.
@@ -29,6 +27,7 @@ public struct File {
         self.path = path
         do {
             self.contents = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            self.lines = self.contents.lines()
         } catch {
             fputs("Could not read contents of `\(path)`\n", stderr)
             return nil
@@ -43,6 +42,7 @@ public struct File {
     public init(contents: String) {
         path = nil
         self.contents = contents
+        self.lines = self.contents.lines()
     }
 
     /**


### PR DESCRIPTION
This is a follow up to https://github.com/jpsim/SourceKitten/pull/60

In that PR I said:

> The one downside to this is the file needs to be a `var` since this property is lazy. I think that is preferred over setting the lines for every file since they won't always be used.

I began to implement this in SwiftLint and the changes were pretty severe. Having to make everything a `var` for this, especially with the recent comment region addition, became very ugly very fast.

Again this has the downside that if this property is unused, this is wasted. In the case of SwiftLint this probably won't ever be the case, but in other applications I'm sure it could be.


I wasn't sure where this change would fit into the changelog so I didn't add anything yet, let me know what makes sense and I'll add it. Once this is merged I can submit a PR to SwiftLint to use this cached property instead of computing it each time.