### PR TITLE
[WIP][SPM] Add `make spm_test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - script: make test
       env: JOB=Xcode
-    - script: make spm
+    - script: make spm_test
       env: JOB=SPM
       before_install:
         - make swift_snapshot_install

--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,11 @@ spm:
 	$(SPM) $(SPMFLAGS)
 	sed -i "" "s/$(SWIFT_SNAPSHOT)/swift-latest/" Source/Clang_C/module.modulemap
 
+spm_test: spm
+	.build/Debug/SourceKittenFrameworkTests
+
 spm_clean:
 	$(SPM) --clean
+
+spm_clean_dist:
+	$(SPM) --clean=dist

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,12 @@ SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a
 SPM=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/bin/swift build
 SPM_INCLUDE=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include
 SPM_LIB=/Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib
-SPMFLAGS=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)                               # for including "clang-c"
-SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB) # for linking sourcekitd and clang-c
-SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)                           # for loading sourcekitd and clang-c
+# for including "clang-c"
+SPMFLAGS=-Xcc -ISource/Clang_C -Xcc -I$(SPM_INCLUDE)
+# for linking sourcekitd and clang-c
+SPMFLAGS+= -Xcc -F$(SPM_LIB) -Xlinker -F$(SPM_LIB) -Xlinker -L$(SPM_LIB)
+# for loading sourcekitd and clang-c
+SPMFLAGS+= -Xlinker -rpath -Xlinker $(SPM_LIB)
 
 .PHONY: all bootstrap clean install package test uninstall
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,13 @@ let package = Package(
   targets: [
     Target(name: "SourceKittenFramework"),
     Target(name: "sourcekitten",
-      dependencies: [.Target(name: "SourceKittenFramework")])
+      dependencies: [.Target(name: "SourceKittenFramework")]),
+    Target(name: "SourceKittenFrameworkTests",
+      dependencies: [.Target(name: "SourceKittenFramework")]),
   ],
   dependencies: [
     .Package(url: "https://github.com/drmohundro/SWXMLHash.git", majorVersion: 2),
-    .Package(url: "https://github.com/Carthage/Commandant.git", majorVersion: 0, minor: 8)
-  ],
-  exclude: ["Source/SourceKittenFrameworkTests"]
+    .Package(url: "https://github.com/Carthage/Commandant.git", majorVersion: 0, minor: 8),
+    .Package(url: "https://github.com/norio-nomura/swift-corelibs-xctest.git", majorVersion: 0),
+  ]
 )

--- a/Source/SourceKittenFrameworkTests/ClangTranslationUnitTests.swift
+++ b/Source/SourceKittenFrameworkTests/ClangTranslationUnitTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 SourceKitten. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 import XCTest
 

--- a/Source/SourceKittenFrameworkTests/ClangTranslationUnitTests.swift
+++ b/Source/SourceKittenFrameworkTests/ClangTranslationUnitTests.swift
@@ -12,6 +12,16 @@ import XCTest
 let fixturesDirectory = (__FILE__ as NSString).stringByDeletingLastPathComponent + "/Fixtures/"
 
 class ClangTranslationUnitTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testParsesObjectiveCHeaderFilesAndXcodebuildArguments",
+            self.testParsesObjectiveCHeaderFilesAndXcodebuildArguments),
+        ("testBasicObjectiveCDocs", self.testBasicObjectiveCDocs),
+        ("testUnicodeInObjectiveCDocs", self.testUnicodeInObjectiveCDocs),
+        ("testRealmObjectiveCDocs", self.testRealmObjectiveCDocs),
+    ]
+
     func testParsesObjectiveCHeaderFilesAndXcodebuildArguments() {
         let headerFiles = [
             "a.h",

--- a/Source/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Source/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -10,6 +10,12 @@ import SourceKittenFramework
 import XCTest
 
 class CodeCompletionTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testSimpleCodeCompletion", self.testSimpleCodeCompletion),
+    ]
+
     func testSimpleCodeCompletion() {
         let file = "\(NSUUID().UUIDString).swift"
         let completionItems = CodeCompletionItem.parseResponse(

--- a/Source/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Source/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 SourceKitten. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 import XCTest
 

--- a/Source/SourceKittenFrameworkTests/FileTests.swift
+++ b/Source/SourceKittenFrameworkTests/FileTests.swift
@@ -10,6 +10,12 @@ import SourceKittenFramework
 import XCTest
 
 class FileTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testUnreadablePath", self.testUnreadablePath)
+    ]
+
     func testUnreadablePath() {
         XCTAssert(File(path: "/dev/null") == nil)
     }

--- a/Source/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Source/SourceKittenFrameworkTests/ModuleTests.swift
@@ -11,6 +11,15 @@ import SourceKittenFramework
 import XCTest
 
 class ModuleTests: XCTestCase {
+    
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testModuleNilInPathWithNoXcodeProject", self.testModuleNilInPathWithNoXcodeProject),
+        ("testSourceKittenFrameworkDocsAreValidJSON",
+            self.testSourceKittenFrameworkDocsAreValidJSON),
+        ("testCommandantDocs", self.testCommandantDocs),
+    ]
+    
     func testModuleNilInPathWithNoXcodeProject() {
         let pathWithNoXcodeProject = (__FILE__ as NSString).stringByDeletingLastPathComponent
         let model = Module(xcodeBuildArguments: [], name: nil, inPath: pathWithNoXcodeProject)

--- a/Source/SourceKittenFrameworkTests/OffsetMapTests.swift
+++ b/Source/SourceKittenFrameworkTests/OffsetMapTests.swift
@@ -11,6 +11,15 @@ import SourceKittenFramework
 import XCTest
 
 class OffsetMapTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testOffsetMapContainsDeclarationOffsetWithDocCommentButNotAlreadyDocumented",
+            self.testOffsetMapContainsDeclarationOffsetWithDocCommentButNotAlreadyDocumented),
+        ("testOffsetMapDoesntContainAlreadyDocumentedDeclarationOffset",
+            self.testOffsetMapDoesntContainAlreadyDocumentedDeclarationOffset),
+    ]
+
     func testOffsetMapContainsDeclarationOffsetWithDocCommentButNotAlreadyDocumented() {
         // Subscripts aren't parsed by SourceKit, so OffsetMap should contain its offset.
         let file = File(contents:

--- a/Source/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Source/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -38,6 +38,12 @@ private func sourcekitStringsStartingWith(pattern: String) -> Set<String> {
 
 class SourceKitTests: XCTestCase {
 
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testSyntaxKinds", self.testSyntaxKinds),
+        ("testSwiftDeclarationKind", self.testSwiftDeclarationKind),
+    ]
+
     func testSyntaxKinds() {
         let expected: [SyntaxKind] = [
             .Argument,

--- a/Source/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Source/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 SourceKitten. All rights reserved.
 //
 
+import Foundation
 import SourceKittenFramework
 import XCTest
 

--- a/Source/SourceKittenFrameworkTests/StringTests.swift
+++ b/Source/SourceKittenFrameworkTests/StringTests.swift
@@ -11,6 +11,27 @@ import SourceKittenFramework
 import XCTest
 
 class StringTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testStringByRemovingCommonLeadingWhitespaceFromLines",
+            self.testStringByRemovingCommonLeadingWhitespaceFromLines),
+        ("testStringByTrimmingTrailingCharactersInSet",
+            self.testStringByTrimmingTrailingCharactersInSet),
+        ("testCommentBody", self.testCommentBody),
+        ("testIsSwiftFile", self.testIsSwiftFile),
+        ("testIsObjectiveCHeaderFile", self.testIsObjectiveCHeaderFile),
+        ("testAbsolutePath", self.testAbsolutePath),
+        ("testIsTokenDocumentable", self.testIsTokenDocumentable),
+        ("testParseDeclaration", self.testParseDeclaration),
+        ("testGenerateDocumentedTokenOffsets", self.testGenerateDocumentedTokenOffsets),
+        ("testDocumentedTokenOffsetsWithSubscript", self.testDocumentedTokenOffsetsWithSubscript),
+        ("testGenerateDocumentedTokenOffsetsEmpty", self.testGenerateDocumentedTokenOffsetsEmpty),
+        ("testSubstringWithByteRange", self.testSubstringWithByteRange),
+        ("testSubstringLinesWithByteRange", self.testSubstringLinesWithByteRange),
+        ("testLineRangeWithByteRange", self.testLineRangeWithByteRange),
+    ]
+
     func testStringByRemovingCommonLeadingWhitespaceFromLines() {
         var input = "a\n b\n  c"
         XCTAssertEqual(input.stringByRemovingCommonLeadingWhitespaceFromLines(), input)

--- a/Source/SourceKittenFrameworkTests/StructureTests.swift
+++ b/Source/SourceKittenFrameworkTests/StructureTests.swift
@@ -11,6 +11,15 @@ import SourceKittenFramework
 import XCTest
 
 class StructureTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testPrintEmptyStructure", self.testPrintEmptyStructure),
+        ("testGenerateSameStructureFileAndContents", self.testGenerateSameStructureFileAndContents),
+        ("testEnum", self.testEnum),
+        ("testStructurePrintValidJSON", self.testStructurePrintValidJSON),
+    ]
+
     func testPrintEmptyStructure() {
         let expected: NSDictionary = [
             "key.offset": 0,

--- a/Source/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Source/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -38,6 +38,14 @@ func compareDocsWithFixturesName(name: String) {
 }
 
 class SwiftDocsTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testSubscript", self.testSubscript),
+        ("testBicycle", self.testBicycle),
+        ("testParseFullXMLDocs", self.testParseFullXMLDocs),
+    ]
+
     func testSubscript() {
         compareDocsWithFixturesName("Subscript")
     }

--- a/Source/SourceKittenFrameworkTests/SyntaxTests.swift
+++ b/Source/SourceKittenFrameworkTests/SyntaxTests.swift
@@ -24,6 +24,15 @@ func compareSyntax(file: File, _ expectedTokens: [(SyntaxKind, Int, Int)]) {
 }
 
 class SyntaxTests: XCTestCase {
+
+    // protocol XCTestCaseProvider
+    lazy var allTests: [(String, () throws -> Void)] = [
+        ("testPrintEmptySyntax", self.testPrintEmptySyntax),
+        ("testGenerateSameSyntaxMapFileAndContents", self.testGenerateSameSyntaxMapFileAndContents),
+        ("testSubscript", self.testSubscript),
+        ("testSyntaxMapPrintValidJSON", self.testSyntaxMapPrintValidJSON),
+    ]
+
     func testPrintEmptySyntax() {
         XCTAssertEqual(SyntaxMap(file: File(contents: "")).description, "[\n\n]", "should print empty syntax")
     }

--- a/Source/SourceKittenFrameworkTests/main.swift
+++ b/Source/SourceKittenFrameworkTests/main.swift
@@ -1,0 +1,22 @@
+//
+//  main.swift
+//  sourcekitten
+//
+//  Created by 野村 憲男 on 2/3/16.
+//  Copyright © 2016 SourceKitten. All rights reserved.
+//
+
+import XCTest
+
+XCTMain([
+    ClangTranslationUnitTests(),
+    CodeCompletionTests(),
+    FileTests(),
+    ModuleTests(),
+    OffsetMapTests(),
+    SourceKitTests(),
+    StringTests(),
+    StructureTests(),
+    SwiftDocsTests(),
+    SyntaxTests(),
+    ])

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		3F56EACF1BAB251C006433D0 /* JSONOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONOutput.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6CDD63421C61DB840094A198 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		D0D1212619E878CC005E4BAA /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -406,6 +407,7 @@
 				E8AB1A2F1A64A21400452012 /* ClangTranslationUnitTests.swift */,
 				E845EFEB1B9941AA00CFA57B /* CodeCompletionTests.swift */,
 				E805A0491B560FCA00EA654A /* FileTests.swift */,
+				6CDD63421C61DB840094A198 /* main.swift */,
 				E8241CA21A5E01840047687E /* ModuleTests.swift */,
 				E8C9EA091A5C9A2900A6D4D1 /* OffsetMapTests.swift */,
 				E805A0471B55CBAF00EA654A /* SourceKitTests.swift */,
@@ -539,7 +541,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "SourceKitten" */;
+			buildConfigurationList = D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "sourcekitten" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -954,7 +956,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "SourceKitten" */ = {
+		D0D1211319E87861005E4BAA /* Build configuration list for PBXProject "sourcekitten" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D0D1211D19E87861005E4BAA /* Debug */,


### PR DESCRIPTION
#154

Notes:
- `swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a` contains `libswiftXCTest.dylib`. But that can not be used on building by SPM because that does not contain module. So, this PR uses `swift-corelibs-xctest` as dependency.
- Use forked [`norio-nomura/swift-corelibs-xctest`](https://github.com/norio-nomura/swift-corelibs-xctest) as dependency because original repository has no version tags yet.
- Test cases are needed conforming to `XCTestCaseProvider`.
- Add `import Foundation` explicitly.

**Test fails currently.**