### PR TITLE
Optimize `NSString.NSRangeToByteRange(start:length:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Master
+
+##### Enhancements
+
+* Optimize `NSRange` operation by using `ByteOffsetCache`  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#119](https://github.com/jpsim/SourceKitten/issues/119)
+
 ## 0.7.1
 
 ##### Enhancements

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -25,8 +25,7 @@ private var keyByteOffsetCache = "ByteOffsetCache"
 
 extension NSString {
     /**
-    ByteOffsetCache is cache byte offset and UTF8Index of UTF16 based location.
-    This depends on using for that will be calculated from begening of the string to the end.
+    ByteOffsetCache caches pairs of byte offset and UTF8Index for referencing by UTF16 based location.
     */
     @objc private class ByteOffsetCache: NSObject {
         struct ByteOffsetIndexPair {


### PR DESCRIPTION
Introduce `ByteOffsetCache` for calculating byte offset.
By applying this, linting KeychainAccess by SwiftLint-0.5.1 is reduced from:
```
swiftlint  21.87s user 0.24s system 97% cpu 22.611 total
```
to:
```
swiftlint  16.62s user 0.24s system 97% cpu 17.362 total
```

On Instruments, `NSRangeToByteRange()` is reduced from 6579ms:
<img width="985" alt="screenshot 2015-12-14 11 38 48" src="https://cloud.githubusercontent.com/assets/33430/11771802/9dad8976-a258-11e5-8631-d750d6d06127.png">

 to 315ms:
<img width="988" alt="screenshot 2015-12-14 11 39 43" src="https://cloud.githubusercontent.com/assets/33430/11771806/ac73b656-a258-11e5-8553-e3c528133d93.png">

 on that test.