### PR TITLE
fix stringByTrimmingTrailingCharactersInSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ None.
   [JP Simard](https://github.com/jpsim)
   [#65](https://github.com/jpsim/SourceKitten/issues/65)
 
+* Fix `String.stringByTrimmingTrailingCharactersInSet(_:)` returning full string
+  when all characters matched character set.  
+  [JP Simard](https://github.com/jpsim)
+
 
 ## 0.6.2
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -89,7 +89,7 @@ extension NSString {
                 return substringWithRange(NSRange(location: 0, length: newLength))
             }
         }
-        return self as String
+        return ""
     }
 
     /**

--- a/Source/SourceKittenFrameworkTests/StringTests.swift
+++ b/Source/SourceKittenFrameworkTests/StringTests.swift
@@ -23,6 +23,8 @@ class StringTests: XCTestCase {
     func testStringByTrimmingTrailingCharactersInSet() {
         XCTAssertEqual("".stringByTrimmingTrailingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()), "")
         XCTAssertEqual(" a ".stringByTrimmingTrailingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()), " a")
+        XCTAssertEqual(" ".stringByTrimmingTrailingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()), "")
+        XCTAssertEqual("a".stringByTrimmingTrailingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()), "a")
     }
 
     func testCommentBody() {


### PR DESCRIPTION
Was previously returning full string when all characters matched character set.