### PR TITLE
Add `Structure.init(sourceKitResponse:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Add `Structure.init(sourceKitResponse:)`  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/Structure.swift
+++ b/Source/SourceKittenFramework/Structure.swift
@@ -15,14 +15,23 @@ public struct Structure {
     public let dictionary: XPCDictionary
 
     /**
+     Create a Structure from a SourceKit `editor.open` response.
+     
+     - parameter sourceKitResponse: SourceKit `editor.open` response.
+     */
+    public init(sourceKitResponse: XPCDictionary) {
+        var sourceKitResponse = sourceKitResponse
+        _ = sourceKitResponse.removeValueForKey(SwiftDocKey.SyntaxMap.rawValue)
+        self.dictionary = sourceKitResponse
+    }
+
+    /**
     Initialize a Structure by passing in a File.
 
     - parameter file: File to parse for structural information.
     */
     public init(file: File) {
-        var tmpDictionary = Request.EditorOpen(file).send()
-        _ = tmpDictionary.removeValueForKey(SwiftDocKey.SyntaxMap.rawValue)
-        dictionary = tmpDictionary
+        self.init(sourceKitResponse: Request.EditorOpen(file).send())
     }
 }
 


### PR DESCRIPTION
SourceKit `editor.open` response can be shared with `SyntaxMap.init(sourceKitResponse:)` for reducing calls to SourceKit.