### PR TITLE
some fixes for xcode 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 ##### Bug Fixes
 
-* `CXComment.commandName()` was returning nil on custom code comments 
-  since xcode 8.1 sdk. This caused a force unwrap when generating 
-  documentation. Inline command comment is now used as a 
-  fallback to catch this edge case.
+* `CXComment.commandName()` was returning nil on custom code comments
+  since Xcode 8.1. This caused a force unwrap when generating
+  documentation. Inline command comment is now used as a
+  fallback to catch this edge case.  
+  [Jérémie Girault](https://github.com/jeremiegirault)
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* `CXComment.commandName()` was returning nil on custom code comments 
+  since xcode 8.1 sdk. This caused a force unwrap when generating 
+  documentation. Inline command comment is now used as a 
+  fallback to catch this edge case.
 
 ## 0.15.0
 

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -243,7 +243,8 @@ extension CXComment {
                 return paragraphString + (paragraphString != "" ? "\n" : "") + text
             } else if child.kind() == CXComment_InlineCommand {
                 // @autoreleasepool etc. get parsed as commands when not in code blocks
-                return paragraphString + "@" + child.commandName()!
+                let inlineCommand = child.commandName().map { "@" + $0 }
+                return paragraphString + (inlineCommand ?? "")
             }
             fatalError("not text: \(child.kind())")
         }
@@ -255,7 +256,8 @@ extension CXComment {
     }
 
     func commandName() -> String? {
-        return clang_BlockCommandComment_getCommandName(self).str()
+        return clang_BlockCommandComment_getCommandName(self).str() ??
+            clang_InlineCommandComment_getCommandName(self).str()
     }
 
     func count() -> UInt32 {


### PR DESCRIPTION
I noticed that I made a typo in a code comment of mine and typed `@type` instead of `@param`.
This was interpreted as a comment command. Previously `clang_BlockCommandComment_getCommandName` returned something. With Xcode 8.1 I had a force unwrap.
I noticed the value was actually returned by `clang_InlineCommandComment_getCommandName`

Maybe we should keep the force unwrap instead of the default value (`""`), but do it in `commandName` if it is always expected to return a value ? It could allow us to detect issues like these.

I also updated the fixtures for Xcode 8.1

Thanks