### PR TITLE
Support loading `libsourcekitdInProc.so` placed in default search paths

### DIFF
--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -25,7 +25,7 @@ struct DynamicLinkLibrary {
 }
 
 #if os(Linux)
-let toolchainLoader = Loader(searchPaths: [linuxSourceKitLibPath!])
+let toolchainLoader = Loader(searchPaths: [linuxSourceKitLibPath, ""].flatMap {$0})
 #else
 let toolchainLoader = Loader(searchPaths: [
     xcodeDefaultToolchainOverride,


### PR DESCRIPTION
Without using `LINUX_SOURCEKIT_LIB_PATH`.