### PR TITLE
Swift 4.0 on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
       os: osx
       osx_image: xcode8.3
     - script: make docker_test
-      env: JOB=Linux3.1
+      env: JOB=Linux-Swift3.1
       sudo: required
       services: docker
-    - script: make docker_test_302
-      env: JOB=Linux3.0.2
+    - script: make docker_test_4
+      env: JOB=Linux-Swift4
       sudo: required
       services: docker
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,20 @@ matrix:
       env: JOB=Linux-Swift4
       sudo: required
       services: docker
+    - script: swift test
+      env: JOB=Linux-Swift4-without-Docker
+      sudo: required
+      dist: trusty
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install -y libblocksruntime0
+      install:
+        - export SWIFT_VERSION=swift-4.0-DEVELOPMENT-SNAPSHOT-2017-05-11-a
+        - >
+          curl https://swift.org/builds/swift-4.0-branch/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz
+          | tar xz --directory $HOME --strip-components=1
+        - export PATH=$HOME/usr/bin:$PATH
+        - export LINUX_SOURCEKIT_LIB_PATH=$HOME/usr/lib
 notifications:
   email: false
   slack: realmio:vPdpsG9NLDo2DNlbqtcMAQuE

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ release: package archive
 docker_test:
 	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:311 swift test
 
-docker_test_302:
-	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:302 swift test
+docker_test_4:
+	docker run -v `pwd`:`pwd` -w `pwd` norionomura/swift:4020170511a swift test
 
 # http://irace.me/swift-profiling/
 display_compilation_time:

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     .Package(url: "https://github.com/norio-nomura/Clang_C.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/SourceKit.git", majorVersion: 1),
   ],
+  swiftLanguageVersions: [3, 4],
   exclude: [
     "Source/SourceKittenFramework/clang-c",
     "Source/SourceKittenFramework/sourcekitd.h",

--- a/Source/SourceKittenFramework/LinuxCompatibility.swift
+++ b/Source/SourceKittenFramework/LinuxCompatibility.swift
@@ -20,11 +20,19 @@ extension CharacterSet {
         return _bridgeToObjectiveC()
     }
 }
+#if swift(>=4.0)
+extension NSTextCheckingResult {
+    public func rangeAt(_ index: Int) -> NSRange {
+        return range(at: index)
+    }
+}
+#else
 extension TextCheckingResult {
     public func rangeAt(_ index: Int) -> NSRange {
         return range(at: index)
     }
 }
+#endif
 #if swift(>=3.1)
 #else
 extension NSString {

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -36,19 +36,19 @@ public struct Module {
 
     public init?(spmName: String) {
         let yamlPath = ".build/debug.yaml"
-        guard let yaml = try? Yams.load(yaml: String(contentsOfFile: yamlPath, encoding: .utf8)) as? [String: Any],
-            let yamlCommands = (yaml?["commands"] as? [String: [String: Any]])?.values else {
+        guard let yaml = try? Yams.compose(yaml: String(contentsOfFile: yamlPath, encoding: .utf8)),
+            let commands = yaml?["commands"]?.mapping?.values else {
             fatalError("SPM build manifest does not exist at `\(yamlPath)` or does not match expected format.")
         }
-        guard let moduleCommand = yamlCommands.first(where: { ($0["module-name"] as? String ?? "") == spmName }) else {
+        guard let moduleCommand = commands.first(where: { $0["module-name"]?.string == spmName }) else {
             fputs("Could not find SPM module '\(spmName)'. Here are the modules available:\n", stderr)
-            let availableModules = yamlCommands.flatMap({ $0["module-name"] as? String })
+            let availableModules = commands.flatMap({ $0["module-name"]?.string })
             fputs("\(availableModules.map({ "  - " + $0 }).joined(separator: "\n"))\n", stderr)
             return nil
         }
-        guard let imports = moduleCommand["import-paths"] as? [String],
-              let otherArguments = moduleCommand["other-args"] as? [String],
-              let sources = moduleCommand["sources"] as? [String] else {
+        guard let imports = moduleCommand["import-paths"]?.array(of: String.self),
+              let otherArguments = moduleCommand["other-args"]?.array(of: String.self),
+              let sources = moduleCommand["sources"]?.array(of: String.self) else {
                 fatalError("SPM build manifest does not match expected format.")
         }
         name = spmName

--- a/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -17,8 +17,13 @@ class CodeCompletionTests: XCTestCase {
         let completionItems = CodeCompletionItem.parse(response:
             Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
                 arguments: ["-c", file, "-sdk", sdkPath()]).send())
-        compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
+    #if swift(>=4.0)
+        compareJSONString(withFixtureNamed: "SimpleCodeCompletion.swift4",
             jsonString: completionItems)
+    #else
+        compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
+                          jsonString: completionItems)
+    #endif
     }
 }
 

--- a/Tests/SourceKittenFrameworkTests/Fixtures/SimpleCodeCompletion.swift4.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/SimpleCodeCompletion.swift4.json
@@ -1,0 +1,309 @@
+[{
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "addingReportingOverflow(other: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si23addingReportingOverflowSi12partialValue_s010ArithmeticC0O8overflowtSiF s:s17FixedWidthIntegerP23addingReportingOverflowx12partialValue_s010ArithmeticF0O8overflowtxF",
+  "typeName": "(partialValue: Int, overflow: ArithmeticOverflow)",
+  "sourcetext": "addingReportingOverflow(<#T##other: Int##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "addingReportingOverflow(:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "advanced(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE8advancedxSi2by_tF",
+  "typeName": "Int",
+  "sourcetext": "advanced(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "advanced(by:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "advanced(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si8advancedS2i2by_tF s:s10StrideableP8advancedx6StrideQz2by_tF s:s11_StrideableP8advancedx6StrideQz2by_tF",
+  "typeName": "Int",
+  "sourcetext": "advanced(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "advanced(by:)"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "bigEndian",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si9bigEndianSiv s:s17FixedWidthIntegerP9bigEndianxv",
+  "typeName": "Int",
+  "sourcetext": "bigEndian",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "bigEndian",
+  "docBrief": "The big-endian representation of this integer."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "bitWidth",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s17FixedWidthIntegerPsE03bitB0Siv",
+  "typeName": "Int",
+  "sourcetext": "bitWidth",
+  "context": "source.codecompletion.context.superclass",
+  "name": "bitWidth"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "byteSwapped",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si11byteSwappedSiv s:s17FixedWidthIntegerP11byteSwappedxv",
+  "typeName": "Int",
+  "sourcetext": "byteSwapped",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "byteSwapped",
+  "docBrief": "A representation of this integer with the byte order swapped."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "countRepresentedWords",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE21countRepresentedWordsSiv",
+  "typeName": "Int",
+  "sourcetext": "countRepresentedWords",
+  "context": "source.codecompletion.context.superclass",
+  "name": "countRepresentedWords",
+  "docBrief": "The number of words used for the current binary representation of this value."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "customMirror",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si12customMirrors0B0Vv s:s17CustomReflectableP12customMirrors0D0Vv",
+  "typeName": "Mirror",
+  "sourcetext": "customMirror",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "customMirror",
+  "docBrief": "A mirror that reflects the Int instance."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "customPlaygroundQuickLook",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si25customPlaygroundQuickLooks0bcD0Ov s:s29CustomPlaygroundQuickLookableP06custombC4Looks0bcF0Ov",
+  "typeName": "PlaygroundQuickLook",
+  "sourcetext": "customPlaygroundQuickLook",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "customPlaygroundQuickLook"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "description",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13SignedIntegerPsE11descriptionSSv",
+  "typeName": "String",
+  "sourcetext": "description",
+  "context": "source.codecompletion.context.superclass",
+  "name": "description",
+  "docBrief": "A textual representation of this value."
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "distance(to: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si8distanceS2i2to_tF s:s10StrideableP8distance6StrideQzx2to_tF s:s11_StrideableP8distance6StrideQzx2to_tF",
+  "typeName": "Int",
+  "sourcetext": "distance(to: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "distance(to:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "distance(to: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE8distanceSix2to_tF",
+  "typeName": "Int",
+  "sourcetext": "distance(to: <#T##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "distance(to:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "dividedReportingOverflow(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si24dividedReportingOverflowSi12partialValue_s010ArithmeticC0O8overflowtSi2by_tF s:s17FixedWidthIntegerP24dividedReportingOverflowx12partialValue_s010ArithmeticF0O8overflowtx2by_tF",
+  "typeName": "(partialValue: Int, overflow: ArithmeticOverflow)",
+  "sourcetext": "dividedReportingOverflow(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "dividedReportingOverflow(by:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "dividingFullWidth(dividend: (high: Int, low: Int.Magnitude))",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si17dividingFullWidthSi8quotient_Si9remaindertSi4high_Su3lowt_tF s:s17FixedWidthIntegerP012dividingFullB0x8quotient_x9remaindertx4high_9MagnitudeQz3lowt_tF",
+  "typeName": "(quotient: Int, remainder: Int)",
+  "sourcetext": "dividingFullWidth(<#T##dividend: (high: Int, low: Int.Magnitude)##(high: Int, low: Int.Magnitude)#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "dividingFullWidth(:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "encode(to: Encoder) throws",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si6encodeys7Encoder_p2to_tKF s:s9EncodableP6encodeys7Encoder_p2to_tKF",
+  "typeName": "Void",
+  "sourcetext": "encode(to: <#T##Encoder#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "encode(to:)"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "hashValue",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si9hashValueSiv s:s8HashableP9hashValueSiv",
+  "typeName": "Int",
+  "sourcetext": "hashValue",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "hashValue",
+  "docBrief": "The integer’s hash value."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "leadingZeroBitCount",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si19leadingZeroBitCountSiv s:s17FixedWidthIntegerP19leadingZeroBitCountSiv",
+  "typeName": "Int",
+  "sourcetext": "leadingZeroBitCount",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "leadingZeroBitCount"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "littleEndian",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si12littleEndianSiv s:s17FixedWidthIntegerP12littleEndianxv",
+  "typeName": "Int",
+  "sourcetext": "littleEndian",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "littleEndian",
+  "docBrief": "The little-endian representation of this integer."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "magnitude",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si9magnitudeSuv s:s7NumericP9magnitude9MagnitudeQzv",
+  "typeName": "UInt",
+  "sourcetext": "magnitude",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "magnitude"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "multipliedFullWidth(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si19multipliedFullWidthSi4high_Su3lowtSi2by_tF s:s17FixedWidthIntegerP014multipliedFullB0x4high_9MagnitudeQz3lowtx2by_tF",
+  "typeName": "(high: Int, low: Int.Magnitude)",
+  "sourcetext": "multipliedFullWidth(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "multipliedFullWidth(by:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "multipliedReportingOverflow(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si27multipliedReportingOverflowSi12partialValue_s010ArithmeticC0O8overflowtSi2by_tF s:s17FixedWidthIntegerP27multipliedReportingOverflowx12partialValue_s010ArithmeticF0O8overflowtx2by_tF",
+  "typeName": "(partialValue: Int, overflow: ArithmeticOverflow)",
+  "sourcetext": "multipliedReportingOverflow(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "multipliedReportingOverflow(by:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "negate()",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13SignedNumericPsE6negateyyF",
+  "typeName": "Void",
+  "sourcetext": "negate()",
+  "context": "source.codecompletion.context.superclass",
+  "name": "negate()"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "nonzeroBitCount",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si15nonzeroBitCountSiv s:s17FixedWidthIntegerP15nonzeroBitCountSiv",
+  "typeName": "Int",
+  "sourcetext": "nonzeroBitCount",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "nonzeroBitCount"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "quotientAndRemainder(dividingBy: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE20quotientAndRemainderx0C0_x9remaindertx10dividingBy_tF",
+  "typeName": "(quotient: Int, remainder: Int)",
+  "sourcetext": "quotientAndRemainder(dividingBy: <#T##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "quotientAndRemainder(dividingBy:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "remainderReportingOverflow(dividingBy: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si26remainderReportingOverflowSi12partialValue_s010ArithmeticC0O8overflowtSi10dividingBy_tF s:s17FixedWidthIntegerP26remainderReportingOverflowx12partialValue_s010ArithmeticF0O8overflowtx10dividingBy_tF",
+  "typeName": "(partialValue: Int, overflow: ArithmeticOverflow)",
+  "sourcetext": "remainderReportingOverflow(dividingBy: <#T##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "remainderReportingOverflow(dividingBy:)"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "signum()",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE6signumxyF",
+  "typeName": "Int",
+  "sourcetext": "signum()",
+  "context": "source.codecompletion.context.superclass",
+  "name": "signum()"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "subtractingReportingOverflow(other: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si28subtractingReportingOverflowSi12partialValue_s010ArithmeticC0O8overflowtSiF s:s17FixedWidthIntegerP28subtractingReportingOverflowx12partialValue_s010ArithmeticF0O8overflowtxF",
+  "typeName": "(partialValue: Int, overflow: ArithmeticOverflow)",
+  "sourcetext": "subtractingReportingOverflow(<#T##other: Int##Int#>)",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "subtractingReportingOverflow(:)"
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "trailingZeroBitCount",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:Si20trailingZeroBitCountSiv s:s13BinaryIntegerP20trailingZeroBitCountSiv",
+  "typeName": "Int",
+  "sourcetext": "trailingZeroBitCount",
+  "context": "source.codecompletion.context.thisclass",
+  "name": "trailingZeroBitCount"
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "unsafeAdding(other: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s17FixedWidthIntegerPsE12unsafeAddingxxF",
+  "typeName": "Int",
+  "sourcetext": "unsafeAdding(<#T##other: Int##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "unsafeAdding(:)",
+  "docBrief": "Returns the sum of this value and the given value without checking for arithmetic overflow."
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "unsafeDivided(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s17FixedWidthIntegerPsE13unsafeDividedxx2by_tF",
+  "typeName": "Int",
+  "sourcetext": "unsafeDivided(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "unsafeDivided(by:)",
+  "docBrief": "Returns the quotient of dividing this value by the given value without checking for arithmetic overflow."
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "unsafeMultiplied(by: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s17FixedWidthIntegerPsE16unsafeMultipliedxx2by_tF",
+  "typeName": "Int",
+  "sourcetext": "unsafeMultiplied(by: <#T##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "unsafeMultiplied(by:)",
+  "docBrief": "Returns the product of this value and the given value without checking for arithmetic overflow."
+}, {
+  "kind": "source.lang.swift.decl.function.method.instance",
+  "descriptionKey": "unsafeSubtracting(other: Int)",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s17FixedWidthIntegerPsE17unsafeSubtractingxxF",
+  "typeName": "Int",
+  "sourcetext": "unsafeSubtracting(<#T##other: Int##Int#>)",
+  "context": "source.codecompletion.context.superclass",
+  "name": "unsafeSubtracting(:)",
+  "docBrief": "Returns the difference of this value and the given value without checking for arithmetic overflow."
+}, {
+  "kind": "source.lang.swift.decl.var.instance",
+  "descriptionKey": "words",
+  "moduleName": "Swift",
+  "associatedUSRs": "s:s13BinaryIntegerPsE5wordsSaySuGv",
+  "typeName": "[UInt]",
+  "sourcetext": "words",
+  "context": "source.codecompletion.context.superclass",
+  "name": "words"
+}]


### PR DESCRIPTION
- Add travis job with `swift-4.0-DEVELOPMENT-SNAPSHOT-2017-05-11-a` on Linux
- It can't be built with `swift-4.0-DEVELOPMENT-SNAPSHOT-2017-05-11-a` on macOS since compiler crashes. [SR-4863](https://bugs.swift.org/browse/SR-4863)
- Building with SwiftPM requires Swift 3.1 or later.
  - Building by SwiftPM with Swift 3.0.2 should be able to resurrect if [SR-4848](https://bugs.swift.org/browse/SR-4848) would be fixed.