### PR TITLE
don't initialize SourceKit twice

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -100,7 +100,7 @@ private let initializeSourceKit: Void = {
     sourcekitd_initialize()
 }()
 private let initializeSourceKitFailable: Void = {
-    sourcekitd_initialize()
+    initializeSourceKit
     sourcekitd_set_notification_handler() { response in
         if !sourcekitd_response_is_error(response!) {
             fflush(stdout)


### PR DESCRIPTION
if calling both `initializeSourceKit` and `initializeSourceKitFailable`