### PR TITLE
move spm_bootstrap and spm_teardown to dedicated scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,16 +75,10 @@ swift_snapshot_install:
 	sudo installer -pkg swift.pkg -target /
 
 spm_bootstrap: spm_teardown
-	cp -r /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/local/include/clang-c /usr/local/include/clang-c
-	cp Source/Clang_C/module.modulemap /usr/local/include/clang-c/module.modulemap
-	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/libclang.dylib /usr/local/lib/libclang.dylib
-	mkdir -p /usr/local/include/sourcekitdInProc
-	ln -s /Library/Developer/Toolchains/$(SWIFT_SNAPSHOT).xctoolchain/usr/lib/sourcekitd.framework/Headers/sourcekitd.h /usr/local/include/sourcekitdInProc/sourcekitd.h
-	curl https://static.realm.io/libsourcekitdInProc/$(SWIFT_SNAPSHOT)/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib
+	script/spm_bootstrap "$(SWIFT_SNAPSHOT)"
 
 spm_teardown:
-	rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib
-	rm -rf /usr/local/include/sourcekitdInProc /usr/local/lib/libsourcekitdInProc.dylib
+	script/spm_teardown
 
 spm:
 	$(SWIFT_BUILD_COMMAND)

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
       dependencies: [.Target(name: "SourceKittenFramework")]),
   ],
   dependencies: [
+    .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 1),
     .Package(url: "https://github.com/jpsim/SourceKit.git", majorVersion: 1),
     .Package(url: "https://github.com/drmohundro/SWXMLHash.git", majorVersion: 2),
     .Package(url: "https://github.com/Carthage/Commandant.git", majorVersion: 0, minor: 8),

--- a/script/spm_bootstrap
+++ b/script/spm_bootstrap
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SWIFT_SNAPSHOT=$1
+
+cp -r /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/local/include/clang-c /usr/local/include/clang-c
+cp Source/Clang_C/module.modulemap /usr/local/include/clang-c/module.modulemap
+ln -s /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/lib/libclang.dylib /usr/local/lib/libclang.dylib
+mkdir -p /usr/local/include/sourcekitdInProc
+ln -s /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/lib/sourcekitd.framework/Headers/sourcekitd.h /usr/local/include/sourcekitdInProc/sourcekitd.h
+curl https://static.realm.io/libsourcekitdInProc/$SWIFT_SNAPSHOT/libsourcekitdInProc.dylib -o /usr/local/lib/libsourcekitdInProc.dylib

--- a/script/spm_bootstrap
+++ b/script/spm_bootstrap
@@ -3,7 +3,7 @@
 SWIFT_SNAPSHOT=$1
 
 cp -r /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/local/include/clang-c /usr/local/include/clang-c
-cp Source/Clang_C/module.modulemap /usr/local/include/clang-c/module.modulemap
+curl https://raw.githubusercontent.com/jpsim/SourceKitten/master/Source/Clang_C/module.modulemap -o /usr/local/include/clang-c/module.modulemap
 ln -s /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/lib/libclang.dylib /usr/local/lib/libclang.dylib
 mkdir -p /usr/local/include/sourcekitdInProc
 ln -s /Library/Developer/Toolchains/$SWIFT_SNAPSHOT.xctoolchain/usr/lib/sourcekitd.framework/Headers/sourcekitd.h /usr/local/include/sourcekitdInProc/sourcekitd.h

--- a/script/spm_teardown
+++ b/script/spm_teardown
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf /usr/local/include/clang-c /usr/local/lib/libclang.dylib
+rm -rf /usr/local/include/sourcekitdInProc /usr/local/lib/libsourcekitdInProc.dylib


### PR DESCRIPTION
also explicitly add antitypical/Result dependency to `Package.swift` due to https://github.com/realm/SwiftLint/pull/516#issuecomment-181734495.