### PR TITLE
Use `isEqualTo()` instead of `==` for `XPCRepresentable`

### DIFF
--- a/Source/SourceKittenFramework/Structure.swift
+++ b/Source/SourceKittenFramework/Structure.swift
@@ -54,5 +54,5 @@ Returns true if `lhs` Structure is equal to `rhs` Structure.
 - returns: True if `lhs` Structure is equal to `rhs` Structure.
 */
 public func ==(lhs: Structure, rhs: Structure) -> Bool {
-    return lhs.dictionary == rhs.dictionary
+    return lhs.dictionary.isEqualTo(rhs.dictionary)
 }


### PR DESCRIPTION
depends on https://github.com/jpsim/SwiftXPC/pull/9