### PR TITLE
[WIP] Use `xcode-select -p` (weak link approach)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,18 @@ installables: clean bootstrap
 	mv -f "$(SOURCEKITTEN_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/sourcekitten"
 	rm -rf "$(BUILT_BUNDLE)"
 
+	# remove rpathes that set by xcodebuild.
+	# SourceKittenFramework has dynamic loading mechanism for CLI.
+	install_name_tool -delete_rpath \
+		`xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/lib \
+	  "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework/Versions/A/SourceKittenFramework"
+	install_name_tool -delete_rpath \
+		/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib \
+	  "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework/Versions/A/SourceKittenFramework"
+	install_name_tool -delete_rpath \
+		/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib \
+	  "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework/Versions/A/SourceKittenFramework"
+
 prefix_install: installables
 	mkdir -p "$(FRAMEWORKS_FOLDER)" "$(BINARIES_FOLDER)"
 	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework" "$(FRAMEWORKS_FOLDER)/"

--- a/Source/SourceKittenFramework/DyldHelper.swift
+++ b/Source/SourceKittenFramework/DyldHelper.swift
@@ -1,0 +1,192 @@
+//
+//  DyldHelper.swift
+//  sourcekitten
+//
+//  Created by Norio Nomura on 2/11/16.
+//  Copyright © 2016 SourceKitten. All rights reserved.
+//
+
+import Foundation
+
+/// Environment Variable that indicates current process is launched through `execv()`
+private let sourceKittenFrameworkLoadingkey = "SOURCEKITTEN_FRAMEWORK_LOADING"
+
+private let libclangPath = "libclang.dylib"
+private let sourcekitdPath = "sourcekitd.framework/Versions/A/sourcekitd"
+
+/// Checks whether depending dynamic link libraries are loaded or not.
+/// If not, coordinates `DYLD_*` environment variables, calls `execv()` and never returns.
+public func checkDepndenciesOfSourceKittenFramework() {
+    if libraryIsLoaded(libclangPath) && libraryIsLoaded(sourcekitdPath) {
+        return
+    }
+
+    // following codes will be executed when dependencies will not be loaded.
+    // On sourcekitten installation, LC_RPATH of SourceKittenFramework does not contain pathes
+    // which can find libclang.dylib and sourcekitd.framework.
+
+    coordinateEnvironmentVariablesForDYLD()
+    setenv(sourceKittenFrameworkLoadingkey, "1", 1)
+
+    let arguments = NSProcessInfo.processInfo().arguments
+    let path = arguments[0]
+    let argv = CStringArray(arguments)
+    execv(path, argv.pointers) // never returns on normal flow
+    let error = String(UTF8String: strerror(errno))! // swiftlint:disable:this force_unwrapping
+    fatalError("execv failed: \(error)")
+}
+
+/// Returns true if library is not loaded.
+/// - Parameter path: string of library's path
+private func libraryIsLoaded(path: String) -> Bool {
+    let library = dlopen(path, RTLD_LAZY)
+    if library != nil {
+        dlclose(library)
+        return true
+    } else  if let _ = NSProcessInfo.processInfo().environment
+        .indexForKey(sourceKittenFrameworkLoadingkey) {
+        fatalError("Can't load \(path)")
+    }
+    return false
+}
+
+/// Coordinates "DYLD_LIBRARY_PATH" and "DYLD_FRAMEWORK_PATH" for `execv`ed process.
+private func coordinateEnvironmentVariablesForDYLD() {
+    let fileManager = NSFileManager.defaultManager()
+    let developerDirXcode = "/Applications/Xcode.app/Contents/Developer"
+    let developerDirXcodeBeta = "/Applications/Xcode-beta.app/Contents/Developer"
+
+    var pathes: [String] = [
+        toolchainDir,
+        xcodeSelectPath.map(toolchainDirFrom),
+        /*
+        Followings are used when `xcode-select -p` points "Command Line Tools OS X for Xcode",
+        but Xcode.app exists.
+        */
+        toolchainDirFrom(developerDirXcode),
+        toolchainDirFrom(developerDirXcodeBeta),
+        toolchainDirFrom(homeDir.stringByAppendingPathComponent(developerDirXcode)),
+        toolchainDirFrom(homeDir.stringByAppendingPathComponent(developerDirXcodeBeta)),
+        ].flatMap { path in
+            if let fullPath = path?.stringByAppendingPathComponent("/usr/lib")
+                where fileManager.fileExistsAtPath(fullPath) {
+                    return fullPath
+            }
+            return nil
+        }
+
+    #if SWIFT_PACKAGE
+        pathes = ["/Library/Developer/Toolchains/swift-latest"] + pathes
+    #endif
+
+    if let dyldLibraryPath = NSProcessInfo.processInfo().environment["DYLD_LIBRARY_PATH"] {
+        setenv("DYLD_LIBRARY_PATH", (pathes + [dyldLibraryPath]).joinWithSeparator(":"), 1)
+    } else {
+        setenv("DYLD_LIBRARY_PATH", pathes.joinWithSeparator(":"), 1)
+    }
+    if let dyldLibraryPath = NSProcessInfo.processInfo().environment["DYLD_FRAMEWORK_PATH"] {
+        setenv("DYLD_FRAMEWORK_PATH", (pathes + [dyldLibraryPath]).joinWithSeparator(":"), 1)
+    } else {
+        setenv("DYLD_FRAMEWORK_PATH", pathes.joinWithSeparator(":"), 1)
+    }
+}
+
+/// Returns "TOOLCHAIN_DIR" environment variable
+///
+/// Xcode/xcodebuild set toolchain path to "TOOLCHAIN_DIR" environment variable.
+private let toolchainDir: String? = {
+    return NSProcessInfo.processInfo().environment["TOOLCHAIN_DIR"]
+}()
+
+/// Returns path of toolchain from developerDir
+/// - Parameter developerDir: string of developer directory
+private func toolchainDirFrom(developerDir: String) -> String {
+    return developerDir.stringByAppendingPathComponent("Toolchains/XcodeDefault.xctoolchain")
+}
+
+/// Returns result string of `xcode-select -p`
+private let xcodeSelectPath: String? = {
+    let pathOfXcodeSelect = "/usr/bin/xcode-select"
+
+    if !NSFileManager.defaultManager().isExecutableFileAtPath(pathOfXcodeSelect) {
+        return nil
+    }
+
+    let task = NSTask()
+    task.launchPath = pathOfXcodeSelect
+    task.arguments = ["-p"]
+
+    let pipe = NSPipe()
+    task.standardOutput = pipe
+    task.standardError = pipe
+    task.launch() // if xcode-select does not exist, crash with `NSInvalidArgumentException`.
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let output = String(data: data, encoding: NSUTF8StringEncoding) else {
+        return nil
+    }
+
+    var start = output.startIndex
+    var end = output.startIndex
+    var contentsEnd = output.startIndex
+    output.getLineStart(&start, end: &end, contentsEnd: &contentsEnd, forRange: start..<start)
+    let xcodeSelectPath = output.substringWithRange(start..<contentsEnd)
+    // If xcodeSelectPath is path of "Command Line Tools OS X for Xcode", return nil.
+    // Because that does not contain `sourcekitd.framework`.
+    if xcodeSelectPath == "/Library/Developer/CommandLineTools" {
+        return nil
+    }
+    return xcodeSelectPath
+}()
+
+private let homeDir: String = {
+    return NSProcessInfo.processInfo().environment["HOME"]!
+}()
+
+private extension String {
+    private func stringByAppendingPathComponent(str: String) -> String {
+        return (self as NSString).stringByAppendingPathComponent(str)
+    }
+}
+
+// https://gist.github.com/neilpa/b430d148d1c5f4ae5ddd
+
+// Is this really the best way to extend the lifetime of C-style strings? The lifetime
+// of those passed to the String.withCString closure are only guaranteed valid during
+// that call. Tried cheating this by returning the same C string from the closure but it
+// gets dealloc'd almost immediately after the closure returns. This isn't terrible when
+// dealing with a small number of constant C strings since you can nest closures. But
+// this breaks down when it's dynamic, e.g. creating the char** argv array for an exec
+// call.
+private class CString {
+    let _len: Int
+    let buffer: UnsafeMutablePointer<Int8>
+
+    init(_ string: String) {
+        (_len, buffer) = string.withCString {
+            let len = Int(strlen($0) + 1)
+            let dst = strcpy(UnsafeMutablePointer<Int8>.alloc(len), $0)
+            return (len, dst)
+        }
+    }
+
+    deinit {
+        buffer.dealloc(_len)
+    }
+}
+
+// An array of C-style strings (e.g. char**) for easier interop.
+private class CStringArray {
+    // Have to keep the owning CString's alive so that the pointers
+    // in our buffer aren't dealloc'd out from under us.
+    let _strings: [CString]
+    var pointers: [UnsafeMutablePointer<Int8>]
+
+    init(_ strings: [String]) {
+        _strings = strings.map { CString($0) }
+        pointers = _strings.map { $0.buffer }
+        // NULL-terminate our string pointer buffer since things like
+        // exec*() and posix_spawn() require this.
+        pointers.append(nil)
+    }
+}

--- a/Source/sourcekitten/main.swift
+++ b/Source/sourcekitten/main.swift
@@ -9,6 +9,9 @@
 import Darwin
 import Foundation
 import Commandant
+import SourceKittenFramework
+
+checkDepndenciesOfSourceKittenFramework()
 
 // `sourcekitd_set_notification_handler()` set the handler to be executed on main thread queue.
 // So, we vacate main thread to `dispatch_main()`.

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		E847636A1A5A0651000EAE22 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84763691A5A0651000EAE22 /* File.swift */; };
 		E852418F1A5F4FB3007099FB /* Dictionary+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E852418E1A5F4FB3007099FB /* Dictionary+Merge.swift */; };
 		E868473A1A587B4D0043DC65 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86847391A587B4D0043DC65 /* Request.swift */; };
-		E868473C1A587C6E0043DC65 /* sourcekitd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E868473B1A587C6E0043DC65 /* sourcekitd.framework */; };
+		E868473C1A587C6E0043DC65 /* sourcekitd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E868473B1A587C6E0043DC65 /* sourcekitd.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E86F588E1C4DC49000426E78 /* sourcekitd.h in Headers */ = {isa = PBXBuildFile; fileRef = E86F588D1C4DC49000426E78 /* sourcekitd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E872121A1AD2FFCD00A484F4 /* Array+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87212191AD2FFCD00A484F4 /* Array+SourceKitten.swift */; };
 		E877D9271B5693E70095BB2B /* ObjCDeclarationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = E877D9261B5693E70095BB2B /* ObjCDeclarationKind.swift */; };
@@ -50,7 +50,7 @@
 		E8A18A3F1A592246000362B7 /* SwiftDocs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A18A3E1A592246000362B7 /* SwiftDocs.swift */; };
 		E8A9B8901B56CB5500CD17D4 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */; };
 		E8A9B8921B56D1B100CD17D4 /* SourceDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A9B8911B56D1B100CD17D4 /* SourceDeclaration.swift */; };
-		E8AB1A2E1A649F2100452012 /* libclang.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E8AB1A2D1A649F2100452012 /* libclang.dylib */; };
+		E8AB1A2E1A649F2100452012 /* libclang.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E8AB1A2D1A649F2100452012 /* libclang.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E8AB1A301A64A21400452012 /* ClangTranslationUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AB1A2F1A64A21400452012 /* ClangTranslationUnitTests.swift */; };
 		E8AE53C71A5B5FCA0092D24A /* String+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AE53C61A5B5FCA0092D24A /* String+SourceKitten.swift */; };
 		E8C0DFCD1AD349DB007EE3D4 /* SWXMLHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C0DFCC1AD349DB007EE3D4 /* SWXMLHash.framework */; };

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -720,7 +720,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -752,7 +752,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -824,7 +824,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",
@@ -881,7 +881,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Source/SourceKittenFramework/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks $(TOOLCHAIN_DIR)/usr/lib /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib",

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2E8FF7101C6268C100F280F0 /* StatementKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED279151C61E2A100084460 /* StatementKind.swift */; };
 		3F0CBB411BAAFF160015BBA8 /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0CBB401BAAFF160015BBA8 /* Clang+SourceKitten.swift */; };
 		3F56EAD01BAB251C006433D0 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56EACF1BAB251C006433D0 /* JSONOutput.swift */; };
+		6C31C15A1C6CADE30008ABFB /* DyldHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C31C1591C6CADE30008ABFB /* DyldHelper.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SourceKittenFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SourceKittenFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0D1217219E87B05005E4BAA /* SourceKittenFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = D0D1217119E87B05005E4BAA /* SourceKittenFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0D1217819E87B05005E4BAA /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SourceKittenFramework.framework */; };
@@ -127,6 +128,7 @@
 		3F56EACF1BAB251C006433D0 /* JSONOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONOutput.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C31C1591C6CADE30008ABFB /* DyldHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DyldHelper.swift; sourceTree = "<group>"; };
 		6CDD63421C61DB840094A198 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
 		D0D1212419E878CC005E4BAA /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 				E8EE34BE1B9A502F00947605 /* CodeCompletionItem.swift */,
 				E852418E1A5F4FB3007099FB /* Dictionary+Merge.swift */,
 				E806D2921BE058D600D1BE41 /* Documentation.swift */,
+				6C31C1591C6CADE30008ABFB /* DyldHelper.swift */,
 				E84763691A5A0651000EAE22 /* File.swift */,
 				3F56EACF1BAB251C006433D0 /* JSONOutput.swift */,
 				E8A18A3A1A58971D000362B7 /* Language.swift */,
@@ -616,6 +619,7 @@
 				E8241CA51A5E01A10047687E /* Module.swift in Sources */,
 				E877D9271B5693E70095BB2B /* ObjCDeclarationKind.swift in Sources */,
 				E83748C31A5BCD7900862B1B /* OffsetMap.swift in Sources */,
+				6C31C15A1C6CADE30008ABFB /* DyldHelper.swift in Sources */,
 				E806D2911BE058C400D1BE41 /* Parameter.swift in Sources */,
 				E868473A1A587B4D0043DC65 /* Request.swift in Sources */,
 				E8A9B8921B56D1B100CD17D4 /* SourceDeclaration.swift in Sources */,


### PR DESCRIPTION
#167 
#### Overview:

- `libclang.dylib` and `sourcekitd.framework` are weakly linked to `SourceKittenFramework`.
- toolchain pathes has been removed from `LC_RPATH` on `SourceKittenFramework`.
- `sourcekitten` loads `libclang.dylib` and `sourcekitd.framework` from active developer directory by calling `checkDepndenciesOfSourceKittenFramework()` in `main.swift`
- `checkDepndenciesOfSourceKittenFramework()` calls `execv` for re-launching main executable for loading `libclang.dylib` and `sourcekitd.framework`. So, it might not be used on some dependent client of `SourceKittenFramework`

#### `checkDepndenciesOfSourceKittenFramework()` does following:

- Check whether `libclang.dylib` and `sourcekitd.framework` are loaded or not
- If not, coordinates `DYLD_*` environment variables and calls `execv`
- New `sourcekitten` process launched by `execv` loads `libclang.dylib` and `sourcekitd.framework` using coordinated `DYLD_*` environment.

#### `DYLD_*` environment variables are coordinated to searching them in following order:
1. `$TOOLCHAIN_DIR/usr/lib` # for debugging on Xcode
2. \`xcode-select -p\` `/Toolchains/XcodeDefault.xctoolchain/usr/lib`
3. `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib`
4. `/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib`
5. `$HOME/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib`
6. `$HOME/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib`

3~6 are fallbacks on `xcode-select -p` pointing Command Line Tools OS X for Xcode, because that does not contains `sourcekitd.framework`.

#### Problems
- SPM does not support weak link yet
- `execv` needed. I don't know how large this affects to other clients.
