### PR TITLE
Update fixture to Xcode 7.3.1

### DIFF
--- a/Tests/SourceKittenFramework/Fixtures/Realm.json
+++ b/Tests/SourceKittenFramework/Fixtures/Realm.json
@@ -4152,6 +4152,7 @@
           "key.usr" : "c:RLMRealm.h@T@RLMMigrationBlock",
           "key.doc.file" : "Realm\/RLMRealm.h",
           "key.doc.full_as_xml" : "",
+          "key.swift_declaration" : "typealias RLMMigrationBlock = (RLMMigration!, UInt64) -> Void",
           "key.parsed_scope.start" : 431,
           "key.filepath" : "Realm\/RLMRealm.h"
         },


### PR DESCRIPTION
Travis-CI has been updated to Xcode 7.3.1.
https://blog.travis-ci.com/2016-05-05-xcode-731-is-here