### PR TITLE
Use `init(minimumCapacity:)` for Dictionary in `fromSourceKit(_:)`

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -64,7 +64,12 @@ private func fromSourceKit(sourcekitObject: sourcekitd_variant_t) -> SourceKitRe
         }
         return array
     case SOURCEKITD_VARIANT_TYPE_DICTIONARY:
-        var dict = [String: SourceKitRepresentable](minimumCapacity: 9)
+        var count: Int = 0
+        sourcekitd_variant_dictionary_apply(sourcekitObject) { _, _ in
+            count += 1
+            return true
+        }
+        var dict = [String: SourceKitRepresentable](minimumCapacity: count)
         sourcekitd_variant_dictionary_apply(sourcekitObject) { key, value in
             if let key = stringForSourceKitUID(key), value = fromSourceKit(value) {
                 dict[key] = value

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -64,7 +64,7 @@ private func fromSourceKit(sourcekitObject: sourcekitd_variant_t) -> SourceKitRe
         }
         return array
     case SOURCEKITD_VARIANT_TYPE_DICTIONARY:
-        var dict = [String: SourceKitRepresentable]()
+        var dict = [String: SourceKitRepresentable](minimumCapacity: 9)
         sourcekitd_variant_dictionary_apply(sourcekitObject) { key, value in
             if let key = stringForSourceKitUID(key), value = fromSourceKit(value) {
                 dict[key] = value


### PR DESCRIPTION
By applying this, the duration of `fromSourceKit(_:)` on linting Carthage 0.13 by SwiftLint is reduced from 2490ms to 1536ms.
from:
<img width="1040" alt="screenshot 2016-02-11 13 25 18" src="https://cloud.githubusercontent.com/assets/33430/13007601/d50f4692-d1d4-11e5-9a80-1e8c8f5c2454.png">
to:
<img width="1039" alt="screenshot 2016-02-11 13 26 12" src="https://cloud.githubusercontent.com/assets/33430/13007607/deb17b84-d1d4-11e5-9242-0bd4c6da6a5a.png">

Why is capacity 9?
The count of dictionaries are following on above condition:

|count|happen|
|----:|-----:|
|    1|  5043|
|    3|274726|
|    4|     2|
|    5|  1216|
|    6|  1359|
|    7| 28351|
|    8| 38175|
|    9| 20653|
|   10|  4403|
|   11|  2513|
|   12|   255|
|   13|   660|
|   14|   173|

This approach couldn't apply before introducing https://github.com/realm/SwiftLint/pull/487, because of increasing persistent memory.