### PR TITLE
Add compilerargs option to complete command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.5.2
+
+##### Breaking
+
+None.
+
+##### Enhancements
+
+* Add `compilerargs` option to complete command.  
+  [Masayuki Yamaya](https://github.com/yamaya)
+
+##### Bug Fixes
+
+None.
+
+
 ## 0.5.1
 
 ##### Breaking

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ options for the offset in the file/text provided:
 ]
 ```
 
+To use the iOS SDK is to specified the `compilerargs` option. The value
+specified by `compilerargs` the `--` to must be prefixed:
+```
+sourcekitten complete --text "import UIKit ; UIColor." --offset 22 --compilerargs -- '-target arm64-apple-ios9.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk'
+```
+
 ## Doc
 
 Running `sourcekitten doc` will pass all arguments after what is parsed to


### PR DESCRIPTION
To use the iOS SDK is "complete" command, `-target` option must also be appropriately used.
So, I have added a `compilerargs` as an option to pass any of the compiler options to SourceKit.