### PR TITLE
Optimize `SyntaxMap.commentRangeBeforeOffset(_:)`

### DIFF
--- a/Source/SourceKittenFramework/SyntaxMap.swift
+++ b/Source/SourceKittenFramework/SyntaxMap.swift
@@ -72,10 +72,23 @@ public struct SyntaxMap {
     - parameter offset: Last possible byte offset of the range's start.
     */
     public func commentRangeBeforeOffset(offset: Int) -> Range<Int>? {
-        let tokensBeforeOffset = tokens.filter { $0.offset < offset }
-        let commentTokensImmediatelyPrecedingOffset = filterLastContiguous(tokensBeforeOffset) { token in
-            SyntaxKind.docComments().map({$0.rawValue}).contains(token.type)
-        }
+        
+        // be lazy for performance
+        let tokensBeforeOffset = tokens.lazy.reverse().filter { $0.offset < offset }
+        
+        let docTypes = SyntaxKind.docComments().map({$0.rawValue})
+        let isDoc = { (token: SyntaxToken) -> Bool in docTypes.contains(token.type) }
+        let isNotDoc = { !isDoc($0) }
+        
+        guard let commentBegin = tokensBeforeOffset.indexOf(isDoc) else { return nil }
+        let tokensBeginningComment = tokensBeforeOffset.suffixFrom(commentBegin)
+
+        // For avoiding declaring `var` with type annotation before `if let`, use `map()`
+        let commentEnd = tokensBeginningComment.indexOf(isNotDoc)
+        let commentTokensImmediatelyPrecedingOffset = (
+            commentEnd.map(tokensBeginningComment.prefixUpTo) ?? tokensBeginningComment
+                ).reverse()
+        
         return commentTokensImmediatelyPrecedingOffset.first.flatMap { firstToken in
             return commentTokensImmediatelyPrecedingOffset.last.map { lastToken in
                 return Range(start: firstToken.offset, end: lastToken.offset + lastToken.length)

--- a/Source/SourceKittenFramework/SyntaxMap.swift
+++ b/Source/SourceKittenFramework/SyntaxMap.swift
@@ -87,7 +87,7 @@ public struct SyntaxMap {
         let commentEnd = tokensBeginningComment.indexOf(isNotDoc)
         let commentTokensImmediatelyPrecedingOffset = (
             commentEnd.map(tokensBeginningComment.prefixUpTo) ?? tokensBeginningComment
-                ).reverse()
+        ).reverse()
         
         return commentTokensImmediatelyPrecedingOffset.first.flatMap { firstToken in
             return commentTokensImmediatelyPrecedingOffset.last.map { lastToken in


### PR DESCRIPTION
By applying this, linting KeychainAccess by SwiftLint-0.5.1 is reduced from:
```
swiftlint  21.87s user 0.24s system 97% cpu 22.611 total
```
to:
```
swiftlint  17.06s user 0.15s system 97% cpu 17.607 total
```

On Instruments, `commentRangeBeforeOffset()` is reduced from 9931ms:
<img width="941" alt="screenshot 2015-12-14 20 19 37" src="https://cloud.githubusercontent.com/assets/33430/11780082/a1bd7144-a2a2-11e5-9779-17cd4c8df8a0.png">
 to 4148ms:
<img width="939" alt="screenshot 2015-12-14 20 19 48" src="https://cloud.githubusercontent.com/assets/33430/11780090/aeaa77b2-a2a2-11e5-96a3-88d6ea96d30c.png">
 on that test.