### PR TITLE
[SPM] Specify stricter version requirements of SWXMLHash in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/SourceKit.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/Clang_C.git", majorVersion: 1),
-    .Package(url: "https://github.com/drmohundro/SWXMLHash.git", majorVersion: 2),
+    .Package(url: "https://github.com/drmohundro/SWXMLHash.git", majorVersion: 2, minor: 2),
     .Package(url: "https://github.com/Carthage/Commandant.git", majorVersion: 0, minor: 9),
   ]
 )


### PR DESCRIPTION
Because building SWXMLHash-2.3 fails on SPM.
Fixing PR is https://github.com/drmohundro/SWXMLHash/pull/72

SWXMLHash does not have test running SPM on CI, so we should specify stricter version in Package.swift.