### PR TITLE
cache sourcekitStrings to speed up tests

### DIFF
--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -26,7 +26,7 @@ private func run(executable: String, arguments: [String]) -> String? {
     return output
 }
 
-private func sourcekitStrings(startingWith pattern: String) -> Set<String> {
+private let sourcekitStrings: [String] = {
     #if os(Linux)
     let sourceKitPath = "\(linuxSourceKitLibPath)/libsourcekitdInProc.so"
     #else
@@ -36,7 +36,11 @@ private func sourcekitStrings(startingWith pattern: String) -> Set<String> {
         .appendingPathComponent("lib/sourcekitd.framework/XPCServices/SourceKitService.xpc/Contents/MacOS/SourceKitService")
     #endif
     let strings = run(executable: "/usr/bin/strings", arguments: [sourceKitPath])
-    return Set(strings!.components(separatedBy: "\n").filter { string in
+    return strings!.components(separatedBy: "\n")
+}()
+
+private func sourcekitStrings(startingWith pattern: String) -> Set<String> {
+    return Set(sourcekitStrings.filter { string in
         return string.range(of: pattern)?.lowerBound == string.startIndex
     })
 }


### PR DESCRIPTION
makes Linux tests run in 5s instead of 10s.