### PR TITLE
Use `sourcekitd_response_dispose()`

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -253,7 +253,9 @@ public enum Request {
         dispatch_once(&sourceKitInitializationToken) {
             sourcekitd_initialize()
         }
-        return fromSourceKit(sourcekitd_response_get_value(sourcekitd_send_request_sync(sourcekitObject))) as! [String: SourceKitRepresentable]
+        let response = sourcekitd_send_request_sync(sourcekitObject)
+        defer { sourcekitd_response_dispose(response) }
+        return fromSourceKit(sourcekitd_response_get_value(response)) as! [String: SourceKitRepresentable]
     }
 }
 


### PR DESCRIPTION
Instruments on linting Carthage 0.12,
maximum Persistent Bytes is reduced from 508.49MB to 386.19MB.
From:
<img width="1039" alt="screenshot 2016-02-05 19 21 17" src="https://cloud.githubusercontent.com/assets/33430/12844237/76c004e8-cc41-11e5-85c1-6584d5b9fb37.png">
To:
<img width="1039" alt="screenshot 2016-02-05 19 22 15" src="https://cloud.githubusercontent.com/assets/33430/12844242/80169e6c-cc41-11e5-90a3-6e7eb226835b.png">
Total number of allocation does not increase. (If disposed memory was reused by sourcekitd, it increases.)

Running Time of calling `sourcekitd_response_dispose()` is 282ms:
<img width="780" alt="screenshot 2016-02-05 19 41 43" src="https://cloud.githubusercontent.com/assets/33430/12844251/8ccdbf3c-cc41-11e5-8f76-61bd6407435a.png">