### PR TITLE
rename SourceKitten.podspec to SourceKittenFramework.podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ##### Breaking
 
-* None.
+* The `SourceKitten` CocoaPods podspec used to actually refer to
+  SourceKittenFramework, so it has been renamed. Existing pushes to CocoaPods
+  trunk will be preserved, but from now on if you use SourceKittenFramework via
+  CocoaPods, please specify to use the `SourceKittenFramework` pod.
+  [JP Simard](https://github.com/jpsim)
 
 ##### Enhancements
 

--- a/SourceKittenFramework.podspec
+++ b/SourceKittenFramework.podspec
@@ -1,6 +1,5 @@
 Pod::Spec.new do |s|
-  s.name                = 'SourceKitten'
-  s.module_name         = 'SourceKittenFramework'
+  s.name                = 'SourceKittenFramework'
   s.version             = `make get_version`
   s.summary             = 'An adorable little framework for interacting with SourceKit.'
   s.homepage            = 'https://github.com/jpsim/SourceKitten'


### PR DESCRIPTION
this will break CocoaPods users of the SourceKitten pod, but I don't think there are any consumers other than SwiftLint.