### PR TITLE
Reduce build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,7 @@ release: package archive
 
 docker_test:
 	docker run -v `pwd`:/SourceKitten norionomura/sourcekit:301 bash -c "cd /SourceKitten && swift test"
+
+# http://irace.me/swift-profiling/
+display_compilation_time:
+	$(BUILD_TOOL) $(XCODEFLAGS) OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" clean build-for-testing | grep -E ^[1-9]{1}[0-9]*.[0-9]ms | sort -n

--- a/Source/SourceKittenFramework/JSONOutput.swift
+++ b/Source/SourceKittenFramework/JSONOutput.swift
@@ -63,7 +63,9 @@ public func toNSDictionary(_ dictionary: [String: SourceKitRepresentable]) -> NS
 #if !os(Linux)
 
 public func declarationsToJSON(_ decl: [String: [SourceDeclaration]]) -> String {
-    return toJSON(decl.map({ [$0: toOutputDictionary($1)] }).sorted { $0.keys.first! < $1.keys.first! })
+    let keyValueToDictionary: ((String, [SourceDeclaration])) -> [String:Any] = { [$0: toOutputDictionary($1)] }
+    let dictionaries: [[String: Any]] = decl.map(keyValueToDictionary).sorted { $0.keys.first! < $1.keys.first! }
+    return toJSON(dictionaries)
 }
 
 private func toOutputDictionary(_ decl: SourceDeclaration) -> [String: Any] {

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -78,7 +78,14 @@ public struct Module {
                 return nil
         }
         name = spmName
-        compilerArguments = sources + ["-module-name", spmName] + otherArguments + ["-I"] + imports
+        compilerArguments = {
+            var arguments = sources
+            arguments.append(contentsOf: ["-module-name", spmName])
+            arguments.append(contentsOf: otherArguments)
+            arguments.append(contentsOf: ["-I"])
+            arguments.append(contentsOf: imports)
+            return arguments
+        }()
         sourceFiles = sources
     }
 

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -747,6 +747,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-function-bodies=200";
 			};
 			name = Debug;
 		};
@@ -759,6 +760,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-function-bodies=200";
 			};
 			name = Release;
 		};
@@ -845,6 +847,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-function-bodies=200";
 			};
 			name = Profile;
 		};
@@ -894,6 +897,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -Xfrontend -warn-long-function-bodies=200";
 			};
 			name = Test;
 		};


### PR DESCRIPTION
- Add `display_compilation_time` target to `Makefile`
- Reduce build time of two functions
- Set `-Xfrontend -warn-long-function-bodies=200` to `OTHER_SWIFT_FLAGS`
