### PR TITLE
fix String(contentsOfFile:) on Linux

### DIFF
--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -36,7 +36,7 @@ public struct Module {
 
     public init?(spmName: String) {
         let yamlPath = ".build/debug.yaml"
-        guard let yamlContents = try? String(contentsOfFile: yamlPath),
+        guard let yamlContents = try? String(contentsOfFile: yamlPath, encoding: .utf8),
               let yamlCommands = Yaml.load(yamlContents).value?.dictionary?["commands"]?.dictionary?.values else {
                 return nil
         }


### PR DESCRIPTION
Otherwise we get the following failure:

```
fatal error: init(contentsOfFile:usedEncoding:) is not yet implemented: file Foundation/NSString.swift, line 1255
```