### PR TITLE
Use `xcrun -find swift` instead of `xcode-select -p`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Add support `TOOLCHAINS` environment variable to selecting alternative
+  toolchains for loading SourceKitService.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
In addition to `DEVELOPER_DIR` environment variable supported by `xcode-select`, `TOOLCHAINS` environment variable is also supported by `xcrun` to selecting alternative toolchains since Xcode 7.3.
SeeAlso: [Alternative Toolchain Support in Xcode Release Notes](https://developer.apple.com/library/mac/releasenotes/DeveloperTools/RN-Xcode/Chapters/xc7_release_notes.html#//apple_ref/doc/uid/TP40001051-CH5-DontLinkElementID_33)
By using `xcrun -find swift` instead of `xcode-select -p`, we can use `DEVELOPER_DIR` and `TOOLCHAINS` environment variables to selecting alternative toolchain for loading SourceKitService.