### PR TITLE
Option to include expressions in addition to declarations from sourcekit output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Added option to include expression structures when running `doc` command.
+  [Paul Taykalo](https://github.com/PaulTaykalo)
+
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -157,9 +157,11 @@ public final class File {
 
     - parameter dictionary:        Dictionary to process.
     - parameter cursorInfoRequest: Cursor.Info request to get declaration information.
+    - parameter elementTypes:      Element types to process
     */
     public func process(dictionary: [String: SourceKitRepresentable], cursorInfoRequest: sourcekitd_object_t? = nil,
-                        syntaxMap: SyntaxMap? = nil) -> [String: SourceKitRepresentable] {
+                        syntaxMap: SyntaxMap? = nil,
+                        elementTypes: ProcessableElements = .declarationsAndComments) -> [String: SourceKitRepresentable] {
         var dictionary = dictionary
         if let cursorInfoRequest = cursorInfoRequest {
             dictionary = merge(
@@ -190,7 +192,7 @@ public final class File {
         }
 
         // Update substructure
-        if let substructure = newSubstructure(dictionary, cursorInfoRequest: cursorInfoRequest, syntaxMap: syntaxMap) {
+        if let substructure = newSubstructure(dictionary, cursorInfoRequest: cursorInfoRequest, syntaxMap: syntaxMap, elementTypes: elementTypes) {
             dictionary[SwiftDocKey.substructure.rawValue] = substructure
         }
         return dictionary
@@ -206,12 +208,13 @@ public final class File {
     */
     internal func furtherProcess(dictionary: [String: SourceKitRepresentable], documentedTokenOffsets: [Int],
                                  cursorInfoRequest: sourcekitd_object_t,
-                                 syntaxMap: SyntaxMap) -> [String: SourceKitRepresentable] {
+                                 syntaxMap: SyntaxMap,
+                                 elementTypes: ProcessableElements) -> [String: SourceKitRepresentable] {
         var dictionary = dictionary
         let offsetMap = makeOffsetMap(documentedTokenOffsets: documentedTokenOffsets, dictionary: dictionary)
         for offset in offsetMap.keys.reversed() { // Do this in reverse to insert the doc at the correct offset
             if let rawResponse = Request.send(cursorInfoRequest: cursorInfoRequest, atOffset: Int64(offset)),
-               case let response = process(dictionary: rawResponse, cursorInfoRequest: nil, syntaxMap: syntaxMap),
+               case let response = process(dictionary: rawResponse, cursorInfoRequest: nil, syntaxMap: syntaxMap, elementTypes: elementTypes),
                let kind = SwiftDocKey.getKind(response),
                SwiftDeclarationKind(rawValue: kind) != nil,
                let parentOffset = offsetMap[offset].flatMap({ Int64($0) }),
@@ -228,18 +231,20 @@ public final class File {
 
     - parameter dictionary:        Input dictionary to process its substructure.
     - parameter cursorInfoRequest: Cursor.Info request to get declaration information.
+    - parameter elementTypes:      Element types to process
 
     - returns: A copy of the input dictionary's substructure processed by running
                `processDictionary(_:cursorInfoRequest:syntaxMap:)` on its elements, only keeping comment marks
                and declarations.
     */
     private func newSubstructure(_ dictionary: [String: SourceKitRepresentable], cursorInfoRequest: sourcekitd_object_t?,
-                                 syntaxMap: SyntaxMap?) -> [SourceKitRepresentable]? {
+                                 syntaxMap: SyntaxMap?,
+                                 elementTypes: ProcessableElements) -> [SourceKitRepresentable]? {
         return SwiftDocKey.getSubstructure(dictionary)?
             .map({ $0 as! [String: SourceKitRepresentable] })
-            .filter(isDeclarationOrCommentMark)
+            .filter { hasProcessable($0, elementType: elementTypes) }
             .map {
-                process(dictionary: $0, cursorInfoRequest: cursorInfoRequest, syntaxMap: syntaxMap)
+                process(dictionary: $0, cursorInfoRequest: cursorInfoRequest, syntaxMap: syntaxMap, elementTypes: elementTypes)
             }
     }
 
@@ -390,20 +395,54 @@ public final class File {
         }
         return nil
     }
+
+    /**
+     Represents processable element types SourceKitten interested in
+     Possible values are comments, declarations and expression types
+     */
+    public struct ProcessableElements: OptionSet {
+        public let rawValue: Int
+
+        public init(rawValue: RawValue) {
+            self.rawValue = rawValue
+        }
+
+        public static let declaration = ProcessableElements(rawValue: 1 << 0)
+        public static let comment = ProcessableElements(rawValue: 1 << 1)
+        public static let expression = ProcessableElements(rawValue: 1 << 2)
+
+        public static let declarationsAndComments: ProcessableElements = [.declaration, .comment]
+        public static let all: ProcessableElements = [.declaration, .comment, .expression]
+    }
 }
 
 /**
-Returns true if the dictionary represents a source declaration or a mark-style comment.
+Returns true if the dictionary represents one of the processable element types, specified in elementType
 
 - parameter dictionary: Dictionary to parse.
+- parameter elementType: Element types to check for.
+
 */
-private func isDeclarationOrCommentMark(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
-    if let kind = SwiftDocKey.getKind(dictionary) {
-        return kind != SwiftDeclarationKind.varParameter.rawValue &&
-            (kind == SyntaxKind.commentMark.rawValue || SwiftDeclarationKind(rawValue: kind) != nil)
+private func hasProcessable(_ dictionary: [String: SourceKitRepresentable], elementType: File.ProcessableElements) -> Bool {
+    guard let kind = SwiftDocKey.getKind(dictionary) else {
+        return false
     }
+
+    if kind == SyntaxKind.commentMark.rawValue {
+        return elementType.contains(.comment)
+    }
+
+    if let declarationKind = SwiftDeclarationKind(rawValue: kind) {
+       return elementType.contains(.declaration) && declarationKind != .varParameter
+    }
+
+    if SwiftExpressionKind(rawValue: kind) != nil {
+        return elementType.contains(.expression)
+    }
+
     return false
 }
+
 
 /**
 Parse XML from `key.doc.full_as_xml` from `cursor.info` request.

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -443,7 +443,6 @@ private func hasProcessable(_ dictionary: [String: SourceKitRepresentable], elem
     return false
 }
 
-
 /**
 Parse XML from `key.doc.full_as_xml` from `cursor.info` request.
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -403,7 +403,7 @@ public final class File {
     public struct ProcessableElements: OptionSet {
         public let rawValue: Int
 
-        public init(rawValue: RawValue) {
+        public init(rawValue: Int) {
             self.rawValue = rawValue
         }
 

--- a/Source/SourceKittenFramework/SwiftExpressionKind.swift
+++ b/Source/SourceKittenFramework/SwiftExpressionKind.swift
@@ -1,0 +1,27 @@
+//
+//  SwiftDeclarationKind.swift
+//  SourceKitten
+//
+//  Created by JP Simard on 2015-01-05.
+//  Copyright (c) 2015 SourceKitten. All rights reserved.
+//
+
+/// Swift expression kinds.
+/// Found in `strings SourceKitService | grep source.lang.swift.expr.`.
+public enum SwiftExpressionKind: String, SwiftLangSyntax {
+    /// Function argument
+    case argument = "source.lang.swift.expr.argument"
+
+    /// Array experssion
+    case array = "source.lang.swift.expr.array"
+
+    /// General call
+    case call = "source.lang.swift.expr.call"
+
+    /// Dictionary experssion
+    case dictionary = "source.lang.swift.expr.dictionary"
+
+    /// Object literal (objective c?)
+    case objectLiteral = "source.lang.swift.expr.object_literal"
+
+}

--- a/Source/SourceKittenFramework/SwiftExpressionKind.swift
+++ b/Source/SourceKittenFramework/SwiftExpressionKind.swift
@@ -12,13 +12,13 @@ public enum SwiftExpressionKind: String, SwiftLangSyntax {
     /// Function argument
     case argument = "source.lang.swift.expr.argument"
 
-    /// Array experssion
+    /// Array expression
     case array = "source.lang.swift.expr.array"
 
     /// General call
     case call = "source.lang.swift.expr.call"
 
-    /// Dictionary experssion
+    /// Dictionary expression
     case dictionary = "source.lang.swift.expr.dictionary"
 
     /// Object literal (objective c?)

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Expression.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Expression.json
@@ -1,0 +1,110 @@
+{
+  "Expression.swift": {
+    "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
+    "key.substructure": [
+      {
+        "key.filepath": "Expression.swift",
+        "key.parsed_declaration": "class Hidden",
+        "key.annotated_decl": "<Declaration>class Hidden</Declaration>",
+        "key.fully_annotated_decl": "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>Hidden</decl.name></decl.class>",
+        "key.accessibility": "source.lang.swift.accessibility.internal",
+        "key.length": 15,
+        "key.runtime_name": "_TtC8__main__6Hidden",
+        "key.parsed_scope.start": 1,
+        "key.typeusr": "_Tt",
+        "key.kind": "source.lang.swift.decl.class",
+        "key.offset": 0,
+        "key.nameoffset": 6,
+        "key.typename": "Hidden.Type",
+        "key.actionable": [
+          {
+            "key.actionname": "Rename"
+          }
+        ],
+        "key.name": "Hidden",
+        "key.usr": "s:C10Expression6Hidden",
+        "key.bodyoffset": 14,
+        "key.bodylength": 0,
+        "key.parsed_scope.end": 1,
+        "key.namelength": 6
+      },
+      {
+        "key.filepath": "Expression.swift",
+        "key.parsed_declaration": "class HiddenUsage",
+        "key.annotated_decl": "<Declaration>class HiddenUsage</Declaration>",
+        "key.fully_annotated_decl": "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>HiddenUsage</decl.name></decl.class>",
+        "key.accessibility": "source.lang.swift.accessibility.internal",
+        "key.length": 126,
+        "key.substructure": [
+          {
+            "key.filepath": "Expression.swift",
+            "key.parsed_declaration": "func functionWithHiddenDependency()",
+            "key.annotated_decl": "<Declaration>func functionWithHiddenDependency()</Declaration>",
+            "key.fully_annotated_decl": "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>functionWithHiddenDependency</decl.name>()</decl.function.method.instance>",
+            "key.accessibility": "source.lang.swift.accessibility.internal",
+            "key.length": 100,
+            "key.substructure": [
+              {
+                "key.namelength": 6,
+                "key.nameoffset": 100,
+                "key.length": 8,
+                "key.name": "Hidden",
+                "key.bodyoffset": 107,
+                "key.bodylength": 0,
+                "key.kind": "source.lang.swift.expr.call",
+                "key.offset": 100
+              },
+              {
+                "key.namelength": 5,
+                "key.nameoffset": 117,
+                "key.length": 18,
+                "key.name": "print",
+                "key.bodyoffset": 123,
+                "key.bodylength": 11,
+                "key.kind": "source.lang.swift.expr.call",
+                "key.offset": 117
+              }
+            ],
+            "key.parsed_scope.start": 4,
+            "key.typeusr": "_TtFT_T_",
+            "key.kind": "source.lang.swift.decl.function.method.instance",
+            "key.offset": 41,
+            "key.nameoffset": 46,
+            "key.typename": "(HiddenUsage) -> () -> ()",
+            "key.actionable": [
+              {
+                "key.actionname": "Rename"
+              }
+            ],
+            "key.name": "functionWithHiddenDependency()",
+            "key.usr": "s:FC10Expression11HiddenUsage28functionWithHiddenDependencyFT_T_",
+            "key.bodyoffset": 78,
+            "key.bodylength": 62,
+            "key.parsed_scope.end": 7,
+            "key.namelength": 30
+          }
+        ],
+        "key.runtime_name": "_TtC8__main__11HiddenUsage",
+        "key.parsed_scope.start": 3,
+        "key.typeusr": "_Tt",
+        "key.kind": "source.lang.swift.decl.class",
+        "key.offset": 17,
+        "key.nameoffset": 23,
+        "key.typename": "HiddenUsage.Type",
+        "key.actionable": [
+          {
+            "key.actionname": "Rename"
+          }
+        ],
+        "key.name": "HiddenUsage",
+        "key.usr": "s:C10Expression11HiddenUsage",
+        "key.bodyoffset": 36,
+        "key.bodylength": 106,
+        "key.parsed_scope.end": 8,
+        "key.namelength": 11
+      }
+    ],
+    "key.offset": 0,
+    "key.length": 143
+  }
+}

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Expression.swift
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Expression.swift
@@ -1,0 +1,8 @@
+class Hidden {}
+
+class HiddenUsage {
+    func functionWithHiddenDependency() {
+        let hidden = Hidden()
+        print("\(hidden)")
+    }
+}

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -160,6 +160,27 @@ class SourceKitTests: XCTestCase {
         }
     }
 
+    // swiftlint:disable:next function_body_length
+    func testSwiftExpessionKind() {
+        let expected: [SwiftExpressionKind] = [
+            .argument,
+            .array,
+            .call,
+            .dictionary,
+            .objectLiteral
+        ]
+        let actual = sourcekitStrings(startingWith: "source.lang.swift.expr.")
+        let expectedStrings = Set(expected.map { $0.rawValue })
+        XCTAssertEqual(
+            actual,
+            expectedStrings
+        )
+        if actual != expectedStrings {
+            print("the following strings were added: \(actual.subtracting(expectedStrings))")
+            print("the following strings were removed: \(expectedStrings.subtracting(actual))")
+        }
+    }
+
     func testLibraryWrappersAreUpToDate() {
         let sourceKittenFrameworkModule = Module(xcodeBuildArguments: sourcekittenXcodebuildArguments, name: nil, inPath: projectRoot)!
         let modules: [(module: String, path: String, linuxPath: String?, spmModule: String)] = [

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -57,7 +57,7 @@ func compareJSONString(withFixtureNamed name: String,
 
 private func compareDocs(withFixtureNamed name: String, processExpressions: Bool = false, file: StaticString = #file, line: UInt = #line) {
     let swiftFilePath = fixturesDirectory + name + ".swift"
-    let docs = SwiftDocs(file: File(path: swiftFilePath)!, arguments: ["-j4", swiftFilePath])!
+    let docs = SwiftDocs(file: File(path: swiftFilePath)!, arguments: ["-j4", swiftFilePath], processExpressions: processExpressions)!
 #if os(Linux)
     let name = "Linux" + name
 #endif

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -55,7 +55,7 @@ func compareJSONString(withFixtureNamed name: String,
     }
 }
 
-private func compareDocs(withFixtureNamed name: String, file: StaticString = #file, line: UInt = #line) {
+private func compareDocs(withFixtureNamed name: String, processExpressions: Bool = false, file: StaticString = #file, line: UInt = #line) {
     let swiftFilePath = fixturesDirectory + name + ".swift"
     let docs = SwiftDocs(file: File(path: swiftFilePath)!, arguments: ["-j4", swiftFilePath])!
 #if os(Linux)
@@ -84,6 +84,15 @@ class SwiftDocsTests: XCTestCase {
     #endif
     }
 
+    func testIncludeExpressions() {
+    #if swift(>=3.1) && os(Linux)
+        // FIXME
+        print("FIXME: Skip \(#function), because our sourcekitInProc on Swift 3.1 for Linux seems to be broken")
+    #else
+        compareDocs(withFixtureNamed: "Expression", processExpressions: true)
+    #endif
+    }
+
     func testParseFullXMLDocs() {
         // swiftlint:disable:next line_length
         let xmlDocsString = "<Type file=\"file\" line=\"1\" column=\"2\"><Name>name</Name><USR>usr</USR><Declaration>declaration</Declaration><Abstract><Para>discussion</Para></Abstract><Parameters><Parameter><Name>param1</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>param1_discussion</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>result_discussion</Para></ResultDiscussion></Type>"
@@ -107,6 +116,7 @@ class SwiftDocsTests: XCTestCase {
 }
 
 extension SwiftDocsTests {
+
     static var allTests: [(String, (SwiftDocsTests) -> () throws -> Void)] {
         return [
             ("testSubscript", testSubscript),

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		D0DB09A419EA354200234B16 /* SyntaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DB09A319EA354200234B16 /* SyntaxTests.swift */; };
 		D0E7B65319E9C6AD00EDBA4D /* SourceKittenFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SourceKittenFramework.framework */; };
 		D0E7B65619E9C76900EDBA4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D1211B19E87861005E4BAA /* main.swift */; };
+		E42269F61E9D07790032A576 /* SwiftExpressionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDBE49107B9337D9AFCD96C /* SwiftExpressionKind.swift */; };
 		E805A0481B55CBAF00EA654A /* SourceKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805A0471B55CBAF00EA654A /* SourceKitTests.swift */; };
 		E805A04A1B560FCA00EA654A /* FileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805A0491B560FCA00EA654A /* FileTests.swift */; };
 		E80678051CF2749300AFC816 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E80678041CF2749300AFC816 /* Yams.framework */; };
@@ -224,6 +225,7 @@
 		E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8EE34BE1B9A502F00947605 /* CodeCompletionItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeCompletionItem.swift; sourceTree = "<group>"; };
 		E8F4AF111B9A56A70054C51C /* CompleteCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompleteCommand.swift; sourceTree = "<group>"; };
+		EEDBE49107B9337D9AFCD96C /* SwiftExpressionKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExpressionKind.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -416,6 +418,7 @@
 				E806D28E1BE058B100D1BE41 /* Text.swift */,
 				E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */,
 				B2FA804AA9D4427FF571EFB2 /* SwiftLangSyntax.swift */,
+				EEDBE49107B9337D9AFCD96C /* SwiftExpressionKind.swift */,
 			);
 			name = SourceKittenFramework;
 			path = Source/SourceKittenFramework;
@@ -677,6 +680,7 @@
 				E834740F1A593B5B00532B9A /* Structure.swift in Sources */,
 				E89291A91A5B800300D91568 /* SwiftDeclarationKind.swift in Sources */,
 				E89291A71A5B7FF800D91568 /* SwiftDocKey.swift in Sources */,
+				E42269F61E9D07790032A576 /* SwiftExpressionKind.swift in Sources */,
 				E8A18A3F1A592246000362B7 /* SwiftDocs.swift in Sources */,
 				E80F23691A5CB01A00FD2352 /* SyntaxKind.swift in Sources */,
 				6C4CF5761C78B47F008532C5 /* library_wrapper_sourcekitd.swift in Sources */,


### PR DESCRIPTION
By this PR, now we can choose which elements should be presented in the resulting SourceKitten output.
This is not a breaking change, by default - comments and declarations will be included in the output.
If `--include-expressions` specified, output will contain expressions as well

Possible usages in documentation:
 - Show hidden dependencies from methods

Other:
 - Find hidden dependencies such as singletons access
