### PR TITLE
Build with swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,10 @@ matrix:
   include:
     - script: make test
       env: JOB=Xcode
-    - script: swift build
+    - script: make spm
       env: JOB=SPM
       before_install:
         - make swift_snapshot_install
-        - make spm_bootstrap
-        - 'export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:"${PATH}"'
   exclude:
     - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OUTPUT_PACKAGE=SourceKitten.pkg
 VERSION_STRING=$(shell agvtool what-marketing-version -terse1)
 COMPONENTS_PLIST=Source/sourcekitten/Components.plist
 
-SWIFT_SNAPSHOT=swift-2.2-SNAPSHOT-2016-01-25-a
+SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a
 
 SPM=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift build
 SPM_INCLUDE=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ spm_bootstrap:
 	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
 
 spm:
+	sed -i "" "s/swift-latest/$(SWIFT_SNAPSHOT)/" Source/Clang_C/module.modulemap
 	$(SPM) $(SPMFLAGS)
 
 spm_clean:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,14 @@ OUTPUT_PACKAGE=SourceKitten.pkg
 VERSION_STRING=$(shell agvtool what-marketing-version -terse1)
 COMPONENTS_PLIST=Source/sourcekitten/Components.plist
 
-SWIFT_SNAPSHOT=swift-2.2-SNAPSHOT-2016-01-11-a
+SWIFT_SNAPSHOT=swift-2.2-SNAPSHOT-2016-01-25-a
+
+SPM=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift build
+SPM_INCLUDE=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include
+SPM_LIB=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib
+SPMFLAGS=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)                               # for including "clang-c"
+SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB) # for linking sourcekitd and clang-c
+SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)                           # for loading sourcekitd and clang-c
 
 .PHONY: all bootstrap clean install package test uninstall
 
@@ -80,6 +87,12 @@ spm_bootstrap:
 	mkdir -p /usr/local/include/sourcekitdInProc
 	curl https://raw.githubusercontent.com/apple/swift/$(SWIFT_SNAPSHOT)/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h > /usr/local/include/sourcekitdInProc/sourcekitd.h
 	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
+
+spm:
+	$(SPM) $(SPMFLAGS)
+
+spm_clean:
+	$(SPM) --clean
 
 spm_teardown:
 	rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ archive:
 release: package archive
 
 swift_snapshot_install:
-	curl https://swift.org/builds/xcode/$(SWIFT_SNAPSHOT)/$(SWIFT_SNAPSHOT)-osx.pkg -o swift.pkg
+	curl https://swift.org/builds/development/xcode/$(SWIFT_SNAPSHOT)/$(SWIFT_SNAPSHOT)-osx.pkg -o swift.pkg
 	sudo installer -pkg swift.pkg -target /
 
 spm_bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -80,21 +80,9 @@ swift_snapshot_install:
 	curl https://swift.org/builds/development/xcode/$(SWIFT_SNAPSHOT)/$(SWIFT_SNAPSHOT)-osx.pkg -o swift.pkg
 	sudo installer -pkg swift.pkg -target /
 
-spm_bootstrap:
-	cd /usr/local/include; svn export --force http://llvm.org/svn/llvm-project/cfe/trunk/include/clang-c/
-	cp clang_c_module.modulemap /usr/local/include/clang-c/module.modulemap
-	cp /Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib/libclang.dylib /usr/local/lib/
-	mkdir -p /usr/local/include/sourcekitdInProc
-	curl https://raw.githubusercontent.com/apple/swift/$(SWIFT_SNAPSHOT)/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h > /usr/local/include/sourcekitdInProc/sourcekitd.h
-	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
-
 spm:
 	sed -i "" "s/swift-latest/$(SWIFT_SNAPSHOT)/" Source/Clang_C/module.modulemap
 	$(SPM) $(SPMFLAGS)
 
 spm_clean:
 	$(SPM) --clean
-
-spm_teardown:
-	rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib
-	rm -rf /usr/local/include/sourcekitdInProc /usr/local/lib/libsourcekitdInProc.dylib

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ COMPONENTS_PLIST=Source/sourcekitten/Components.plist
 
 SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a
 
-SPM=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin/swift build
-SPM_INCLUDE=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include
-SPM_LIB=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/lib
+SPM=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/bin/swift build
+SPM_INCLUDE=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include
+SPM_LIB=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib
 SPMFLAGS=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)                               # for including "clang-c"
 SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB) # for linking sourcekitd and clang-c
 SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)                           # for loading sourcekitd and clang-c

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ swift_snapshot_install:
 spm:
 	sed -i "" "s/swift-latest/$(SWIFT_SNAPSHOT)/" Source/Clang_C/module.modulemap
 	$(SPM) $(SPMFLAGS)
+	sed -i "" "s/$(SWIFT_SNAPSHOT)/swift-latest/" Source/Clang_C/module.modulemap
 
 spm_clean:
 	$(SPM) --clean

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
       dependencies: [.Target(name: "SourceKittenFramework")])
   ],
   dependencies: [
-    .Package(url: "https://github.com/jpsim/SourceKit.git", majorVersion: 1),
     .Package(url: "https://github.com/jpsim/SWXMLHash.git", majorVersion: 1),
     .Package(url: "https://github.com/jpsim/Commandant.git", majorVersion: 1)
   ],

--- a/Source/Clang_C/module.modulemap
+++ b/Source/Clang_C/module.modulemap
@@ -1,0 +1,5 @@
+module Clang_C [system] {
+  header "/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/local/include/clang-c/Documentation.h"
+  link "clang"
+  export *
+}

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SWXMLHash
 #if SWIFT_PACKAGE
-import SourceKit
+import sourcekitd
 #endif
 
 /// Represents a source file.

--- a/Source/SourceKittenFramework/ObjCDeclarationKind.swift
+++ b/Source/SourceKittenFramework/ObjCDeclarationKind.swift
@@ -35,7 +35,7 @@ public enum ObjCDeclarationKind: String {
     /// `property`.
     case Property = "sourcekitten.source.lang.objc.decl.property"
     /// `protocol`.
-    case Protocol = "sourcekitten.source.lang.objc.decl.protocol"
+    case `Protocol` = "sourcekitten.source.lang.objc.decl.protocol"
     /// `typedef`.
     case Typedef = "sourcekitten.source.lang.objc.decl.typedef"
     /// `function`.

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 #if SWIFT_PACKAGE
-import SourceKit
+import sourcekitd
 #endif
 
 public protocol SourceKitRepresentable {

--- a/Source/SourceKittenFramework/SwiftDeclarationKind.swift
+++ b/Source/SourceKittenFramework/SwiftDeclarationKind.swift
@@ -60,7 +60,7 @@ public enum SwiftDeclarationKind: String {
     /// `module`
     case Module = "source.lang.swift.decl.module"
     /// `protocol`.
-    case Protocol = "source.lang.swift.decl.protocol"
+    case `Protocol` = "source.lang.swift.decl.protocol"
     /// `struct`.
     case Struct = "source.lang.swift.decl.struct"
     /// `typealias`.

--- a/Source/SourceKittenFramework/SwiftDocs.swift
+++ b/Source/SourceKittenFramework/SwiftDocs.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 #if SWIFT_PACKAGE
-import SourceKit
+import sourcekitd
 #endif
 
 /// Represents docs for a Swift file.

--- a/clang_c_module.modulemap
+++ b/clang_c_module.modulemap
@@ -1,5 +1,0 @@
-module Clang_C {
-  umbrella "."
-  link "clang"
-  module * { export * }
-}


### PR DESCRIPTION
- Use new options of Swift Package Manager.
>   -Xcc <flag>        Pass flag through to all compiler instantiations
  -Xlinker <flag>    Pass flag through to all linker instantiations

    By using them:
    - Link `libclang.dylib` in swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a.xctoolchain
    - Link `sourcekitd.framework` in swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a.xctoolchain

- Fix build error:
> error: type member may not be named 'Protocol', since it would conflict with the 'foo.Protocol' expression

