### PR TITLE
Expose properties of `SourceDeclaration` which can be used by `SourceKittenFramework` users.

### DIFF
--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -39,11 +39,11 @@ struct ClangIndex {
     }
 }
 
-struct ClangAvailability {
-    let alwaysDeprecated: Bool
-    let alwaysUnavailable: Bool
-    let deprecationMessage: String?
-    let unavailableMessage: String?
+public struct ClangAvailability {
+    public let alwaysDeprecated: Bool
+    public let alwaysUnavailable: Bool
+    public let deprecationMessage: String?
+    public let unavailableMessage: String?
 }
 
 extension CXString: CustomStringConvertible {

--- a/Source/SourceKittenFramework/Documentation.swift
+++ b/Source/SourceKittenFramework/Documentation.swift
@@ -13,8 +13,8 @@ import Clang_C
 #endif
 
 public struct Documentation {
-    let parameters: [Parameter]
-    let returnDiscussion: [Text]
+    public let parameters: [Parameter]
+    public let returnDiscussion: [Text]
 
     init(comment: CXComment) {
         let comments = (0..<comment.count()).map { comment[$0] }

--- a/Source/SourceKittenFramework/Parameter.swift
+++ b/Source/SourceKittenFramework/Parameter.swift
@@ -13,8 +13,8 @@ import Clang_C
 #endif
 
 public struct Parameter {
-    let name: String
-    let discussion: [Text]
+    public let name: String
+    public let discussion: [Text]
 
     init(comment: CXComment) {
         name = comment.paramName() ?? "<none>"

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -32,34 +32,34 @@ public func insertMarks(declarations: [SourceDeclaration], limit: NSRange? = nil
 
 /// Represents a source code declaration.
 public struct SourceDeclaration {
-    let type: ObjCDeclarationKind
-    let location: SourceLocation
-    let extent: (start: SourceLocation, end: SourceLocation)
-    let name: String?
-    let usr: String?
-    let declaration: String?
-    let documentation: Documentation?
-    let commentBody: String?
-    var children: [SourceDeclaration]
-    let swiftDeclaration: String?
-    let availability: ClangAvailability?
+    public let type: ObjCDeclarationKind
+    public let location: SourceLocation
+    public let extent: (start: SourceLocation, end: SourceLocation)
+    public let name: String?
+    public let usr: String?
+    public let declaration: String?
+    public let documentation: Documentation?
+    public let commentBody: String?
+    public var children: [SourceDeclaration]
+    public let swiftDeclaration: String?
+    public let availability: ClangAvailability?
 
     /// Range
-    var range: NSRange {
+    public var range: NSRange {
         return extent.start.range(toEnd: extent.end)
     }
 
     /// Returns the USR for the auto-generated getter for this property.
     ///
     /// - warning: can only be invoked if `type == .Property`.
-    var getterUSR: String {
+    public var getterUSR: String {
         return accessorUSR(getter: true)
     }
 
     /// Returns the USR for the auto-generated setter for this property.
     ///
     /// - warning: can only be invoked if `type == .Property`.
-    var setterUSR: String {
+    public var setterUSR: String {
         return accessorUSR(getter: false)
     }
 

--- a/Source/SourceKittenFramework/SourceLocation.swift
+++ b/Source/SourceKittenFramework/SourceLocation.swift
@@ -14,10 +14,10 @@ import Clang_C
 import Foundation
 
 public struct SourceLocation {
-    let file: String
-    let line: UInt32
-    let column: UInt32
-    let offset: UInt32
+    public let file: String
+    public let line: UInt32
+    public let column: UInt32
+    public let offset: UInt32
 
     public func range(toEnd end: SourceLocation) -> NSRange {
         return NSRange(location: Int(offset), length: Int(end.offset - offset))


### PR DESCRIPTION
I'm making a command line tool to generate documentation from Objective-C headers. (Similar to jazzy but written in swift). So I embed `SourceKittenFramework` in my app and use `ClangTranslationUnit` to parse headers and get `SourceDeclaration` instances. If those properties can not be access outside the framework, it seems I must transform `SourceDeclaration` instances to JSON then parse JSON to Dictionary then map to my models.

By mark those properties public, application can directly map information from `SourceDeclaration` to their models. Rather than parse the JSON output from `ClangTranslationUnit`.