### PR TITLE
Add option to disable uid cache for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ##### Enhancements
 
-* None.
+* Add option to disable `Request` global UID cache.
+  [@krzysztofzablocki](https://github.com/krzysztofzablocki)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
Adds option to disable request global UID cache, this might be useful if someone wants to use SourceKittenFramework to parse specific files in parallel, e.g. Sourcery.
