### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Master
+## 0.6.2
 
 ##### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ None.
 
 ##### Bug Fixes
 
-* Add support for C/C++ struct & field types.  
+* Add support for C/C++ struct, field & ivar types.  
   [JP Simard](https://github.com/jpsim)
   [jazzy#374](https://github.com/realm/jazzy/issues/374)
+  [jazzy#387](https://github.com/realm/jazzy/issues/387)
 
 
 ## 0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ None.
 
 ##### Enhancements
 
-None.
+* Increase robustness of file path handling.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#86](https://github.com/jpsim/SourceKitten/issues/86)
 
 ##### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ installables: clean bootstrap
 
 prefix_install: installables
 	mkdir -p "$(FRAMEWORKS_FOLDER)" "$(BINARIES_FOLDER)"
-	cp -rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework" "$(FRAMEWORKS_FOLDER)/"
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework" "$(FRAMEWORKS_FOLDER)/"
 	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/sourcekitten" "$(BINARIES_FOLDER)/"
 
 package: installables

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -25,7 +25,7 @@ public struct File {
     - parameter path: File path.
     */
     public init?(path: String) {
-        self.path = path
+        self.path = (path as NSString).absolutePathRepresentation()
         do {
             contents = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
             lines = contents.lines()

--- a/Source/SourceKittenFramework/Info.plist
+++ b/Source/SourceKittenFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.1</string>
+	<string>0.6.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/SourceKittenFramework/ObjCDeclarationKind.swift
+++ b/Source/SourceKittenFramework/ObjCDeclarationKind.swift
@@ -42,6 +42,8 @@ public enum ObjCDeclarationKind: String {
     case Struct = "sourcekitten.source.lang.objc.decl.struct"
     /// `field`
     case Field = "sourcekitten.source.lang.objc.decl.field"
+    /// `ivar`
+    case Ivar = "sourcekitten.source.lang.objc.decl.ivar"
 
     public static func fromClang(kind: CXCursorKind) -> ObjCDeclarationKind {
         switch kind.rawValue {
@@ -58,6 +60,7 @@ public enum ObjCDeclarationKind: String {
         case CXCursor_FunctionDecl.rawValue: return .Function
         case CXCursor_StructDecl.rawValue: return .Struct
         case CXCursor_FieldDecl.rawValue: return .Field
+        case CXCursor_ObjCIvarDecl.rawValue: return .Ivar
         default: fatalError("Unsupported CXCursorKind: \(clang_getCursorKindSpelling(kind))")
         }
     }

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -159,8 +159,7 @@ public func parseHeaderFilesAndXcodebuildArguments(sourcekittenArguments: [Strin
     var xcodebuildArguments = sourcekittenArguments
     var headerFiles = [String]()
     while let headerFile = xcodebuildArguments.first where headerFile.isObjectiveCHeaderFile() {
-        headerFiles.append(headerFile.absolutePathRepresentation())
-        xcodebuildArguments.removeAtIndex(0)
+        headerFiles.append(xcodebuildArguments.removeAtIndex(0).absolutePathRepresentation())
     }
     return (headerFiles, xcodebuildArguments)
 }

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -24,8 +24,7 @@ struct CompleteCommand: CommandType {
                 path = options.file.absolutePathRepresentation()
                 if let file = File(path: path) {
                     contents = file.contents
-                }
-                else {
+                } else {
                     return .Failure(.CommandError(.ReadFailed(path: options.file)))
                 }
             } else {
@@ -38,8 +37,7 @@ struct CompleteCommand: CommandType {
                 args.appendContentsOf(options.compilerargs.componentsSeparatedByString(" "))
             }
             if args.indexOf("-sdk") == nil {
-                args.append("-sdk")
-                args.append(sdkPath())
+                args.appendContentsOf(["-sdk", sdkPath()])
             }
 
             let request = Request.CodeCompletionRequest(file: path, contents: contents,

--- a/Source/sourcekitten/Info.plist
+++ b/Source/sourcekitten/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.1</string>
+	<string>0.6.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/sourcekitten/StructureCommand.swift
+++ b/Source/sourcekitten/StructureCommand.swift
@@ -18,7 +18,7 @@ struct StructureCommand: CommandType {
     func run(mode: CommandMode) -> Result<(), CommandantError<SourceKittenError>> {
         return StructureOptions.evaluate(mode).flatMap { options in
             if !options.file.isEmpty {
-                if let file = File(path: options.file.absolutePathRepresentation()) {
+                if let file = File(path: options.file) {
                     print(Structure(file: file))
                     return .Success()
                 }

--- a/Source/sourcekitten/SyntaxCommand.swift
+++ b/Source/sourcekitten/SyntaxCommand.swift
@@ -18,7 +18,7 @@ struct SyntaxCommand: CommandType {
     func run(mode: CommandMode) -> Result<(), CommandantError<SourceKittenError>> {
         return SyntaxOptions.evaluate(mode).flatMap { options in
             if !options.file.isEmpty {
-                if let file = File(path: options.file.absolutePathRepresentation()) {
+                if let file = File(path: options.file) {
                     print(SyntaxMap(file: file))
                     return .Success()
                 }

--- a/Source/sourcekitten/VersionCommand.swift
+++ b/Source/sourcekitten/VersionCommand.swift
@@ -9,7 +9,7 @@
 import Commandant
 import Result
 
-private let version = "0.6.1"
+private let version = "0.6.2"
 
 struct VersionCommand: CommandType {
     let verb = "version"

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -4,8 +4,8 @@ jazzy -m SourceKitten \
 -a "JP Simard" \
 -u https://github.com/jpsim/SourceKitten \
 -g https://github.com/jpsim/SourceKitten \
---github-file-prefix https://github.com/jpsim/SourceKitten/blob/0.6.1 \
---module-version 0.6.1 \
+--github-file-prefix https://github.com/jpsim/SourceKitten/blob/0.6.2 \
+--module-version 0.6.2 \
 -r http://www.jpsim.com/SourceKitten/ \
 -x -workspace,SourceKitten.xcworkspace,-scheme,SourceKittenFramework \
 -c


### PR DESCRIPTION
This is `master` minus 083a529 & 2d161d8, which breaks some Swift 1.2 comments. I intend for this release to be used in the last release of jazzy supporting Swift 1.x.