### PR TITLE
pull version number from info.plist

### DIFF
--- a/Source/sourcekitten/VersionCommand.swift
+++ b/Source/sourcekitten/VersionCommand.swift
@@ -9,7 +9,8 @@
 import Commandant
 import Result
 
-private let version = "0.6.2"
+private let version = NSBundle.mainBundle()
+    .objectForInfoDictionaryKey("CFBundleShortVersionString")!
 
 struct VersionCommand: CommandType {
     let verb = "version"


### PR DESCRIPTION
rather than hardcode in VersionCommand. Same as https://github.com/realm/SwiftLint/pull/224.