### PR TITLE
Update CHANGELOG and README for compilerargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Require passing compiler arguments to `index` command.  
   [Brian Gesiak](https://github.com/modocache)
 
+* Remove `--compilerargs` CLI flag. Arguments are now passed after `--`
+  [Keith Smiley](https://github.com/keith)
+
 ##### Enhancements
 
 * Refactor to unite swift lang syntax types with SwiftLangSyntax protocol

--- a/README.md
+++ b/README.md
@@ -71,10 +71,9 @@ options for the offset in the file/text provided:
 ]
 ```
 
-To use the iOS SDK is to specified the `compilerargs` option. The value
-specified by `compilerargs` the `--` to must be prefixed:
+To use the iOS SDK, pass `-sdk` and `-target` arguments preceded by `--`:
 ```
-sourcekitten complete --text "import UIKit ; UIColor." --offset 22 --compilerargs -- '-target arm64-apple-ios9.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk'
+sourcekitten complete --text "import UIKit ; UIColor." --offset 22 -- -target arm64-apple-ios9.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk
 ```
 
 ## Doc


### PR DESCRIPTION
This updates the CHANGELOG and README to reflect that you no longer pass
`--compilerargs` to the `complete` command.

This is follow up to https://github.com/jpsim/SourceKitten/pull/231