### PR TITLE
Use `cp -Rf` instead of `cp -rf` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ installables: clean bootstrap
 
 prefix_install: installables
 	mkdir -p "$(FRAMEWORKS_FOLDER)" "$(BINARIES_FOLDER)"
-	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework" "$(FRAMEWORKS_FOLDER)/"
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework" "$(FRAMEWORKS_FOLDER)/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/sourcekitten" "$(BINARIES_FOLDER)/"
 
 package: installables


### PR DESCRIPTION
`-r` option of `cp` copies symbolic links as normal files.
As the result of that, `SourceKittenFramework.framework` that distributed by Homebrew contains a lot of duplicated files inside that.
`-R` option copies symbolic links as symbolic links.

On my testing, this fix reduces the size of `sourcekitten-0.6.0.el_capitan.bottle.tar.gz` from 5.5MB to 2.1MB.