### PR TITLE
Inherit custom toolchains while building Xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       env: JOB=SPM
       before_install:
         - make swift_snapshot_install
+    - script: make with_toolchain
+      env: JOB=XcodeExternal
+      before_install:
+        - make swift_snapshot_install
   exclude:
     - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
 notifications:

--- a/Source/SourceKittenFramework/SourceLocation.swift
+++ b/Source/SourceKittenFramework/SourceLocation.swift
@@ -24,7 +24,7 @@ public struct SourceLocation {
 
 extension SourceLocation {
     init(clangLocation: CXSourceLocation) {
-        var cxfile = CXFile()
+        var cxfile: CXFile = nil
         var line: UInt32 = 0
         var column: UInt32 = 0
         var offset: UInt32 = 0

--- a/Source/SourceKittenFramework/SwiftDeclarationKind.swift
+++ b/Source/SourceKittenFramework/SwiftDeclarationKind.swift
@@ -51,8 +51,12 @@ public enum SwiftDeclarationKind: String {
     case FunctionMethodInstance = "source.lang.swift.decl.function.method.instance"
     /// `function.method.static`.
     case FunctionMethodStatic = "source.lang.swift.decl.function.method.static"
-    /// `function.operator`.
-    case FunctionOperator = "source.lang.swift.decl.function.operator"
+    /// `function.operator.postfix`.
+    case FunctionOperatorPostfix = "source.lang.swift.decl.function.operator.postfix"
+    /// `function.operator.prefix`.
+    case FunctionOperatorPrefix = "source.lang.swift.decl.function.operator.prefix"
+    /// `function.operator.infix`.
+    case FunctionOperatorInfix = "source.lang.swift.decl.function.operator.infix"
     /// `function.subscript`.
     case FunctionSubscript = "source.lang.swift.decl.function.subscript"
     /// `generic_type_param`.

--- a/Source/SourceKittenFramework/SyntaxMap.swift
+++ b/Source/SourceKittenFramework/SyntaxMap.swift
@@ -78,7 +78,7 @@ public struct SyntaxMap {
 
         return commentTokensImmediatelyPrecedingOffset.first.flatMap { firstToken in
             return commentTokensImmediatelyPrecedingOffset.last.map { lastToken in
-                return Range(start: firstToken.offset, end: lastToken.offset + lastToken.length)
+                return firstToken.offset ..< lastToken.offset + lastToken.length
             }
         }
     }

--- a/Source/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Source/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -58,16 +58,16 @@ class SourceKitTests: XCTestCase {
             .StringInterpolationAnchor,
             .Typeidentifier
         ]
-        let actual = sourcekitStringsStartingWith("source.lang.swift.syntaxtype.")
-        let expectedStrings = Set(expected.map { $0.rawValue })
-        XCTAssertEqual(
-            actual,
-            expectedStrings
-        )
-        if actual != expectedStrings {
-            print("the following strings were added: \(actual.subtract(expectedStrings))")
-            print("the following strings were removed: \(expectedStrings.subtract(actual))")
+
+        // SourceKit occasionally builds these through interpolation, so check prefixes only.
+        var actual = sourcekitStringsStartingWith("source.lang.swift.syntaxtype.")
+        for string in expected.lazy.map({ String($0.rawValue) }) {
+            if actual.remove(string) != nil { continue }
+            if let indexToRemove = actual.indexOf(string.hasPrefix) {
+                actual.removeAtIndex(indexToRemove)
+            }
         }
+        XCTAssert(actual.isEmpty, "the following strings were unmatched: \(actual)")
     }
 
     func testSwiftDeclarationKind() {
@@ -93,7 +93,9 @@ class SourceKitTests: XCTestCase {
             .FunctionMethodClass,
             .FunctionMethodInstance,
             .FunctionMethodStatic,
-            .FunctionOperator,
+            .FunctionOperatorPostfix,
+            .FunctionOperatorPrefix,
+            .FunctionOperatorInfix,
             .FunctionSubscript,
             .GenericTypeParam,
             .Module,
@@ -107,15 +109,14 @@ class SourceKitTests: XCTestCase {
             .VarParameter,
             .VarStatic
         ]
-        let actual = sourcekitStringsStartingWith("source.lang.swift.decl.")
-        let expectedStrings = Set(expected.map { $0.rawValue })
-        XCTAssertEqual(
-            actual,
-            expectedStrings
-        )
-        if actual != expectedStrings {
-            print("the following strings were added: \(actual.subtract(expectedStrings))")
-            print("the following strings were removed: \(expectedStrings.subtract(actual))")
+        // SourceKit occasionally builds these through interpolation, so check prefixes only.
+        var actual = sourcekitStringsStartingWith("source.lang.swift.decl.")
+        for string in expected.lazy.map({ String($0.rawValue) }) {
+            if actual.remove(string) != nil { continue }
+            if let indexToRemove = actual.indexOf(string.hasPrefix) {
+                actual.removeAtIndex(indexToRemove)
+            }
         }
+        XCTAssert(actual.isEmpty, "the following strings were unmatched: \(actual)")
     }
 }

--- a/Source/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Source/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2015 SourceKitten. All rights reserved.
 //
 
-import SourceKittenFramework
 import XCTest
+@testable import SourceKittenFramework
 
 private func run(executable: String, arguments: [String]) -> String? {
     let task = NSTask()
@@ -20,20 +20,18 @@ private func run(executable: String, arguments: [String]) -> String? {
     task.launch()
 
     let file = pipe.fileHandleForReading
-    let output = NSString(data: file.readDataToEndOfFile(), encoding: NSUTF8StringEncoding)
-    file.closeFile()
-    return output as String?
+    defer { file.closeFile() }
+    return String(data: file.readDataToEndOfFile(), encoding: NSUTF8StringEncoding)
 }
 
 private func sourcekitStringsStartingWith(pattern: String) -> Set<String> {
-    let sourceKitServicePath = (((run("/usr/bin/xcrun", arguments: ["-f", "swiftc"])! as NSString)
-        .stringByDeletingLastPathComponent as NSString)
-        .stringByDeletingLastPathComponent as NSString)
-        .stringByAppendingPathComponent("lib/sourcekitd.framework/XPCServices/SourceKitService.xpc/Contents/MacOS/SourceKitService")
+    // Should ideally use NSURL(fileURLWithPath:isDirectory:relativeToURL:)
+    // but that's 10.11+.
+    guard let sourceKitServicePath = toolchainPath().flatMap({
+        NSURL(fileURLWithPath: $0, isDirectory: true).URLByAppendingPathComponent("usr/lib/sourcekitd.framework/XPCServices/SourceKitService.xpc/Contents/MacOS/SourceKitService", isDirectory: false).path
+    }) else { return [] }
     let strings = run("/usr/bin/strings", arguments: [sourceKitServicePath])
-    return Set(strings!.componentsSeparatedByString("\n").filter { string in
-        return string.rangeOfString(pattern)?.startIndex == string.startIndex
-    })
+    return Set(strings!.componentsSeparatedByString("\n").filter({ $0.hasPrefix(pattern) }))
 }
 
 class SourceKitTests: XCTestCase {

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		E847636A1A5A0651000EAE22 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84763691A5A0651000EAE22 /* File.swift */; };
 		E852418F1A5F4FB3007099FB /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E852418E1A5F4FB3007099FB /* Dictionary+Merge.swift */; };
 		E868473A1A587B4D0043DC65 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86847391A587B4D0043DC65 /* Request.swift */; };
-		E868473C1A587C6E0043DC65 /* sourcekitd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E868473B1A587C6E0043DC65 /* sourcekitd.framework */; };
 		E86F588E1C4DC49000426E78 /* sourcekitd.h in Headers */ = {isa = PBXBuildFile; fileRef = E86F588D1C4DC49000426E78 /* sourcekitd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E872121A1AD2FFCD00A484F4 /* Array+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87212191AD2FFCD00A484F4 /* Array+SourceKitten.swift */; };
 		E877D9271B5693E70095BB2B /* ObjCDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = E877D9261B5693E70095BB2B /* ObjCDeclarationKind.swift */; };
@@ -49,7 +48,6 @@
 		E8A18A3F1A592246000362B7 /* SwiftDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A18A3E1A592246000362B7 /* SwiftDocs.swift */; };
 		E8A9B8901B56CB5500CD17D4 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */; };
 		E8A9B8921B56D1B100CD17D4 /* SourceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9B8911B56D1B100CD17D4 /* SourceDeclaration.swift */; };
-		E8AB1A2E1A649F2100452012 /* libclang.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E8AB1A2D1A649F2100452012 /* libclang.dylib */; };
 		E8AB1A301A64A21400452012 /* ClangTranslationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AB1A2F1A64A21400452012 /* ClangTranslationUnitTests.swift */; };
 		E8AE53C71A5B5FCA0092D24A /* String+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AE53C61A5B5FCA0092D24A /* String+SourceKitten.swift */; };
 		E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; };
@@ -172,7 +170,6 @@
 		E84763691A5A0651000EAE22 /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; usesTabs = 0; };
 		E852418E1A5F4FB3007099FB /* Dictionary+Merge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merge.swift"; sourceTree = "<group>"; };
 		E86847391A587B4D0043DC65 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; usesTabs = 0; };
-		E868473B1A587C6E0043DC65 /* sourcekitd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = sourcekitd.framework; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework; sourceTree = DEVELOPER_DIR; };
 		E86F588D1C4DC49000426E78 /* sourcekitd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sourcekitd.h; sourceTree = "<group>"; };
 		E87212191AD2FFCD00A484F4 /* Array+SourceKitten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+SourceKitten.swift"; sourceTree = "<group>"; };
 		E877D9261B5693E70095BB2B /* ObjCDeclarationKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCDeclarationKind.swift; sourceTree = "<group>"; };
@@ -182,7 +179,6 @@
 		E8A18A3E1A592246000362B7 /* SwiftDocs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftDocs.swift; sourceTree = "<group>"; usesTabs = 0; };
 		E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Xcode.swift; sourceTree = "<group>"; };
 		E8A9B8911B56D1B100CD17D4 /* SourceDeclaration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceDeclaration.swift; sourceTree = "<group>"; };
-		E8AB1A2D1A649F2100452012 /* libclang.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libclang.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib; sourceTree = DEVELOPER_DIR; };
 		E8AB1A2F1A64A21400452012 /* ClangTranslationUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClangTranslationUnitTests.swift; sourceTree = "<group>"; };
 		E8AE53C61A5B5FCA0092D24A /* String+SourceKitten.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SourceKitten.swift"; sourceTree = "<group>"; };
 		E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SWXMLHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -209,8 +205,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E8AB1A2E1A649F2100452012 /* libclang.dylib in Frameworks */,
-				E868473C1A587C6E0043DC65 /* sourcekitd.framework in Frameworks */,
 				E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -391,8 +385,6 @@
 		D0D1216F19E87B05005E4BAA /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				E8AB1A2D1A649F2100452012 /* libclang.dylib */,
-				E868473B1A587C6E0043DC65 /* sourcekitd.framework */,
 				E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */,
 			);
 			name = "Supporting Files";
@@ -706,7 +698,9 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+					"$(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib",
+					"$(TOOLCHAIN_DIR)/usr/lib",
+					"$(DT_TOOLCHAIN_DIR)/usr/lib",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
@@ -714,6 +708,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					sourcekitd,
+					"-lclang",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sourcekitten.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SourceKittenFramework;
@@ -738,7 +738,9 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+					"$(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib",
+					"$(TOOLCHAIN_DIR)/usr/lib",
+					"$(DT_TOOLCHAIN_DIR)/usr/lib",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
@@ -746,6 +748,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					sourcekitd,
+					"-lclang",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sourcekitten.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SourceKittenFramework;
@@ -810,7 +818,9 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+					"$(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib",
+					"$(TOOLCHAIN_DIR)/usr/lib",
+					"$(DT_TOOLCHAIN_DIR)/usr/lib",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
@@ -818,6 +828,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					sourcekitd,
+					"-lclang",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sourcekitten.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SourceKittenFramework;
@@ -867,7 +883,9 @@
 				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+					"$(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib",
+					"$(TOOLCHAIN_DIR)/usr/lib",
+					"$(DT_TOOLCHAIN_DIR)/usr/lib",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
@@ -875,6 +893,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					sourcekitd,
+					"-lclang",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sourcekitten.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SourceKittenFramework;

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib $(TOOLCHAIN_DIR)/usr/lib $(DT_TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -744,7 +744,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib $(TOOLCHAIN_DIR)/usr/lib $(DT_TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -824,7 +824,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib $(TOOLCHAIN_DIR)/usr/lib $(DT_TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -889,7 +889,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(XCODE_DEFAULT_TOOLCHAIN_OVERRIDE)/usr/lib $(TOOLCHAIN_DIR)/usr/lib $(DT_TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",


### PR DESCRIPTION
Analogous to #150, but for hacking on SourceKitten under Xcode.

Builds and runs in Xcode 6.2 and 6.3, but currently the tests only succeed under 6.2 with any Swift prior to 2016-01-25. Later builds of Swift 2.2 have the new `associatedtype` token and Xcode 6.3 causes changes to the autocomplete output that are valid (better, even) but don't pass the tests.