### PR TITLE
Make comparison faster between `SyntaxToken.type` and `SyntaxKind.rawValue`

### DIFF
--- a/Source/SourceKittenFramework/SyntaxToken.swift
+++ b/Source/SourceKittenFramework/SyntaxToken.swift
@@ -28,7 +28,7 @@ public struct SyntaxToken {
     - parameter length: Token length.
     */
     public init(type: String, offset: Int, length: Int) {
-        self.type = type
+        self.type = SyntaxKind(rawValue: type)?.rawValue ?? type
         self.offset = offset
         self.length = length
     }


### PR DESCRIPTION
Contain `SyntaxKind.rawValue` instance instead of `type: String` parameter instance into `SyntaxToken.type`.
This makes comparison faster in some functions. e.g. `commentRangeBeforeOffset(_:)`

Duration of linting KeychainAccess by SwiftLint 0.5.2
before:
```
time swiftlint
…
swiftlint  7.96s user 0.14s system 95% cpu 8.481 total
```

after:
```
swiftlint  5.25s user 0.09s system 93% cpu 5.683 total
```

Now current SwiftLint is faster than 0.4.0 on my test. :smile: