### PR TITLE
Fix bug where documentation inside a function would crash SourceKitten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ None.
 
 ##### Bug Fixes
 
-None.
+* Fix a bug where documentation inside a function would crash SourceKitten.  
+  [JP Simard](https://github.com/jpsim)
+  [#75](https://github.com/jpsim/SourceKitten/issues/75)
 
 
 ## 0.5.2

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -228,8 +228,9 @@ public struct File {
     - returns: True if a doc should be inserted in the parent at the provided offset.
     */
     private func shouldInsert(parent: XPCDictionary, offset: Int64) -> Bool {
-        return (offset == 0) ||
-            (shouldTreatAsSameFile(parent) && SwiftDocKey.getOffset(parent) == offset)
+        return SwiftDocKey.getSubstructure(parent) != nil &&
+            ((offset == 0) ||
+            (shouldTreatAsSameFile(parent) && SwiftDocKey.getOffset(parent) == offset))
     }
 
     /**


### PR DESCRIPTION
Partially fixes #75.