### PR TITLE
Consider asterisks when trimming the common prefix of comment blocks.

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -12,6 +12,15 @@ public typealias Line = (index: Int, content: String)
 
 private let whitespaceAndNewlineCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
 
+private let commentLinePrefixCharacterSet: NSCharacterSet = {
+  let characterSet = NSMutableCharacterSet.whitespaceAndNewlineCharacterSet()
+  /**
+   * For "wall of asterisk" comment blocks, such as this one.
+   */
+  characterSet.addCharactersInString("*")
+  return characterSet
+}()
+
 extension NSString {
     /**
     Binary search for NSString index equivalent to byte offset.
@@ -301,9 +310,10 @@ extension String {
     /// Returns a copy of `self` with the leading whitespace common in each line removed.
     public func stringByRemovingCommonLeadingWhitespaceFromLines() -> String {
         var minLeadingWhitespace = Int.max
+
         enumerateLines { line, _ in
-            let lineLeadingWhitespace = line.countOfLeadingCharactersInSet(whitespaceAndNewlineCharacterSet)
-            if lineLeadingWhitespace < minLeadingWhitespace && lineLeadingWhitespace != line.characters.count {
+            let lineLeadingWhitespace = line.countOfLeadingCharactersInSet(commentLinePrefixCharacterSet)
+            if lineLeadingWhitespace < minLeadingWhitespace {
                 minLeadingWhitespace = lineLeadingWhitespace
             }
         }

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -309,18 +309,20 @@ extension String {
 
     /// Returns a copy of `self` with the leading whitespace common in each line removed.
     public func stringByRemovingCommonLeadingWhitespaceFromLines() -> String {
-        var minLeadingWhitespace = Int.max
+        var minLeadingCharacters = Int.max
 
         enumerateLines { line, _ in
-            let lineLeadingWhitespace = line.countOfLeadingCharactersInSet(commentLinePrefixCharacterSet)
-            if lineLeadingWhitespace < minLeadingWhitespace {
-                minLeadingWhitespace = lineLeadingWhitespace
+            let lineLeadingWhitespace = line.countOfLeadingCharactersInSet(whitespaceAndNewlineCharacterSet)
+            let lineLeadingCharacters = line.countOfLeadingCharactersInSet(commentLinePrefixCharacterSet)
+            // Is this prefix smaller than our last, not entirely whitespace?
+            if lineLeadingCharacters < minLeadingCharacters && lineLeadingWhitespace != line.characters.count {
+                minLeadingCharacters = lineLeadingCharacters
             }
         }
         var lines = [String]()
         enumerateLines { line, _ in
-            if line.characters.count >= minLeadingWhitespace {
-                lines.append(line[line.startIndex.advancedBy(minLeadingWhitespace)..<line.endIndex])
+            if line.characters.count >= minLeadingCharacters {
+                lines.append(line[line.startIndex.advancedBy(minLeadingCharacters)..<line.endIndex])
             } else {
                 lines.append(line)
             }

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -314,7 +314,7 @@ extension String {
         enumerateLines { line, _ in
             let lineLeadingWhitespace = line.countOfLeadingCharactersInSet(whitespaceAndNewlineCharacterSet)
             let lineLeadingCharacters = line.countOfLeadingCharactersInSet(commentLinePrefixCharacterSet)
-            // Is this prefix smaller than our last, not entirely whitespace?
+            // Is this prefix smaller than our last and not entirely whitespace?
             if lineLeadingCharacters < minLeadingCharacters && lineLeadingWhitespace != line.characters.count {
                 minLeadingCharacters = lineLeadingCharacters
             }


### PR DESCRIPTION
As discussed in https://github.com/realm/jazzy/issues/347.

Verified that this no longer results in wall of asterisk-style documentation turning into a ul.