### PR TITLE
[Index] Support --compilerargs

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -191,7 +191,7 @@ public enum Request {
     /// Find USR
     case FindUSR(file: String, usr: String)
     /// Index
-    case Index(file: String)
+    case Index(file: String, arguments: [String])
     /// Format
     case Format(file: String, line: Int64, useTabs: Bool, indentWidth: Int64)
     /// ReplaceText
@@ -250,8 +250,7 @@ public enum Request {
                 sourcekitd_uid_get_from_cstr("key.usr"): sourcekitd_request_string_create(usr),
                 sourcekitd_uid_get_from_cstr("key.sourcefile"): sourcekitd_request_string_create(file)
             ]
-        case .Index(let file):
-            let arguments = ["-sdk", sdkPath(), "-j4", file ]
+        case .Index(let file, let arguments):
             var compilerargs = arguments.map({ sourcekitd_request_string_create($0) })
             dict = [
                 sourcekitd_uid_get_from_cstr("key.request"): sourcekitd_request_uid_create(sourcekitd_uid_get_from_cstr("source.request.indexsource")),

--- a/Tests/SourceKittenFramework/SourceKitTests.swift
+++ b/Tests/SourceKittenFramework/SourceKitTests.swift
@@ -172,7 +172,8 @@ class SourceKitTests: XCTestCase {
 
     func testIndex() {
         let file = "\(fixturesDirectory)Bicycle.swift"
-        let indexJSON = NSMutableString(string: toJSON(toAnyObject(Request.Index(file: file).send())) + "\n")
+        let arguments = ["-sdk", sdkPath(), "-j4", file ]
+        let indexJSON = NSMutableString(string: toJSON(toAnyObject(Request.Index(file: file, arguments: arguments).send())) + "\n")
 
         func replace(pattern: String, withTemplate template: String) {
             try! NSRegularExpression(pattern: pattern, options: []).replaceMatchesInString(indexJSON, options: [], range: NSRange(location: 0, length: indexJSON.length), withTemplate: template)


### PR DESCRIPTION
Just as with `sourcekitten complete`, SourceKit provides much better information when given the correct compiler arguments. Provide a `sourcekitten index --compilerargs` argument, to allow for more correct indexing.

---

This is sort of a work-in-progress, because this removes the automatic mechanism for finding the SDK path. Do consumers of SourceKitten rely on this automatic behavior? Should I provide it as a fallback in case the user didn't specify any `--compilerargs`? Advice from maintainers would be appreciated here. :)