### PR TITLE
Support hyphenated #pragma mark names.

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -190,9 +190,9 @@ extension NSString {
 
 extension String {
     /// Returns the `#pragma mark`s in the string.
-    /// Just the content; no dashes or leading `#pragma mark`.
+    /// Just the content; no leading dashes or leading `#pragma mark`.
     public func pragmaMarks(filename: String, excludeRanges: [NSRange], limitRange: NSRange?) -> [SourceDeclaration] {
-        let regex = try! NSRegularExpression(pattern: "(#pragma\\smark|@name)[ -]*([^-\\n]+)", options: []) // Safe to force try
+        let regex = try! NSRegularExpression(pattern: "(#pragma\\smark|@name)[ -]*([^\\n]+)", options: []) // Safe to force try
         let range = limitRange ?? NSRange(location: 0, length: utf16.count)
         let matches = regex.matchesInString(self, options: [], range: range)
 

--- a/Source/SourceKittenFrameworkTests/Fixtures/Musician.h
+++ b/Source/SourceKittenFrameworkTests/Fixtures/Musician.h
@@ -23,7 +23,7 @@
  */
 @property (nonatomic, readonly) NSUInteger birthyear;
 
-#pragma mark - Initializers
+#pragma mark - Initializers-hyphenated
 
 /**
  Initialize a JAZMusician.

--- a/Source/SourceKittenFrameworkTests/Fixtures/Musician.json
+++ b/Source/SourceKittenFrameworkTests/Fixtures/Musician.json
@@ -56,7 +56,7 @@
               "key.kind" : "sourcekitten.source.lang.objc.mark",
               "key.doc.file" : "Musician.h",
               "key.doc.line" : 26,
-              "key.name" : "Initializers",
+              "key.name" : "Initializers-hyphenated",
               "key.parsed_scope.start" : 26,
               "key.doc.column" : 1,
               "key.parsed_scope.end" : 26,


### PR DESCRIPTION
A pragma mark like the following:

```
#pragma mark - A partially-hyphenated name
```

Was simply showing up as "A partially" in the generated docs. This adjustment to the regex addresses this - though I'm not sure if the hyphen being part of the regex was addressing a different issue.