### PR TITLE
Added the Yaml and SWXMLHash frameworks to address issue #232.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ package: installables
 
 archive:
 	carthage build --no-skip-current --platform mac
-	carthage archive SourceKittenFramework
+	carthage archive SourceKittenFramework Yaml SWXMLHash
 
 release: package archive
 


### PR DESCRIPTION
This partially addresses issue #232.

I'm a little confused though as I'm not seeing a `Carthage.zip` file being produced. I do see a `SourceKittenFramework.framework.zip` file though.