### PR TITLE
make `File` `final class` instead of `struct`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Breaking
 
-None.
+* `File` is now a `final class` instead of a `struct` and `contents` & `lines`
+  are now marked as `var`. This was done so that mutations to the underlying
+  file on disk can be mirrored in a `File` instance.
 
 ##### Enhancements
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -11,13 +11,13 @@ import SwiftXPC
 import SWXMLHash
 
 /// Represents a source file.
-public struct File {
+public final class File {
     /// File path. Nil if initialized directly with `File(contents:)`.
     public let path: String?
     /// File contents.
-    public let contents: String
+    public var contents: String
     /// File lines.
-    public let lines: [Line]
+    public var lines: [Line]
 
     /**
     Failable initializer by path. Fails if file contents could not be read as a UTF8 string.
@@ -31,6 +31,9 @@ public struct File {
             lines = contents.lines()
         } catch {
             fputs("Could not read contents of `\(path)`\n", stderr)
+            // necessary to set contents & lines because of rdar://21744509
+            contents = ""
+            lines = []
             return nil
         }
     }

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -138,7 +138,7 @@ extension NSString {
     /**
     Returns an array of Lines for each line in the file.
     */
-    internal func lines() -> [Line] {
+    public func lines() -> [Line] {
         var lines = [Line]()
         var lineIndex = 1
         enumerateLinesUsingBlock { line, _ in


### PR DESCRIPTION
`File` is now a `final class` instead of a `struct` and `contents` & `lines` are now marked as `var`. This was done so that mutations to the underlying file on disk can be mirrored in a `File` instance.