### PR TITLE
removed Curry dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "Carthage/Checkouts/Result"]
 	path = Carthage/Checkouts/Result
 	url = https://github.com/antitypical/Result.git
-[submodule "Carthage/Checkouts/Curry"]
-	path = Carthage/Checkouts/Curry
-	url = https://github.com/thoughtbot/Curry.git

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,2 @@
 github "Carthage/Commandant"
 github "jspahrsummers/xcconfigs"
-github "thoughtbot/Curry"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
-github "thoughtbot/Curry" "v1.4.0"
 github "antitypical/Result" "1.0.1"
 github "drmohundro/SWXMLHash" "2.0.6"
 github "jpsim/SwiftXPC" "1.1.1"

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -53,8 +52,14 @@ struct CompleteOptions: OptionsType {
     let offset: Int
     let compilerargs: String
 
+    static func create(file: String) -> (text: String) -> (offset: Int) -> (compilerargs: String) -> CompleteOptions {
+        return { text in { offset in { compilerargs in
+            self.init(file: file, text: text, offset: offset, compilerargs: compilerargs)
+        }}}
+    }
+
     static func evaluate(m: CommandMode) -> Result<CompleteOptions, CommandantError<SourceKittenError>> {
-        return curry(self.init)
+        return create
             <*> m <| Option(key: "file", defaultValue: "", usage: "relative or absolute path of Swift file to parse")
             <*> m <| Option(key: "text", defaultValue: "", usage: "Swift code text to parse")
             <*> m <| Option(key: "offset", defaultValue: 0, usage: "Offset for which to generate code completion options.")

--- a/Source/sourcekitten/Components.plist
+++ b/Source/sourcekitten/Components.plist
@@ -31,12 +31,6 @@
 				<key>BundleOverwriteAction</key>
 				<string></string>
 				<key>RootRelativeBundlePath</key>
-				<string>/usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Curry.framework</string>
-			</dict>
-			<dict>
-				<key>BundleOverwriteAction</key>
-				<string></string>
-				<key>RootRelativeBundlePath</key>
 				<string>/usr/local/Frameworks/SourceKittenFramework.framework/Versions/A/Frameworks/Result.framework</string>
 			</dict>
 		</array>

--- a/Source/sourcekitten/DocCommand.swift
+++ b/Source/sourcekitten/DocCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -64,8 +63,14 @@ struct DocOptions: OptionsType {
     let moduleName: String
     let objc: Bool
 
+    static func create(singleFile: Bool) -> (moduleName: String) -> (objc: Bool) -> DocOptions {
+        return { moduleName in { objc in
+            self.init(singleFile: singleFile, moduleName: moduleName, objc: objc)
+        }}
+    }
+
     static func evaluate(m: CommandMode) -> Result<DocOptions, CommandantError<SourceKittenError>> {
-        return curry(self.init)
+        return create
             <*> m <| Option(key: "single-file", defaultValue: false, usage: "only document one file")
             <*> m <| Option(key: "module-name", defaultValue: "",    usage: "name of module to document (can't be used with `--single-file` or `--objc`)")
             <*> m <| Option(key: "objc",        defaultValue: false, usage: "document Objective-C headers")

--- a/Source/sourcekitten/StructureCommand.swift
+++ b/Source/sourcekitten/StructureCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -38,8 +37,14 @@ struct StructureOptions: OptionsType {
     let file: String
     let text: String
 
+    static func create(file: String) -> (text: String) -> StructureOptions {
+        return { text in
+            self.init(file: file, text: text)
+        }
+    }
+
     static func evaluate(m: CommandMode) -> Result<StructureOptions, CommandantError<SourceKittenError>> {
-        return curry(self.init)
+        return create
             <*> m <| Option(key: "file", defaultValue: "", usage: "relative or absolute path of Swift file to parse")
             <*> m <| Option(key: "text", defaultValue: "", usage: "Swift code text to parse")
     }

--- a/Source/sourcekitten/SyntaxCommand.swift
+++ b/Source/sourcekitten/SyntaxCommand.swift
@@ -7,7 +7,6 @@
 //
 
 import Commandant
-import Curry
 import Foundation
 import Result
 import SourceKittenFramework
@@ -33,8 +32,14 @@ struct SyntaxOptions: OptionsType {
     let file: String
     let text: String
 
+    static func create(file: String) -> (text: String) -> SyntaxOptions {
+        return { text in
+            self.init(file: file, text: text)
+        }
+    }
+
     static func evaluate(m: CommandMode) -> Result<SyntaxOptions, CommandantError<SourceKittenError>> {
-        return curry(self.init)
+        return create
             <*> m <| Option(key: "file", defaultValue: "", usage: "relative or absolute path of Swift file to parse")
             <*> m <| Option(key: "text", defaultValue: "", usage: "Swift code text to parse")
     }

--- a/SourceKitten.xcworkspace/contents.xcworkspacedata
+++ b/SourceKitten.xcworkspace/contents.xcworkspacedata
@@ -16,7 +16,4 @@
    <FileRef
       location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:Carthage/Checkouts/Curry/Curry.xcodeproj">
-   </FileRef>
 </Workspace>

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -10,8 +10,6 @@
 		2C55B3321BEB3CA7002E8C6B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; };
 		2C55B3331BEB3CAB002E8C6B /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; };
 		2C55B3341BEB3D7D002E8C6B /* Commandant.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E80BE6A11C1D0E4C00D5961F /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E80BE6A01C1D0E4C00D5961F /* Curry.framework */; };
-		E80BE6A11C1D0E4C00D5961F /* Curry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E80BE6A01C1D0E4C00D5961F /* Curry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2C55B3351BEB3D7D002E8C6B /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3F0CBB411BAAFF160015BBA8 /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0CBB401BAAFF160015BBA8 /* Clang+SourceKitten.swift */; };
 		3F56EAD01BAB251C006433D0 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56EACF1BAB251C006433D0 /* JSONOutput.swift */; };
@@ -34,7 +32,6 @@
 		E8241CA51A5E01A10047687E /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8241CA41A5E01A10047687E /* Module.swift */; };
 		E834740F1A593B5B00532B9A /* Structure.swift in Sources */ = {isa = PBXBuildFile; fileRef = E834740E1A593B5B00532B9A /* Structure.swift */; };
 		E834AE641BED76B00017B386 /* Commandant.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E82E914E1C1D110000FCF44F /* Curry.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E80BE6A01C1D0E4C00D5961F /* Curry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E834AE651BED76B30017B386 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E83748C31A5BCD7900862B1B /* OffsetMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83748C21A5BCD7900862B1B /* OffsetMap.swift */; };
 		E83A0B351A5D382B0041A60A /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83A0B341A5D382B0041A60A /* VersionCommand.swift */; };
@@ -106,7 +103,6 @@
 			files = (
 				E834AE651BED76B30017B386 /* Result.framework in Copy Frameworks */,
 				E834AE641BED76B00017B386 /* Commandant.framework in Copy Frameworks */,
-				E82E914E1C1D110000FCF44F /* Curry.framework in Copy Frameworks */,
 				E8C0DFCE1AD349E5007EE3D4 /* SWXMLHash.framework in Copy Frameworks */,
 				E86847381A587B0A0043DC65 /* SwiftXPC.framework in Copy Frameworks */,
 			);
@@ -120,7 +116,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				2C55B3341BEB3D7D002E8C6B /* Commandant.framework in Embed Frameworks */,
-				E80BE6A21C1D0E5600D5961F /* Curry.framework in Embed Frameworks */,
 				2C55B3351BEB3D7D002E8C6B /* Result.framework in Embed Frameworks */,
 				D0AAAB5019FB0960007B24B3 /* SourceKittenFramework.framework in Embed Frameworks */,
 			);
@@ -211,7 +206,6 @@
 		E8D4743A1A648F290011A49C /* ClangTranslationUnit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClangTranslationUnit.swift; sourceTree = "<group>"; };
 		E8D86D841A688EF20063E8E9 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E80BE6A01C1D0E4C00D5961F /* Curry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8EE34BE1B9A502F00947605 /* CodeCompletionItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeCompletionItem.swift; sourceTree = "<group>"; };
 		E8F4AF111B9A56A70054C51C /* CompleteCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompleteCommand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -241,7 +235,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C55B3331BEB3CAB002E8C6B /* Commandant.framework in Frameworks */,
-				E80BE6A11C1D0E4C00D5961F /* Curry.framework in Frameworks */,
 				2C55B3321BEB3CA7002E8C6B /* Result.framework in Frameworks */,
 				D0E7B65319E9C6AD00EDBA4D /* SourceKittenFramework.framework in Frameworks */,
 			);
@@ -256,7 +249,6 @@
 				5499CA961A2394B700783309 /* Components.plist */,
 				5499CA971A2394B700783309 /* Info.plist */,
 				E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */,
-				E80BE6A01C1D0E4C00D5961F /* Curry.framework */,
 				E834D61D1B2D054B002AA1FE /* Result.framework */,
 			);
 			name = "Supporting Files";


### PR DESCRIPTION
The syntax is going away in Swift 3, and it's not that hard to do ourselves.