### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Master
+## 0.14.0
+
+This is the last release to support Swift 2.2 and Swift 2.3.
+The next release will require Swift 3.0.
 
 ##### Breaking
 

--- a/Source/SourceKittenFramework/Info.plist
+++ b/Source/SourceKittenFramework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0</string>
+	<string>0.14.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/sourcekitten/Info.plist
+++ b/Source/sourcekitten/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.0</string>
+	<string>0.14.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/sourcekitten/VersionCommand.swift
+++ b/Source/sourcekitten/VersionCommand.swift
@@ -9,7 +9,7 @@
 import Commandant
 import Result
 
-private let version = "0.13.0"
+private let version = "0.14.0"
 
 struct VersionCommand: CommandType {
     let verb = "version"


### PR DESCRIPTION
This is the last release to support Swift 2.2 and Swift 2.3. The next release will require Swift 3.0.