### PR TITLE
Remove redundant conformance constraint 'U': 'Hashable'

### DIFF
--- a/Source/SourceKittenFramework/ClangTranslationUnit.swift
+++ b/Source/SourceKittenFramework/ClangTranslationUnit.swift
@@ -20,7 +20,7 @@ extension Sequence where Iterator.Element: Hashable {
 }
 
 extension Sequence {
-    fileprivate func grouped<U: Hashable>(by transform: (Iterator.Element) -> U) -> [U: [Iterator.Element]] {
+    fileprivate func grouped<U>(by transform: (Iterator.Element) -> U) -> [U: [Iterator.Element]] {
         return reduce([:]) { dictionary, element in
             var dictionary = dictionary
             let key = transform(element)


### PR DESCRIPTION
Swift 4.0 produces error for this.
```
…/Source/SourceKittenFramework/ClangTranslationUnit.swift:23:33: error: redundant conformance constraint 'U': 'Hashable'
    fileprivate func grouped<U: Hashable>(by transform: (Iterator.Element) -> U) -> [U: [Iterator.Element]] {
                                ^
…/Source/SourceKittenFramework/ClangTranslationUnit.swift:23:85: note: conformance constraint 'U': 'Hashable' inferred from type here
    fileprivate func grouped<U: Hashable>(by transform: (Iterator.Element) -> U) -> [U: [Iterator.Element]] {
                                                                                    ^
```