### PR TITLE
[Request] Avoid force casting null responses

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -328,7 +328,12 @@ public enum Request {
         }
         let response = sourcekitd_send_request_sync(sourcekitObject)
         defer { sourcekitd_response_dispose(response) }
-        return fromSourceKit(sourcekitd_response_get_value(response)) as! [String: SourceKitRepresentable]
+        if let value = fromSourceKit(sourcekitd_response_get_value(response)) {
+          return value as! [String: SourceKitRepresentable]
+        } else {
+          return [String: SourceKitRepresentable]()
+        }
+
     }
     
     /// A enum representation of SOURCEKITD_ERROR_*


### PR DESCRIPTION
In cases in which SourceKit returns a null response from an index request (for example, if the index request is not passed any compiler args), a force cast to `[String: SourceKitRepresentable]` would cause a crash at runtime.

Instead, attempt a cast, and if it fails, return an empty dictionary.