### PR TITLE
Fix `NSString.lines()` generated surplus line when string ended with new line character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* `NSString.lines()` generated surplus line when string ended with newline
+  character.  
+  [Norio Nomura](https://github.com/norio-nomura)
+  [#259](https://github.com/jpsim/SourceKitten/issues/259)
 
 ## 0.14.1
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -85,7 +85,7 @@ public final class File {
             }
         }
 
-        return newContents.joinWithSeparator("\n")
+        return newContents.joinWithSeparator("\n") + "\n"
     }
 
     /**

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -65,7 +65,14 @@ extension NSString {
             var bytesSoFar = 0
             var lines = [Line]()
             let lineContents = string.componentsSeparatedByCharactersInSet(.newlineCharacterSet())
-            for (index, content) in lineContents.enumerate() {
+            // Be compatible with `NSString.getLineStart(_:end:contentsEnd:forRange:)`
+            let endsWithNewLineCharacter = string.utf16.last
+                .map(NSCharacterSet.newlineCharacterSet().characterIsMember) ?? false
+            // if string ends with new line character, no empty line is generated after that.
+            let enumerator = endsWithNewLineCharacter
+                ? AnySequence(lineContents.dropLast().enumerate())
+                : AnySequence(lineContents.enumerate())
+            for (index, content) in enumerator {
                 let index = index + 1
                 let rangeStart = utf16CountSoFar
                 let utf16Count = content.utf16.count


### PR DESCRIPTION
This makes it compatible with previous behavior and will fix [failing tests](https://travis-ci.org/realm/SwiftLint/jobs/162080744#L761) of https://github.com/realm/SwiftLint/pull/771.