### PR TITLE
fix an out-of-bounds issue when generating pragma marks

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -193,7 +193,12 @@ extension String {
     /// Just the content; no leading dashes or leading `#pragma mark`.
     public func pragmaMarks(filename: String, excludeRanges: [NSRange], limitRange: NSRange?) -> [SourceDeclaration] {
         let regex = try! NSRegularExpression(pattern: "(#pragma\\smark|@name)[ -]*([^\\n]+)", options: []) // Safe to force try
-        let range = limitRange ?? NSRange(location: 0, length: utf16.count)
+        let range: NSRange
+        if let limitRange = limitRange {
+            range = NSRange(location: limitRange.location, length: min(utf16.count - limitRange.location, limitRange.length))
+        } else {
+            range = NSRange(location: 0, length: utf16.count)
+        }
         let matches = regex.matchesInString(self, options: [], range: range)
 
         return matches.flatMap { match in


### PR DESCRIPTION
It looks as though clang_getCursorExtent() occasionally exceeds the file's length. This fixes https://github.com/realm/jazzy/issues/370