### PR TITLE
Fix the trimming of trailing characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix a crash that occurred when a documentation comment ended with an extended
+  grapheme cluster.  
+  [Lukas Stührk](https://github.com/Lukas-Stuehrk)
+  [#350](https://github.com/jpsim/SourceKitten/issues/350)
 
 ## 0.17.0
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -232,14 +232,15 @@ extension NSString {
     - parameter characterSet: Character set to check for membership.
     */
     public func trimmingTrailingCharacters(in characterSet: CharacterSet) -> String {
-        if length == 0 {
+        guard length > 0 else {
             return ""
         }
-        var charBuffer = [unichar](repeating: 0, count: length)
-        getCharacters(&charBuffer, range: NSRange(location: 0, length: charBuffer.count))
-        for newLength in (1...length).reversed() {
-            if !characterSet.contains(UnicodeScalar(charBuffer[newLength - 1])!) {
-                return substring(with: NSRange(location: 0, length: newLength))
+        var string = self.bridge()
+        let endIndex = string.unicodeScalars.endIndex
+        for offset in 1...string.unicodeScalars.count {
+            let index = string.unicodeScalars.index(endIndex, offsetBy: -offset)
+            if !characterSet.contains(string.unicodeScalars[index]), let stringIndex = index.samePosition(in: string) {
+                return string.substring(to: string.index(stringIndex, offsetBy: 1))
             }
         }
         return ""

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -235,13 +235,12 @@ extension NSString {
         guard length > 0 else {
             return ""
         }
-        var string = self.bridge()
-        let endIndex = string.unicodeScalars.endIndex
-        for offset in 1...string.unicodeScalars.count {
-            let index = string.unicodeScalars.index(endIndex, offsetBy: -offset)
-            if !characterSet.contains(string.unicodeScalars[index]), let stringIndex = index.samePosition(in: string) {
-                return string.substring(to: string.index(stringIndex, offsetBy: 1))
+        var unicodeScalars = self.bridge().unicodeScalars
+        while let scalar = unicodeScalars.last {
+            if !characterSet.contains(scalar) {
+                return String(unicodeScalars)
             }
+            unicodeScalars.removeLast()
         }
         return ""
     }

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -25,6 +25,7 @@ class StringTests: XCTestCase {
         XCTAssertEqual(" a ".bridge().trimmingTrailingCharacters(in: .whitespacesAndNewlines), " a")
         XCTAssertEqual(" ".bridge().trimmingTrailingCharacters(in: .whitespacesAndNewlines), "")
         XCTAssertEqual("a".bridge().trimmingTrailingCharacters(in: .whitespacesAndNewlines), "a")
+        XCTAssertEqual("Foobar💣".bridge().trimmingTrailingCharacters(in: .whitespacesAndNewlines), "Foobar💣")
     }
 
     func testCommentBody() {


### PR DESCRIPTION
When the string ended with extended grapheme clusters, the method
crashed because of the force-unwrapping. This refactoring adds support
for handling extended grapheme clusters.

This fixes #350