### PR TITLE
fix '--file' option

### DIFF
--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -25,7 +25,9 @@ struct CompleteCommand: CommandType {
                 if let file = File(path: path) {
                     contents = file.contents
                 }
-                return .Failure(.CommandError(.ReadFailed(path: options.file)))
+                else {
+                    return .Failure(.CommandError(.ReadFailed(path: options.file)))
+                }
             } else {
                 path = "\(NSUUID().UUIDString).swift"
                 contents = options.text


### PR DESCRIPTION
conditions that return .failure enum will be only when it fails to read the file.