### PR TITLE
Use ptthread_mutex instead of locks for significant performance boost

### DIFF
--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -15,19 +15,19 @@ import Foundation
 import SWXMLHash
 
 private var _interfaceUUIDMap = [String: String]()
-private var _interfaceUUIDMapLock = NSLock()
+private var _interfaceUUIDMapMutex = pthread_mutex_t()
 
 /// Thread safe read from sourceKitUID map
 private func uuidString(`for` sourceKitUID: String) -> String? {
-    _interfaceUUIDMapLock.lock()
-    defer { _interfaceUUIDMapLock.unlock() }
+    pthread_mutex_lock(&_interfaceUUIDMapMutex)
+    defer { pthread_mutex_unlock(&_interfaceUUIDMapMutex) }
     return _interfaceUUIDMap[sourceKitUID]
 }
 
 /// Thread safe write from sourceKitUID map
 private func setUUIDString(uidString: String, `for` file: String) {
-    _interfaceUUIDMapLock.lock()
-    defer { _interfaceUUIDMapLock.unlock() }
+    pthread_mutex_lock(&_interfaceUUIDMapMutex)
+    defer { pthread_mutex_unlock(&_interfaceUUIDMapMutex) }
     _interfaceUUIDMap[file] = uidString
 }
 

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -119,19 +119,19 @@ private var sourceKitWaitingRestoredSemaphore = DispatchSemaphore(value: 0)
 
 /// SourceKit UID to String map.
 private var _uidStringMap = [sourcekitd_uid_t: String]()
-private var _uidStringMapLock = NSLock()
+private var _uidStringMapMutex = pthread_mutex_t()
 
 /// Thread safe read from sourceKitUID map
 private func uidString(`for` sourceKitUID: sourcekitd_uid_t) -> String? {
-    _uidStringMapLock.lock()
-    defer { _uidStringMapLock.unlock() }
+    pthread_mutex_lock(&_uidStringMapMutex)
+    defer { pthread_mutex_unlock(&_uidStringMapMutex) }
     return _uidStringMap[sourceKitUID]
 }
 
 /// Thread safe write from sourceKitUID map
 private func setUIDString(uidString: String, `for` identifier: sourcekitd_uid_t) {
-    _uidStringMapLock.lock()
-    defer { _uidStringMapLock.unlock() }
+    pthread_mutex_lock(&_uidStringMapMutex)
+    defer { pthread_mutex_unlock(&_uidStringMapMutex) }
     _uidStringMap[identifier] = uidString
 }
 


### PR DESCRIPTION
As I'm doing more work on threading I have seen that `NSLock` is really slow, using pt_thread_mutex lowers my performance metric from 3.5s to 2.6. No functionality change here.

PS. SpinLock might be faster but it has many side-effects, so I preferred to use safer yet efficent approach here.