### PR TITLE
Replace results of `sourcekitd_uid_get_string_ptr()` with enum's rawValue

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -104,6 +104,9 @@ internal func stringForSourceKitUID(uid: sourcekitd_uid_t) -> String? {
     if let string = uidStringMap[uid] {
         return string
     } else if let uidString = String(UTF8String: sourcekitd_uid_get_string_ptr(uid)) {
+        let uidString = SwiftDocKey(rawValue: uidString)?.rawValue ??
+            SwiftDeclarationKind(rawValue: uidString)?.rawValue ??
+            SyntaxKind(rawValue: uidString)?.rawValue ?? uidString
         uidStringMap[uid] = uidString
         return uidString
     }


### PR DESCRIPTION
By applying this, linting Carthage 0.11 by SwiftLint(1fca735):
- Duration is reduced from 22sec to 19sec.
- Persistent Bytes on termination is reduced from 584.61MB to 487.86MB.

Instruments
From:
<img width="783" alt="screenshot 2016-01-27 22 17 12" src="https://cloud.githubusercontent.com/assets/33430/12614601/5277eca8-c544-11e5-8422-331ff19349b9.png">
To:
<img width="782" alt="screenshot 2016-01-27 22 17 26" src="https://cloud.githubusercontent.com/assets/33430/12614607/599da360-c544-11e5-8636-05fb61fbf099.png">


## Why?
`String(UTF8String:)`'s back end is `NSString`.
On using `String` as key of Dictionary, it uses `hashValue`.
When `String` is `NSString`, `_stdlib_NSStringNFDHashValue` is always called.
https://github.com/apple/swift/blob/swift-2.2-branch/stdlib%2Fpublic%2Fcore%2FString.swift#L484
That uses `NSString.decomposedStringWithCanonicalMapping` for Unicode Normalization Form D.
https://github.com/apple/swift/blob/swift-2.2-branch/stdlib%2Fpublic%2Fstubs%2FSwiftNativeNSXXXBase.mm.gyb#L118
It seems `decomposedStringWithCanonicalMapping` leaks some memory on above process.
Reduced `CFString (mutable)` and `CFString (store)` on Instruments are that maybe.
Those enum's String rawValue is used instead of them.