### PR TITLE
Change dictionary enumeration in `replaceUIDsWithSourceKitStrings(_:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Add `Structure.init(sourceKitResponse:)`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Imporve performance of `Request.send()`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Bug Fixes
 
 * Add support for parsing module imports in Objective-C.  

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -333,12 +333,12 @@ Traverse the dictionary replacing SourceKit UIDs with their string value.
 - returns: Dictionary with UIDs replaced by strings.
 */
 internal func replaceUIDsWithSourceKitStrings(var dictionary: XPCDictionary) -> XPCDictionary {
-    for key in dictionary.keys {
-        if let uid = dictionary[key] as? UInt64, uidString = stringForSourceKitUID(uid) {
+    for (key, value) in dictionary {
+        if let uid = value as? UInt64, uidString = stringForSourceKitUID(uid) {
             dictionary[key] = uidString
-        } else if let array = dictionary[key] as? XPCArray {
+        } else if let array = value as? XPCArray {
             dictionary[key] = array.map { replaceUIDsWithSourceKitStrings($0 as! XPCDictionary) } as XPCArray
-        } else if let dict = dictionary[key] as? XPCDictionary {
+        } else if let dict = value as? XPCDictionary {
             dictionary[key] = replaceUIDsWithSourceKitStrings(dict)
         }
     }


### PR DESCRIPTION
By applying this, the duration of `replaceUIDsWithSourceKitStrings(_:)` on linting Carthage is reduced from 3680ms to 1346ms.
from:
<img width="1008" alt="screenshot 2016-01-10 22 02 49" src="https://cloud.githubusercontent.com/assets/33430/12221620/07567d54-b7e6-11e5-8347-1db121285c07.png">
to:
<img width="992" alt="screenshot 2016-01-10 22 03 09" src="https://cloud.githubusercontent.com/assets/33430/12221622/0e7922f8-b7e6-11e5-92de-2e6cecaf6025.png">
