### PR TITLE
Change completion's compilerargs to array of strings

### DIFF
--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -19,9 +19,9 @@ struct CompleteCommand: CommandType {
         let file: String
         let text: String
         let offset: Int
-        let compilerargs: String
+        let compilerargs: [String]
 
-        static func create(file: String) -> (text: String) -> (offset: Int) -> (compilerargs: String) -> Options {
+        static func create(file: String) -> (text: String) -> (offset: Int) -> (compilerargs: [String]) -> Options {
             return { text in { offset in { compilerargs in
                 self.init(file: file, text: text, offset: offset, compilerargs: compilerargs)
             }}}
@@ -32,7 +32,7 @@ struct CompleteCommand: CommandType {
                 <*> m <| Option(key: "file", defaultValue: "", usage: "relative or absolute path of Swift file to parse")
                 <*> m <| Option(key: "text", defaultValue: "", usage: "Swift code text to parse")
                 <*> m <| Option(key: "offset", defaultValue: 0, usage: "Offset for which to generate code completion options.")
-                <*> m <| Option(key: "compilerargs", defaultValue: "", usage: "Compiler arguments to pass to SourceKit. This must be specified following the '--'")
+                <*> m <| Argument(defaultValue: [String](), usage: "Compiler arguments to pass to SourceKit. This must be specified following the '--'")
         }
     }
 
@@ -51,9 +51,8 @@ struct CompleteCommand: CommandType {
         }
 
         var args = ["-c", path]
-        if !options.compilerargs.isEmpty {
-            args.appendContentsOf(options.compilerargs.componentsSeparatedByString(" "))
-        }
+        args.appendContentsOf(options.compilerargs)
+
         if args.indexOf("-sdk") == nil {
             args.appendContentsOf(["-sdk", sdkPath()])
         }


### PR DESCRIPTION
Currently the compilerargs are consumed from commandant as a single
quoted string. Because of this, we have to manually split the string at
spaces, which causes issues with arguments, or filepaths with spaces in
them. Instead of doing this we can allow commandant to pass us the
"remaining" arguments trailing the `--` so we can avoid having to split
anything ourselves.

Currently there is a backwards compatibility problem with this, since now doing:

```
sourcekitten complete ... --compilerargs -- ...
```

Will leave `compilerargs` as an unused argument. If we want to make sure we don't break this for current users we could either try to make this command relevant to the new array of arguments, or we could make it a no-op which at least wouldn't throw an error.


Let me know what you think!