### PR TITLE
'subscript' returning `String` will be obsoleted in Swift 4

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -557,7 +557,8 @@ extension String {
 
         return lineComponents.map { line in
             if line.characters.count >= minLeadingCharacters {
-                return line[line.index(line.startIndex, offsetBy: minLeadingCharacters)..<line.endIndex]
+                let range = line.index(line.startIndex, offsetBy: minLeadingCharacters)..<line.endIndex
+                return line.substring(with: range)
             }
             return line
         }.joined(separator: "\n")


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/master/proposals/0163-string-revision-1.md#source-compatibility

Extracted from #377 which can be applied without passing test on #377.