### PR TITLE
Fix tests crash with Swift 3.1.1 on Linux

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Carthage/Commandant" "0.12.0"
 github "antitypical/Result" "3.2.1"
-github "drmohundro/SWXMLHash" "3.0.4"
+github "drmohundro/SWXMLHash" "3.0.5"
 github "jpsim/Yams" "0.3.2"
 github "jspahrsummers/xcconfigs" "2055f18efbe18e77408f7f43947f7ad92b2d4ff0"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ archive:
 release: package archive
 
 docker_test:
-	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:311 swift test
+	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:311 bash -c "swift package fetch; swift package edit SWXMLHash --revision nn-fix-crash-with-swift-3.1-on-linux; swift test"
 
 docker_test_302:
 	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:302 swift test

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ archive:
 release: package archive
 
 docker_test:
-	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:311 bash -c "swift package fetch; swift package edit SWXMLHash --revision nn-fix-crash-with-swift-3.1-on-linux; swift test"
+	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:311 swift test
 
 docker_test_302:
 	docker run -v `pwd`:`pwd` -w `pwd` norionomura/sourcekit:302 swift test

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
   ],
   dependencies: [
     .Package(url: "https://github.com/Carthage/Commandant.git", versions: Version(0, 12, 0)..<Version(0, 12, .max)),
-    .Package(url: "https://github.com/norio-nomura/SWXMLHash.git", Version(3, 0, 4)),
+    .Package(url: "https://github.com/drmohundro/SWXMLHash.git", Version(3, 0, 5)),
     .Package(url: "https://github.com/jpsim/Yams.git", majorVersion: 0, minor: 3),
     .Package(url: "https://github.com/norio-nomura/Clang_C.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/SourceKit.git", majorVersion: 1),

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
   ],
   dependencies: [
     .Package(url: "https://github.com/Carthage/Commandant.git", versions: Version(0, 12, 0)..<Version(0, 12, .max)),
-    .Package(url: "https://github.com/drmohundro/SWXMLHash.git", Version(3, 0, 4)),
+    .Package(url: "https://github.com/norio-nomura/SWXMLHash.git", Version(3, 0, 4)),
     .Package(url: "https://github.com/jpsim/Yams.git", majorVersion: 0, minor: 3),
     .Package(url: "https://github.com/norio-nomura/Clang_C.git", majorVersion: 1),
     .Package(url: "https://github.com/norio-nomura/SourceKit.git", majorVersion: 1),

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -48,10 +48,6 @@ class ModuleTests: XCTestCase {
 #if SWIFT_PACKAGE
 extension ModuleTests {
     func testCommandantDocsSPM() {
-    #if swift(>=3.1) && os(Linux)
-        // FIXME
-        print("FIXME: Skip \(#function), because our sourcekitInProc on Swift 3.1 for Linux seems to be broken")
-    #else
         func findCommandant(in directory: String) -> String? {
             guard let contents = try? FileManager.default.contentsOfDirectory(atPath: directory),
                 let subDirectory = contents.first(where: { $0.hasPrefix("Commandant") }) else {
@@ -72,7 +68,6 @@ extension ModuleTests {
         }
         let commandantModule = Module(spmName: "Commandant")!
         compareJSONString(withFixtureNamed: "CommandantSPM", jsonString: commandantModule.docs, rootDirectory: commandantPath)
-    #endif
     }
 
     static var allTests: [(String, (ModuleTests) -> () throws -> Void)] {

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -67,21 +67,11 @@ private func compareDocs(withFixtureNamed name: String, file: StaticString = #fi
 class SwiftDocsTests: XCTestCase {
 
     func testSubscript() {
-    #if swift(>=3.1) && os(Linux)
-        // FIXME
-        print("FIXME: Skip \(#function), because our sourcekitInProc on Swift 3.1 for Linux seems to be broken")
-    #else
         compareDocs(withFixtureNamed: "Subscript")
-    #endif
     }
 
     func testBicycle() {
-    #if swift(>=3.1) && os(Linux)
-        // FIXME
-        print("FIXME: Skip \(#function), because our sourcekitInProc on Swift 3.1 for Linux seems to be broken")
-    #else
         compareDocs(withFixtureNamed: "Bicycle")
-    #endif
     }
 
     func testParseFullXMLDocs() {


### PR DESCRIPTION
tests crash with Swift 3.1.1 on Linux:
- [x] `SourceKittenFrameworkTests.ModuleTests/testCommandantDocsSPM`
- [x] `SourceKittenFrameworkTests.SwiftDocsTests/testSubscript`
- [x] `SourceKittenFrameworkTests.SwiftDocsTests/testBicycle`

Fixes #379