### PR TITLE
Make enum case's first letter lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ##### Breaking
 
-* Change `Text` enum case names to match Swift 3 API guidelines.
-  [@istx25](https://github.com/istx25), [#324](https://github.com/jpsim/SourceKitten/pull/324).
+* Change `Text` enum case names to match Swift 3 API guidelines.  
+  [@istx25](https://github.com/istx25)
 
 ##### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ##### Breaking
 
-* None.
+* Change `Text` enum case names to match Swift 3 API guidelines.
+  [@istx25](https://github.com/istx25), [#324](https://github.com/jpsim/SourceKitten/pull/324).
 
 ##### Enhancements
 

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -213,7 +213,7 @@ extension CXComment {
 
     func paragraphToString(kindString: String? = nil) -> [Text] {
         if kind() == CXComment_VerbatimLine {
-            return [.Verbatim(clang_VerbatimLineComment_getText(self).str()!)]
+            return [.verbatim(clang_VerbatimLineComment_getText(self).str()!)]
         } else if kind() == CXComment_BlockCommand {
             return (0..<count()).reduce([]) { returnValue, childIndex in
                 return returnValue + self[childIndex].paragraphToString()
@@ -236,7 +236,7 @@ extension CXComment {
             }
             fatalError("not text: \(child.kind())")
         }
-        return [.Para(paragraphString.removingCommonLeadingWhitespaceFromLines(), kindString)]
+        return [.para(paragraphString.removingCommonLeadingWhitespaceFromLines(), kindString)]
     }
 
     func kind() -> CXCommentKind {

--- a/Source/SourceKittenFramework/JSONOutput.swift
+++ b/Source/SourceKittenFramework/JSONOutput.swift
@@ -119,9 +119,9 @@ private func toOutputDictionary(_ param: Parameter) -> [String: Any] {
 
 private func toOutputDictionary(_ text: Text) -> [String: Any] {
     switch text {
-    case .Para(let str, let kind):
+    case .para(let str, let kind):
         return ["kind": kind ?? "", "Para": str]
-    case .Verbatim(let str):
+    case .verbatim(let str):
         return ["kind": "", "Verbatim": str]
     }
 }

--- a/Source/SourceKittenFramework/Text.swift
+++ b/Source/SourceKittenFramework/Text.swift
@@ -7,6 +7,6 @@
 //
 
 public enum Text {
-    case Para(String, String?)
-    case Verbatim(String)
+    case para(String, String?)
+    case verbatim(String)
 }


### PR DESCRIPTION
I noticed that the `Text` enum wasn't following the Swift 3 API guidelines for enums. Specifically, I changed `.Para(str1, str2)` to `.para(str1, str2)` and `.Verbatim(str1)` to `.verbatim(str1)`.