### PR TITLE
add spm-module to complete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 
 * Add `--spm-module [ModuleName]` flag to `complete` to automatically detect
   compiler flags for Swift Package Manager modules. `swift build` must be run
-  prior to support detection.
+  prior to support detection.  
   [vdka](https://github.com/vdka)
+  [#270](https://github.com/jpsim/SourceKitten/issues/270)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 
 ##### Enhancements
 
-* None.
+* Add `--spm-module [ModuleName]` flag to `complete` to automatically detect
+  compiler flags for Swift Package Manager modules. `swift build` must be run
+  prior to support detection.
+  [vdka](https://github.com/vdka)
 
 ##### Bug Fixes
 

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -52,19 +52,20 @@ struct CompleteCommand: CommandProtocol {
             contents = options.text
         }
 
-        var args = ["-c", path]
-        if !options.spmModule.isEmpty {
+        var args: [String]
+        if options.spmModule.isEmpty {
+            args = ["-c", path] + options.compilerargs
+            if args.index(of: "-sdk") == nil {
+                args.append(contentsOf: ["-sdk", sdkPath()])
+            }
+        } else {
             guard let module = Module(spmName: options.spmModule) else {
                 return .failure(.invalidArgument(description: "Bad module name"))
             }
-            args.append(contentsOf: module.compilerArguments)
+            args = module.compilerArguments
         }
 
-        args.append(contentsOf: options.compilerargs)
 
-        if args.index(of: "-sdk") == nil {
-            args.append(contentsOf: ["-sdk", sdkPath()])
-        }
 
         let request = Request.codeCompletionRequest(file: path, contents: contents,
             offset: Int64(options.offset),

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -19,12 +19,13 @@ struct CompleteCommand: CommandProtocol {
         let file: String
         let text: String
         let offset: Int
+        let spmModule: String
         let compilerargs: [String]
 
-        static func create(file: String) -> (_ text: String) -> (_ offset: Int) -> (_ compilerargs: [String]) -> Options {
-            return { text in { offset in { compilerargs in
-                self.init(file: file, text: text, offset: offset, compilerargs: compilerargs)
-            }}}
+        static func create(file: String) -> (_ text: String) -> (_ offset: Int) -> (_ spmModule: String) -> (_ compilerargs: [String]) -> Options {
+            return { text in { offset in { spmModule in { compilerargs in
+                self.init(file: file, text: text, offset: offset, spmModule: spmModule, compilerargs: compilerargs)
+            }}}}
         }
 
         static func evaluate(_ m: CommandMode) -> Result<Options, CommandantError<SourceKittenError>> {
@@ -32,6 +33,7 @@ struct CompleteCommand: CommandProtocol {
                 <*> m <| Option(key: "file", defaultValue: "", usage: "relative or absolute path of Swift file to parse")
                 <*> m <| Option(key: "text", defaultValue: "", usage: "Swift code text to parse")
                 <*> m <| Option(key: "offset", defaultValue: 0, usage: "Offset for which to generate code completion options.")
+                <*> m <| Option(key: "spm-module", defaultValue: "", usage: "Read compiler flags from a Swift Package Manager module")
                 <*> m <| Argument(defaultValue: [String](), usage: "Compiler arguments to pass to SourceKit. This must be specified following the '--'")
         }
     }
@@ -51,6 +53,13 @@ struct CompleteCommand: CommandProtocol {
         }
 
         var args = ["-c", path]
+        if !options.spmModule.isEmpty {
+            guard let module = Module(spmName: options.spmModule) else {
+                return .failure(.invalidArgument(description: "Bad module name"))
+            }
+            args.append(contentsOf: module.compilerArguments)
+        }
+
         args.append(contentsOf: options.compilerargs)
 
         if args.index(of: "-sdk") == nil {


### PR DESCRIPTION
Adds support for reading the build commands from the `build.yaml` file
closes #270