### PR TITLE
Fix crash in lineAndCharacter(forByteOffset:)

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -171,23 +171,8 @@ extension NSString {
         }
 
         func lineAndCharacter(forByteOffset offset: Int) -> (line: Int, character: Int)? {
-            let index = lines.index(where: { NSLocationInRange(offset, $0.byteRange) })
-            return index.map {
-                let line = lines[$0]
-
-                let character: Int
-                let content = line.content
-                let length = offset - line.byteRange.location + 1
-                if length == line.byteRange.length {
-                    character = content.utf16.count
-                } else {
-                    let utf8View = content.utf8
-                    let endIndex = utf8View.index(utf8View.startIndex, offsetBy: length, limitedBy: utf8View.endIndex)!
-                        .samePosition(in: content.utf16)!
-                    character = content.utf16.distance(from: content.utf16.startIndex, to: endIndex)
-                }
-                return (line: line.index, character: character)
-            }
+            let characterOffset = location(fromByteOffset: offset)
+            return lineAndCharacter(forCharacterOffset: characterOffset)
         }
     }
 

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -170,6 +170,11 @@ class StringTests: XCTestCase {
         XCTAssert(string.bridge().lineRangeWithByteRange(start: 0, length: 27)! == (1, 2))
         XCTAssert(string.bridge().lineRangeWithByteRange(start: 27, length: 0)! == (2, 2))
     }
+
+    func testLineAndCharacterForByteOffset() {
+        let string = "public typealias 🔳 = QRCode"
+        XCTAssert(string.bridge().lineAndCharacter(forByteOffset: 17)! == (1, 18))
+    }
 }
 
 typealias LineRangeType = (start: Int, end: Int)
@@ -194,7 +199,8 @@ extension StringTests {
             ("testGenerateDocumentedTokenOffsetsEmpty", testGenerateDocumentedTokenOffsetsEmpty),
             ("testSubstringWithByteRange", testSubstringWithByteRange),
             ("testSubstringLinesWithByteRange", testSubstringLinesWithByteRange),
-            ("testLineRangeWithByteRange", testLineRangeWithByteRange)
+            ("testLineRangeWithByteRange", testLineRangeWithByteRange),
+            ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset)
         ]
     }
 }


### PR DESCRIPTION
See https://github.com/realm/SwiftLint/issues/1006