### PR TITLE
Fix "Unrecognized arguments:" error on `doc` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [Norio Nomura](https://github.com/norio-nomura)
   [#142](https://github.com/jpsim/SourceKitten/issues/142)
 
+* Fix "Unrecognized arguments:" error on `doc` command.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#174](https://github.com/jpsim/SourceKitten/issues/174)
+
 ## 0.10.0
 
 ##### Breaking

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Running `sourcekitten doc` will pass all arguments after what is parsed to
 
 ### Example usage
 
-1. `sourcekitten doc -workspace SourceKitten.xcworkspace -scheme SourceKittenFramework`
-2. `sourcekitten doc --single-file file.swift -j4 file.swift`
-3. `sourcekitten doc --module-name Alamofire -project Alamofire.xcodeproj`
-4. `sourcekitten doc -workspace Haneke.xcworkspace -scheme Haneke`
-5. `sourcekitten doc --objc Realm/Realm.h -x objective-c -isysroot $(xcrun --show-sdk-path) -I $(pwd)`
+1. `sourcekitten doc -- -workspace SourceKitten.xcworkspace -scheme SourceKittenFramework`
+2. `sourcekitten doc --single-file file.swift -- -j4 file.swift`
+3. `sourcekitten doc --module-name Alamofire -- -project Alamofire.xcodeproj`
+4. `sourcekitten doc -- -workspace Haneke.xcworkspace -scheme Haneke`
+5. `sourcekitten doc --objc Realm/Realm.h -- -x objective-c -isysroot $(xcrun --show-sdk-path) -I $(pwd)`
 
 ## Structure
 

--- a/Source/sourcekitten/DocCommand.swift
+++ b/Source/sourcekitten/DocCommand.swift
@@ -16,7 +16,7 @@ struct DocCommand: CommandType {
     let function = "Print Swift docs as JSON or Objective-C docs as XML"
 
     func run(options: DocOptions) -> Result<(), SourceKittenError> {
-        let args = Process.arguments
+        let args = options.arguments
         if options.objc {
             return runObjC(options, args: args)
         } else if options.singleFile {
@@ -27,9 +27,7 @@ struct DocCommand: CommandType {
     }
 
     func runSwiftModule(moduleName: String?, args: [String]) -> Result<(), SourceKittenError> {
-        let xcodeBuildArgumentsStart = (moduleName != nil) ? 4 : 2
-        let xcodeBuildArguments = Array<String>(args[xcodeBuildArgumentsStart..<args.count])
-        let module = Module(xcodeBuildArguments: xcodeBuildArguments, name: moduleName)
+        let module = Module(xcodeBuildArguments: args, name: moduleName)
 
         if let docs = module?.docs {
             print(docs)
@@ -39,20 +37,23 @@ struct DocCommand: CommandType {
     }
 
     func runSwiftSingleFile(args: [String]) -> Result<(), SourceKittenError> {
-        if args.count < 5 {
+        if args.isEmpty {
             return .Failure(.InvalidArgument(description: "at least 5 arguments are required when using `--single-file`"))
         }
-        let sourcekitdArguments = Array<String>(args[4..<args.count])
-        if let file = File(path: args[3]),
+        let sourcekitdArguments = Array(args.dropFirst(1))
+        if let file = File(path: args[0]),
             docs = SwiftDocs(file: file, arguments: sourcekitdArguments) {
             print(docs)
             return .Success()
         }
-        return .Failure(.ReadFailed(path: args[3]))
+        return .Failure(.ReadFailed(path: args[0]))
     }
 
     func runObjC(options: DocOptions, args: [String]) -> Result<(), SourceKittenError> {
-        let translationUnit = ClangTranslationUnit(headerFiles: [args[3]], compilerArguments: Array<String>(args[4..<args.count]))
+        if args.isEmpty {
+            return .Failure(.InvalidArgument(description: "at least 5 arguments are required when using `--objc`"))
+        }
+        let translationUnit = ClangTranslationUnit(headerFiles: [args[0]], compilerArguments: Array(args.dropFirst(1)))
         print(translationUnit)
         return .Success()
     }
@@ -62,11 +63,12 @@ struct DocOptions: OptionsType {
     let singleFile: Bool
     let moduleName: String
     let objc: Bool
+    let arguments: [String]
 
-    static func create(singleFile: Bool) -> (moduleName: String) -> (objc: Bool) -> DocOptions {
-        return { moduleName in { objc in
-            self.init(singleFile: singleFile, moduleName: moduleName, objc: objc)
-        }}
+    static func create(singleFile: Bool) -> (moduleName: String) -> (objc: Bool) -> (arguments: [String]) -> DocOptions {
+        return { moduleName in { objc in { arguments in
+            self.init(singleFile: singleFile, moduleName: moduleName, objc: objc, arguments: arguments)
+            }}}
     }
 
     static func evaluate(m: CommandMode) -> Result<DocOptions, CommandantError<SourceKittenError>> {
@@ -74,5 +76,6 @@ struct DocOptions: OptionsType {
             <*> m <| Option(key: "single-file", defaultValue: false, usage: "only document one file")
             <*> m <| Option(key: "module-name", defaultValue: "",    usage: "name of module to document (can't be used with `--single-file` or `--objc`)")
             <*> m <| Option(key: "objc",        defaultValue: false, usage: "document Objective-C headers")
+            <*> m <| Argument(defaultValue: [], usage: "Arguments list that passed to xcodebuild. If `-` prefixed argument exists, place ` -- ` before that.")
     }
 }


### PR DESCRIPTION
- Fix #174  
  Commandant treats `--` as separator that stop parsing named arguments.
- Update Example usage of Doc in README.md  
  Insert `--` separator before arguments for `xcodebuild`.