### PR TITLE
Fix crash on offset points end of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Master
+
+##### Breaking
+
+* None.
+
+##### Enhancements
+
+* None.
+
+##### Bug Fixes
+
+* Fix crash when offset points end of string.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#164](https://github.com/realm/SwiftLint/issues/379)
+
 ## 0.9.0
 
 ##### Breaking

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -112,10 +112,11 @@ extension NSString {
             if lines.isEmpty {
                 return 0
             }
-            guard let index = lines.indexOf({ NSLocationInRange(byteOffset, $0.byteRange) }) else {
+            let index = lines.indexOf({ NSLocationInRange(byteOffset, $0.byteRange) })
+            // byteOffset may be out of bounds when sourcekitd points end of string.
+            guard let line = (index.map { lines[$0] } ?? lines.last) else {
                 fatalError()
             }
-            let line = lines[index]
             let diff = byteOffset - line.byteRange.location
             if diff == 0 {
                 return line.range.location

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -140,10 +140,11 @@ extension NSString {
             if lines.isEmpty {
                 return 0
             }
-            guard let index = lines.indexOf({ NSLocationInRange(location, $0.range) }) else {
+            let index = lines.indexOf({ NSLocationInRange(location, $0.range) })
+            // location may be out of bounds when NSRegularExpression points end of string.
+            guard let line = (index.map { lines[$0] } ?? lines.last) else {
                 fatalError()
             }
-            let line = lines[index]
             let diff = location - line.range.location
             if diff == 0 {
                 return line.byteRange.location


### PR DESCRIPTION
- `locationFromByteOffset` crashed on `byteOffset` points end of string  
`byteOffset` may be out of bounds when sourcekitd points end of string.  
Fix #164
- `byteOffsetFromLocation` crashed on `location` points end of string  
`location` may be out of bounds when `NSRegularExpression` points end of string.