### PR TITLE
Chang to explicitly pass `()` to `Result.success()`

### DIFF
--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -69,6 +69,6 @@ struct CompleteCommand: CommandProtocol {
             offset: Int64(options.offset),
             arguments: args)
         print(CodeCompletionItem.parse(response: request.send()))
-        return .success()
+        return .success(())
     }
 }

--- a/Source/sourcekitten/DocCommand.swift
+++ b/Source/sourcekitten/DocCommand.swift
@@ -59,7 +59,7 @@ struct DocCommand: CommandProtocol {
     func runSPMModule(moduleName: String) -> Result<(), SourceKittenError> {
         if let docs = Module(spmName: moduleName)?.docs {
             print(docs)
-            return .success()
+            return .success(())
         }
         return .failure(.docFailed)
     }
@@ -69,7 +69,7 @@ struct DocCommand: CommandProtocol {
 
         if let docs = module?.docs {
             print(docs)
-            return .success()
+            return .success(())
         }
         return .failure(.docFailed)
     }
@@ -82,7 +82,7 @@ struct DocCommand: CommandProtocol {
         if let file = File(path: args[0]),
            let docs = SwiftDocs(file: file, arguments: sourcekitdArguments) {
             print(docs)
-            return .success()
+            return .success(())
         }
         return .failure(.readFailed(path: args[0]))
     }
@@ -96,7 +96,7 @@ struct DocCommand: CommandProtocol {
         }
         let translationUnit = ClangTranslationUnit(headerFiles: [args[0]], compilerArguments: Array(args.dropFirst(1)))
         print(translationUnit)
-        return .success()
+        return .success(())
         #endif
     }
 }

--- a/Source/sourcekitten/FormatCommand.swift
+++ b/Source/sourcekitten/FormatCommand.swift
@@ -46,6 +46,6 @@ struct FormatCommand: CommandProtocol {
                     indentWidth: options.indentWidth)
             .data(using: .utf8)?
             .write(to: URL(fileURLWithPath: options.file), options: [])
-        return .success()
+        return .success(())
     }
 }

--- a/Source/sourcekitten/IndexCommand.swift
+++ b/Source/sourcekitten/IndexCommand.swift
@@ -40,6 +40,6 @@ struct IndexCommand: CommandProtocol {
         let absoluteFile = options.file.bridge().absolutePathRepresentation()
         let request = Request.index(file: absoluteFile, arguments: options.compilerargs.components(separatedBy: " "))
         print(toJSON(toNSDictionary(request.send())))
-        return .success()
+        return .success(())
     }
 }

--- a/Source/sourcekitten/StructureCommand.swift
+++ b/Source/sourcekitten/StructureCommand.swift
@@ -36,13 +36,13 @@ struct StructureCommand: CommandProtocol {
         if !options.file.isEmpty {
             if let file = File(path: options.file) {
                 print(Structure(file: file))
-                return .success()
+                return .success(())
             }
             return .failure(.readFailed(path: options.file))
         }
         if !options.text.isEmpty {
             print(Structure(file: File(contents: options.text)))
-            return .success()
+            return .success(())
         }
         return .failure(
             .invalidArgument(description: "either file or text must be set when calling structure")

--- a/Source/sourcekitten/SyntaxCommand.swift
+++ b/Source/sourcekitten/SyntaxCommand.swift
@@ -36,11 +36,11 @@ struct SyntaxCommand: CommandProtocol {
         if !options.file.isEmpty {
             if let file = File(path: options.file) {
                 print(SyntaxMap(file: file))
-                return .success()
+                return .success(())
             }
             return .failure(.readFailed(path: options.file))
         }
         print(SyntaxMap(file: File(contents: options.text)))
-        return .success()
+        return .success(())
     }
 }

--- a/Source/sourcekitten/VersionCommand.swift
+++ b/Source/sourcekitten/VersionCommand.swift
@@ -19,6 +19,6 @@ struct VersionCommand: CommandProtocol {
 
     func run(_ options: NoOptions<SourceKittenError>) -> Result<(), SourceKittenError> {
         print(version)
-        return .success()
+        return .success(())
     }
 }

--- a/Source/sourcekitten/YamlRequestCommand.swift
+++ b/Source/sourcekitten/YamlRequestCommand.swift
@@ -42,6 +42,6 @@ struct RequestCommand: CommandProtocol {
 
         let request = Request.yamlRequest(yaml: yaml)
         print(toJSON(toNSDictionary(request.send())))
-        return .success()
+        return .success(())
     }
 }


### PR DESCRIPTION
Is this affected by [SE-0110](https://github.com/apple/swift-evolution/blob/master/proposals/0110-distingish-single-tuple-arg.md)?

Extracted from https://github.com/jpsim/SourceKitten/pull/377 which can be applied without passing test on https://github.com/jpsim/SourceKitten/pull/377.