### PR TITLE
Fix #142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#315](https://github.com/realm/SwiftLint/issues/315)
 
+* Fix doc.comment blank for many declarations, causing missing Jazzy docs.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#142](https://github.com/jpsim/SourceKitten/issues/142)
+
 ## 0.10.0
 
 ##### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix crash on DOS newlines.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#315](https://github.com/realm/SwiftLint/issues/315)
 
 ## 0.10.0
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -318,11 +318,6 @@ public final class File {
     public func getDocumentationCommentBody(dictionary: [String: SourceKitRepresentable], syntaxMap: SyntaxMap) -> String? {
         return SwiftDocKey.getOffset(dictionary).flatMap { offset in
             return syntaxMap.commentRangeBeforeOffset(Int(offset)).flatMap { commentByteRange in
-                let commentEndLine = (contents as NSString).lineAndCharacterForByteOffset(commentByteRange.endIndex)?.line
-                let tokenStartLine = (contents as NSString).lineAndCharacterForByteOffset(Int(offset))?.line
-                guard commentEndLine == tokenStartLine || commentEndLine == tokenStartLine?.predecessor() else {
-                    return nil
-                }
                 return contents.byteRangeToNSRange(start: commentByteRange.startIndex, length: commentByteRange.endIndex - commentByteRange.startIndex).flatMap { nsRange in
                     return contents.commentBody(nsRange)
                 }


### PR DESCRIPTION
Fix #142
- Change `SyntaxMap.commentRangeBeforeOffset(_:)` to returns nil on finding identifier.  
If finds identifier earlier than doc comment, stops searching and returns nil, because doc comment belong to identifier.
- Remove checking line number on `getDocumentationCommentBody(_:syntaxMap:)`.  
Now `SyntaxMap.commentRangeBeforeOffset(_:)` detects comment more strictly, so line number checking is not needed anymore.

Should we change the name of `SyntaxMap.commentRangeBeforeOffset(_:)`?