### PR TITLE
Change packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ XCODEFLAGS=-workspace 'SourceKitten.xcworkspace' \
 	DSTROOT=$(TEMPORARY_FOLDER) \
 	OTHER_LDFLAGS=-Wl,-headerpad_max_install_names
 
-BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/sourcekitten.app
+APPLICATIONS_FOLDER=$(TEMPORARY_FOLDER)/Applications
+BUILT_BUNDLE=$(APPLICATIONS_FOLDER)/sourcekitten.app
 SOURCEKITTEN_FRAMEWORK_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/SourceKittenFramework.framework
 SOURCEKITTEN_EXECUTABLE=$(BUILT_BUNDLE)/Contents/MacOS/sourcekitten
 SWIFT_STANDARD_LIBRARIES=$(BUILT_BUNDLE)/Contents/Frameworks/libswift*
@@ -55,7 +56,7 @@ installables: clean bootstrap
 	mv -f "$(SOURCEKITTEN_FRAMEWORK_BUNDLE)" "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework"
 	mv -f "$(SOURCEKITTEN_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/sourcekitten"
 	mv -f $(SWIFT_STANDARD_LIBRARIES) "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework/Versions/A/Frameworks"
-	rm -rf "$(BUILT_BUNDLE)"
+	rm -rf "$(APPLICATIONS_FOLDER)"
 
 prefix_install: installables
 	mkdir -p "$(FRAMEWORKS_FOLDER)" "$(BINARIES_FOLDER)"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ XCODEFLAGS=-workspace 'SourceKitten.xcworkspace' \
 BUILT_BUNDLE=$(TEMPORARY_FOLDER)/Applications/sourcekitten.app
 SOURCEKITTEN_FRAMEWORK_BUNDLE=$(BUILT_BUNDLE)/Contents/Frameworks/SourceKittenFramework.framework
 SOURCEKITTEN_EXECUTABLE=$(BUILT_BUNDLE)/Contents/MacOS/sourcekitten
+SWIFT_STANDARD_LIBRARIES=$(BUILT_BUNDLE)/Contents/Frameworks/libswift*
 
 FRAMEWORKS_FOLDER=$(PREFIX)/Frameworks
 BINARIES_FOLDER=$(PREFIX)/bin
@@ -53,6 +54,7 @@ installables: clean bootstrap
 	mkdir -p "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)"
 	mv -f "$(SOURCEKITTEN_FRAMEWORK_BUNDLE)" "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework"
 	mv -f "$(SOURCEKITTEN_EXECUTABLE)" "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/sourcekitten"
+	mv -f $(SWIFT_STANDARD_LIBRARIES) "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SourceKittenFramework.framework/Versions/A/Frameworks"
 	rm -rf "$(BUILT_BUNDLE)"
 
 prefix_install: installables

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -543,7 +543,6 @@
 				D0E7B65719E9C7C700EDBA4D /* Extract CLI Tool */,
 				D0AAAB5319FB0960007B24B3 /* Embed Frameworks */,
 				6CCFCE881CFECFBD003239EB /* Embed Frameworks into SourceKittenFramework.framework */,
-				6CCFCEC01CFED30B003239EB /* Embed Swift libraries into SourceKittenFramework.framework */,
 				E877EB421E0C5CD9003D1423 /* Run SwiftLint */,
 			);
 			buildRules = (
@@ -602,21 +601,6 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6CCFCEC01CFED30B003239EB /* Embed Swift libraries into SourceKittenFramework.framework */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Swift libraries into SourceKittenFramework.framework";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cd \"$TARGET_BUILD_DIR\"\nSOURCEKITTENFRAMEWORK_BUNDLE=\"$FRAMEWORKS_FOLDER_PATH/SourceKittenFramework.framework\"\n\nxcrun swift-stdlib-tool --copy --verbose --Xcodesign --timestamp=none \\\n  --scan-executable \"$EXECUTABLE_PATH\" \\\n  --scan-folder \"$FRAMEWORKS_FOLDER_PATH\" \\\n  --platform macosx --destination \"$SOURCEKITTENFRAMEWORK_BUNDLE/Versions/Current/Frameworks\" \\\n  --strip-bitcode\n";
-			showEnvVarsInLog = 0;
-		};
 		C2265FAB1A4B86AC00158358 /* Check Xcode Version */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
- Stop using `swift-stdlib-tool`  
  Xcode 8.3 beta 2 no longer includes `swift-stdlib-tool`.
  So, we need changes:
  - Remove “Embed Swift libraries into SourceKittenFramework.framework” build phase that using `swift-stdlib-tool`
  - Add a job to `installables` target that moves Swift Standard Libraries from `sourcekitten.app` bundle to `SourceKittenFramework.framework`
- Change so that `SourceKitten.pkg` does not include `/Applications`

The former change is also needed in `SwiftLint` on Xcode 8.3 beta 2.