### PR TITLE
Fix extensions of nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix handling of Swift extensions of nested types.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.17.5
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -572,6 +572,15 @@ extension String {
         unwantedSet.insert(charactersIn: "{")
         return trimmingCharacters(in: unwantedSet)
     }
+
+    /// Returns the byte offset of the section of the string following the last dot ".", or 0 if no dots.
+    internal func byteOffsetOfInnerTypeName() -> Int64 {
+        guard let range = range(of: ".", options: .backwards) else {
+            return 0
+        }
+        let utf8pos = index(after: range.lowerBound).samePosition(in: utf8)
+        return Int64(utf8.distance(from: utf8.startIndex, to: utf8pos))
+    }
 }
 
 // MARK: - migration support

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -145,6 +145,17 @@ public enum SwiftDocKey: String {
     }
 
     /**
+     Get name string from dictionary.
+
+     - parameter dictionary: Dictionary to get value from.
+
+     - returns: Name string if successful.
+     */
+    internal static func getName(_ dictionary: [String: SourceKitRepresentable]) -> String? {
+        return get(.name, dictionary)
+    }
+
+    /**
     Get type name string from dictionary.
 
     - parameter dictionary: Dictionary to get value from.

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Extension.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Extension.json
@@ -4,7 +4,7 @@
     "key.substructure" : [
       {
         "key.accessibility" : "source.lang.swift.accessibility.internal",
-        "key.length" : 125,
+        "key.length" : 179,
         "key.doc.type" : "Class",
         "key.runtime_name" : "_TtC8__main__4Base",
         "key.parsed_scope.start" : 2,
@@ -84,6 +84,39 @@
             "key.bodylength" : 5,
             "key.parsed_scope.end" : 9,
             "key.namelength" : 15
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 20,
+            "key.doc.type" : "Class",
+            "key.parsed_scope.start" : 12,
+            "key.kind" : "source.lang.swift.decl.class",
+            "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"12\" column=\"11\"><Name>Nested<\/Name><USR>s:CC9Extension4Base6Nested<\/USR><Declaration>class Nested<\/Declaration><Abstract><Para>Doc for Base.Nested<\/Para><\/Abstract><\/Class>",
+            "key.nameoffset" : 180,
+            "key.typename" : "Base.Nested.Type",
+            "key.doc.column" : 11,
+            "key.doc.comment" : "Doc for Base.Nested",
+            "key.bodyoffset" : 188,
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>class Nested<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Nested<\/decl.name><\/decl.class>",
+            "key.doc.declaration" : "class Nested",
+            "key.typeusr" : "_Tt",
+            "key.offset" : 174,
+            "key.doc.line" : 12,
+            "key.doc.name" : "Nested",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "Nested",
+            "key.usr" : "s:CC9Extension4Base6Nested",
+            "key.parsed_declaration" : "class Nested",
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 13,
+            "key.namelength" : 6
           }
         ],
         "key.typeusr" : "_Tt",
@@ -98,8 +131,8 @@
         "key.name" : "Base",
         "key.usr" : "s:C9Extension4Base",
         "key.parsed_declaration" : "class Base",
-        "key.bodylength" : 112,
-        "key.parsed_scope.end" : 10,
+        "key.bodylength" : 166,
+        "key.parsed_scope.end" : 14,
         "key.namelength" : 4
       },
       {
@@ -118,12 +151,12 @@
             "key.doc.declaration" : "typealias ExtendedIndex = Double",
             "key.length" : 13,
             "key.doc.type" : "Other",
-            "key.parsed_scope.start" : 15,
+            "key.parsed_scope.start" : 19,
             "key.typeusr" : "_Tt",
             "key.kind" : "source.lang.swift.decl.typealias",
-            "key.doc.full_as_xml" : "<Other file=\"Extension.swift\" line=\"15\" column=\"15\"><Name>ExtendedIndex<\/Name><USR>s:C9Extension4Base13ExtendedIndex<\/USR><Declaration>typealias ExtendedIndex = Double<\/Declaration><Abstract><Para>Doc for Base.ExtendedIndex<\/Para><\/Abstract><\/Other>",
-            "key.offset" : 211,
-            "key.doc.line" : 15,
+            "key.doc.full_as_xml" : "<Other file=\"Extension.swift\" line=\"19\" column=\"15\"><Name>ExtendedIndex<\/Name><USR>s:C9Extension4Base13ExtendedIndex<\/USR><Declaration>typealias ExtendedIndex = Double<\/Declaration><Abstract><Para>Doc for Base.ExtendedIndex<\/Para><\/Abstract><\/Other>",
+            "key.offset" : 265,
+            "key.doc.line" : 19,
             "key.typename" : "Double.Type",
             "key.actionable" : [
               {
@@ -136,20 +169,20 @@
             "key.doc.comment" : "Doc for Base.ExtendedIndex",
             "key.usr" : "s:C9Extension4Base13ExtendedIndex",
             "key.parsed_declaration" : "typealias ExtendedIndex = Double",
-            "key.parsed_scope.end" : 15
+            "key.parsed_scope.end" : 19
           },
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.length" : 44,
             "key.doc.type" : "Function",
-            "key.parsed_scope.start" : 18,
+            "key.parsed_scope.start" : 22,
             "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.doc.full_as_xml" : "<Function file=\"Extension.swift\" line=\"18\" column=\"10\"><Name>extendedF(index:)<\/Name><USR>s:FC9Extension4Base9extendedFFT5indexSd_T_<\/USR><Declaration>func extendedF(index: ExtendedIndex)<\/Declaration><Abstract><Para>Doc for Base.extendedF<\/Para><\/Abstract><\/Function>",
-            "key.nameoffset" : 275,
+            "key.doc.full_as_xml" : "<Function file=\"Extension.swift\" line=\"22\" column=\"10\"><Name>extendedF(index:)<\/Name><USR>s:FC9Extension4Base9extendedFFT5indexSd_T_<\/USR><Declaration>func extendedF(index: ExtendedIndex)<\/Declaration><Abstract><Para>Doc for Base.extendedF<\/Para><\/Abstract><\/Function>",
+            "key.nameoffset" : 329,
             "key.typename" : "(Base) -> (Double) -> ()",
             "key.doc.column" : 10,
             "key.doc.comment" : "Doc for Base.extendedF",
-            "key.bodyoffset" : 308,
+            "key.bodyoffset" : 362,
             "key.filepath" : "Extension.swift",
             "key.doc.file" : "Extension.swift",
             "key.annotated_decl" : "<Declaration>func extendedF(index: <Type usr=\"s:C9Extension4Base13ExtendedIndex\">ExtendedIndex<\/Type>)<\/Declaration>",
@@ -159,8 +192,8 @@
 
             ],
             "key.typeusr" : "_TtFT5indexSd_T_",
-            "key.offset" : 270,
-            "key.doc.line" : 18,
+            "key.offset" : 324,
+            "key.doc.line" : 22,
             "key.doc.name" : "extendedF(index:)",
             "key.actionable" : [
               {
@@ -171,16 +204,16 @@
             "key.usr" : "s:FC9Extension4Base9extendedFFT5indexSd_T_",
             "key.parsed_declaration" : "func extendedF(index: ExtendedIndex)",
             "key.bodylength" : 5,
-            "key.parsed_scope.end" : 19,
+            "key.parsed_scope.end" : 23,
             "key.namelength" : 31
           }
         ],
         "key.doc.type" : "Class",
         "key.typeusr" : "_Tt",
         "key.kind" : "source.lang.swift.decl.extension",
-        "key.offset" : 144,
+        "key.offset" : 198,
         "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"2\" column=\"7\"><Name>Base<\/Name><USR>s:C9Extension4Base<\/USR><Declaration>class Base<\/Declaration><Abstract><Para>Doc for Base<\/Para><\/Abstract><\/Class>",
-        "key.nameoffset" : 154,
+        "key.nameoffset" : 208,
         "key.doc.line" : 2,
         "key.typename" : "Base.Type",
         "key.actionable" : [
@@ -192,12 +225,114 @@
         "key.doc.column" : 7,
         "key.name" : "Base",
         "key.usr" : "s:C9Extension4Base",
-        "key.bodyoffset" : 160,
+        "key.bodyoffset" : 214,
         "key.bodylength" : 155,
         "key.namelength" : 4
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.doc.file" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>class Nested<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Nested<\/decl.name><\/decl.class>",
+        "key.doc.declaration" : "class Nested",
+        "key.length" : 25,
+        "key.doc.type" : "Class",
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.offset" : 413,
+        "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"12\" column=\"11\"><Name>Nested<\/Name><USR>s:CC9Extension4Base6Nested<\/USR><Declaration>class Nested<\/Declaration><Abstract><Para>Doc for Base.Nested<\/Para><\/Abstract><\/Class>",
+        "key.nameoffset" : 423,
+        "key.doc.line" : 12,
+        "key.typename" : "Base.Nested.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.doc.name" : "Nested",
+        "key.doc.column" : 11,
+        "key.name" : "Base.Nested",
+        "key.usr" : "s:CC9Extension4Base6Nested",
+        "key.bodyoffset" : 436,
+        "key.bodylength" : 1,
+        "key.namelength" : 11
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.parsed_declaration" : "class 🐽",
+        "key.annotated_decl" : "<Declaration>class 🐽<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>🐽<\/decl.name><\/decl.class>",
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.length" : 38,
+        "key.substructure" : [
+          {
+            "key.filepath" : "Extension.swift",
+            "key.parsed_declaration" : "struct 🐧",
+            "key.annotated_decl" : "<Declaration>struct 🐧<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>🐧<\/decl.name><\/decl.struct>",
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 19,
+            "key.parsed_scope.start" : 32,
+            "key.typeusr" : "_Tt",
+            "key.kind" : "source.lang.swift.decl.struct",
+            "key.offset" : 457,
+            "key.nameoffset" : 464,
+            "key.typename" : "🐽.🐧.Type",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "🐧",
+            "key.usr" : "s:VC9ExtensionX4ipIhX4voIh",
+            "key.bodyoffset" : 470,
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 33,
+            "key.namelength" : 4
+          }
+        ],
+        "key.runtime_name" : "_TtC8__main__4🐽",
+        "key.parsed_scope.start" : 31,
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.offset" : 440,
+        "key.nameoffset" : 446,
+        "key.typename" : "🐽.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.name" : "🐽",
+        "key.usr" : "s:C9ExtensionX4ipIh",
+        "key.bodyoffset" : 452,
+        "key.bodylength" : 25,
+        "key.parsed_scope.end" : 34,
+        "key.namelength" : 4
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>struct 🐧<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>🐧<\/decl.name><\/decl.struct>",
+        "key.length" : 23,
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.offset" : 480,
+        "key.nameoffset" : 490,
+        "key.typename" : "🐽.🐧.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.name" : "🐽.🐧",
+        "key.usr" : "s:VC9ExtensionX4ipIhX4voIh",
+        "key.bodyoffset" : 501,
+        "key.bodylength" : 1,
+        "key.namelength" : 9
       }
     ],
     "key.offset" : 0,
-    "key.length" : 317
+    "key.length" : 504
   }
 }

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Extension.swift
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Extension.swift
@@ -7,6 +7,10 @@ class Base {
     /// Doc for Base.f
     func f(index: Index) {
     }
+
+    /// Doc for Base.Nested
+    class Nested {
+    }
 }
 
 extension Base {
@@ -17,4 +21,17 @@ extension Base {
     /// Doc for Base.extendedF
     func extendedF(index: ExtendedIndex) {
     }
+}
+
+// Tests for extensions of nested types
+
+extension Base.Nested {
+}
+
+class 🐽 {
+    struct 🐧 {
+    }
+}
+
+extension 🐽.🐧 {
 }

--- a/Tests/SourceKittenFrameworkTests/Fixtures/LinuxExtension.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/LinuxExtension.json
@@ -1,137 +1,338 @@
 {
-  "Extension.swift": {
-    "key.substructure": [
+  "Extension.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.substructure" : [
       {
-        "key.typename": "Base.Type",
-        "key.filepath": "Extension.swift",
-        "key.annotated_decl": "<Declaration>class Base</Declaration>",
-        "key.nameoffset": 23,
-        "key.doc.full_as_xml": "<Class file=\"Extension.swift\" line=\"2\" column=\"7\"><Name>Base</Name><USR>s:C9Extension4Base</USR><Declaration>class Base</Declaration><Abstract><Para>Doc for Base</Para></Abstract></Class>",
-        "key.usr": "s:C9Extension4Base",
-        "key.namelength": 4,
-        "key.bodyoffset": 29,
-        "key.bodylength": 112,
-        "key.parsed_scope.end": 10,
-        "key.runtime_name": "_TtC8__main__4Base",
-        "key.accessibility": "source.lang.swift.accessibility.internal",
-        "key.fully_annotated_decl": "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>Base</decl.name></decl.class>",
-        "key.length": 125,
-        "key.name": "Base",
-        "key.typeusr": "_Tt",
-        "key.offset": 17,
-        "key.substructure": [
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.length" : 179,
+        "key.doc.type" : "Class",
+        "key.runtime_name" : "_TtC8__main__4Base",
+        "key.parsed_scope.start" : 2,
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"2\" column=\"7\"><Name>Base<\/Name><USR>s:C9Extension4Base<\/USR><Declaration>class Base<\/Declaration><Abstract><Para>Doc for Base<\/Para><\/Abstract><\/Class>",
+        "key.nameoffset" : 23,
+        "key.typename" : "Base.Type",
+        "key.doc.column" : 7,
+        "key.doc.comment" : "Doc for Base",
+        "key.bodyoffset" : 29,
+        "key.filepath" : "Extension.swift",
+        "key.doc.file" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>class Base<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Base<\/decl.name><\/decl.class>",
+        "key.doc.declaration" : "class Base",
+        "key.substructure" : [
           {
-            "key.typename": "Base.Index.Type",
-            "key.filepath": "Extension.swift",
-            "key.annotated_decl": "<Declaration>typealias Index = <Type usr=\"s:Si\">Int</Type></Declaration>",
-            "key.doc.full_as_xml": "<Other file=\"Extension.swift\" line=\"5\" column=\"15\"><Name>Index</Name><USR>s:C9Extension4Base5Index</USR><Declaration>typealias Index = Int</Declaration><Abstract><Para>Doc for Base.Index</Para></Abstract></Other>",
-            "key.usr": "s:C9Extension4Base5Index",
-            "key.parsed_scope.end": 5,
-            "key.fully_annotated_decl": "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Index</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
-            "key.typeusr": "_Tt",
-            "key.length": 5,
-            "key.name": "Index",
-            "key.offset": 72,
-            "key.kind": "source.lang.swift.decl.typealias",
-            "key.doc.comment": "Doc for Base.Index",
-            "key.parsed_declaration": "typealias Index = Int",
-            "key.parsed_scope.start": 5
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>typealias Index = <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.typealias><syntaxtype.keyword>typealias<\/syntaxtype.keyword> <decl.name>Index<\/decl.name> = <ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.typealias>",
+            "key.doc.declaration" : "typealias Index = Int",
+            "key.length" : 5,
+            "key.doc.type" : "Other",
+            "key.parsed_scope.start" : 5,
+            "key.typeusr" : "_Tt",
+            "key.kind" : "source.lang.swift.decl.typealias",
+            "key.doc.full_as_xml" : "<Other file=\"Extension.swift\" line=\"5\" column=\"15\"><Name>Index<\/Name><USR>s:C9Extension4Base5Index<\/USR><Declaration>typealias Index = Int<\/Declaration><Abstract><Para>Doc for Base.Index<\/Para><\/Abstract><\/Other>",
+            "key.offset" : 72,
+            "key.doc.line" : 5,
+            "key.typename" : "Int.Type",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.doc.name" : "Index",
+            "key.doc.column" : 15,
+            "key.name" : "Index",
+            "key.doc.comment" : "Doc for Base.Index",
+            "key.usr" : "s:C9Extension4Base5Index",
+            "key.parsed_declaration" : "typealias Index = Int",
+            "key.parsed_scope.end" : 5
           },
           {
-            "key.typename": "(Base) -> (Base.Index) -> ()",
-            "key.filepath": "Extension.swift",
-            "key.annotated_decl": "<Declaration>func f(index: <Type usr=\"s:C9Extension4Base5Index\">Index</Type>)</Declaration>",
-            "key.nameoffset": 117,
-            "key.doc.full_as_xml": "<Function file=\"Extension.swift\" line=\"8\" column=\"10\"><Name>f(index:)</Name><USR>s:FC9Extension4Base1fFT5indexSi_T_</USR><Declaration>func f(index: Index)</Declaration><Abstract><Para>Doc for Base.f</Para></Abstract></Function>",
-            "key.usr": "s:FC9Extension4Base1fFT5indexSi_T_",
-            "key.namelength": 15,
-            "key.bodyoffset": 134,
-            "key.bodylength": 5,
-            "key.parsed_scope.end": 9,
-            "key.accessibility": "source.lang.swift.accessibility.internal",
-            "key.fully_annotated_decl": "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>f</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>index</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.typealias usr=\"s:C9Extension4Base5Index\">Index</ref.typealias></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
-            "key.length": 28,
-            "key.name": "f(index:)",
-            "key.typeusr": "_TtFT5indexSi_T_",
-            "key.offset": 112,
-            "key.substructure": [
-              
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 28,
+            "key.doc.type" : "Function",
+            "key.parsed_scope.start" : 8,
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.doc.full_as_xml" : "<Function file=\"Extension.swift\" line=\"8\" column=\"10\"><Name>f(index:)<\/Name><USR>s:FC9Extension4Base1fFT5indexSi_T_<\/USR><Declaration>func f(index: Index)<\/Declaration><Abstract><Para>Doc for Base.f<\/Para><\/Abstract><\/Function>",
+            "key.nameoffset" : 117,
+            "key.typename" : "(Base) -> (Int) -> ()",
+            "key.doc.column" : 10,
+            "key.doc.comment" : "Doc for Base.f",
+            "key.bodyoffset" : 134,
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>func f(index: <Type usr=\"s:C9Extension4Base5Index\">Index<\/Type>)<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>f<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>index<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.typealias usr=\"s:C9Extension4Base5Index\">Index<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.method.instance>",
+            "key.doc.declaration" : "func f(index: Index)",
+            "key.substructure" : [
+
             ],
-            "key.kind": "source.lang.swift.decl.function.method.instance",
-            "key.parsed_declaration": "func f(index: Index)",
-            "key.doc.comment": "Doc for Base.f",
-            "key.parsed_scope.start": 8
+            "key.typeusr" : "_TtFT5indexSi_T_",
+            "key.offset" : 112,
+            "key.doc.line" : 8,
+            "key.doc.name" : "f(index:)",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "f(index:)",
+            "key.usr" : "s:FC9Extension4Base1fFT5indexSi_T_",
+            "key.parsed_declaration" : "func f(index: Index)",
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 9,
+            "key.namelength" : 15
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 20,
+            "key.doc.type" : "Class",
+            "key.parsed_scope.start" : 12,
+            "key.kind" : "source.lang.swift.decl.class",
+            "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"12\" column=\"11\"><Name>Nested<\/Name><USR>s:CC9Extension4Base6Nested<\/USR><Declaration>class Nested<\/Declaration><Abstract><Para>Doc for Base.Nested<\/Para><\/Abstract><\/Class>",
+            "key.nameoffset" : 180,
+            "key.typename" : "Base.Nested.Type",
+            "key.doc.column" : 11,
+            "key.doc.comment" : "Doc for Base.Nested",
+            "key.bodyoffset" : 188,
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>class Nested<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Nested<\/decl.name><\/decl.class>",
+            "key.doc.declaration" : "class Nested",
+            "key.typeusr" : "_Tt",
+            "key.offset" : 174,
+            "key.doc.line" : 12,
+            "key.doc.name" : "Nested",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "Nested",
+            "key.usr" : "s:CC9Extension4Base6Nested",
+            "key.parsed_declaration" : "class Nested",
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 13,
+            "key.namelength" : 6
           }
         ],
-        "key.kind": "source.lang.swift.decl.class",
-        "key.parsed_declaration": "/// Doc for Base\nclass Base",
-        "key.doc.comment": "Doc for Base",
-        "key.parsed_scope.start": 2
+        "key.typeusr" : "_Tt",
+        "key.offset" : 17,
+        "key.doc.line" : 2,
+        "key.doc.name" : "Base",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.name" : "Base",
+        "key.usr" : "s:C9Extension4Base",
+        "key.parsed_declaration" : "class Base",
+        "key.bodylength" : 166,
+        "key.parsed_scope.end" : 14,
+        "key.namelength" : 4
       },
       {
-        "key.typename": "Base.Type",
-        "key.filepath": "Extension.swift",
-        "key.annotated_decl": "<Declaration>class Base</Declaration>",
-        "key.nameoffset": 154,
-        "key.doc.full_as_xml": "<Class file=\"Extension.swift\" line=\"2\" column=\"7\"><Name>Base</Name><USR>s:C9Extension4Base</USR><Declaration>class Base</Declaration><Abstract><Para>Doc for Base</Para></Abstract></Class>",
-        "key.usr": "s:C9Extension4Base",
-        "key.namelength": 4,
-        "key.bodyoffset": 160,
-        "key.bodylength": 155,
-        "key.fully_annotated_decl": "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>Base</decl.name></decl.class>",
-        "key.length": 172,
-        "key.name": "Base",
-        "key.typeusr": "_Tt",
-        "key.offset": 144,
-        "key.substructure": [
+        "key.filepath" : "Extension.swift",
+        "key.doc.file" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>class Base<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Base<\/decl.name><\/decl.class>",
+        "key.doc.declaration" : "class Base",
+        "key.length" : 172,
+        "key.substructure" : [
           {
-            "key.typename": "Base.ExtendedIndex.Type",
-            "key.filepath": "Extension.swift",
-            "key.annotated_decl": "<Declaration>typealias ExtendedIndex = <Type usr=\"s:Sd\">Double</Type></Declaration>",
-            "key.doc.full_as_xml": "<Other file=\"Extension.swift\" line=\"15\" column=\"15\"><Name>ExtendedIndex</Name><USR>s:C9Extension4Base13ExtendedIndex</USR><Declaration>typealias ExtendedIndex = Double</Declaration><Abstract><Para>Doc for Base.ExtendedIndex</Para></Abstract></Other>",
-            "key.usr": "s:C9Extension4Base13ExtendedIndex",
-            "key.parsed_scope.end": 15,
-            "key.fully_annotated_decl": "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>ExtendedIndex</decl.name> = <ref.struct usr=\"s:Sd\">Double</ref.struct></decl.typealias>",
-            "key.typeusr": "_Tt",
-            "key.length": 13,
-            "key.name": "ExtendedIndex",
-            "key.offset": 211,
-            "key.kind": "source.lang.swift.decl.typealias",
-            "key.doc.comment": "Doc for Base.ExtendedIndex",
-            "key.parsed_declaration": "typealias ExtendedIndex = Double",
-            "key.parsed_scope.start": 15
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>typealias ExtendedIndex = <Type usr=\"s:Sd\">Double<\/Type><\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.typealias><syntaxtype.keyword>typealias<\/syntaxtype.keyword> <decl.name>ExtendedIndex<\/decl.name> = <ref.struct usr=\"s:Sd\">Double<\/ref.struct><\/decl.typealias>",
+            "key.doc.declaration" : "typealias ExtendedIndex = Double",
+            "key.length" : 13,
+            "key.doc.type" : "Other",
+            "key.parsed_scope.start" : 19,
+            "key.typeusr" : "_Tt",
+            "key.kind" : "source.lang.swift.decl.typealias",
+            "key.doc.full_as_xml" : "<Other file=\"Extension.swift\" line=\"19\" column=\"15\"><Name>ExtendedIndex<\/Name><USR>s:C9Extension4Base13ExtendedIndex<\/USR><Declaration>typealias ExtendedIndex = Double<\/Declaration><Abstract><Para>Doc for Base.ExtendedIndex<\/Para><\/Abstract><\/Other>",
+            "key.offset" : 265,
+            "key.doc.line" : 19,
+            "key.typename" : "Double.Type",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.doc.name" : "ExtendedIndex",
+            "key.doc.column" : 15,
+            "key.name" : "ExtendedIndex",
+            "key.doc.comment" : "Doc for Base.ExtendedIndex",
+            "key.usr" : "s:C9Extension4Base13ExtendedIndex",
+            "key.parsed_declaration" : "typealias ExtendedIndex = Double",
+            "key.parsed_scope.end" : 19
           },
           {
-            "key.typename": "(Base) -> (Base.ExtendedIndex) -> ()",
-            "key.filepath": "Extension.swift",
-            "key.annotated_decl": "<Declaration>func extendedF(index: <Type usr=\"s:C9Extension4Base13ExtendedIndex\">ExtendedIndex</Type>)</Declaration>",
-            "key.nameoffset": 275,
-            "key.doc.full_as_xml": "<Function file=\"Extension.swift\" line=\"18\" column=\"10\"><Name>extendedF(index:)</Name><USR>s:FC9Extension4Base9extendedFFT5indexSd_T_</USR><Declaration>func extendedF(index: ExtendedIndex)</Declaration><Abstract><Para>Doc for Base.extendedF</Para></Abstract></Function>",
-            "key.usr": "s:FC9Extension4Base9extendedFFT5indexSd_T_",
-            "key.namelength": 31,
-            "key.bodyoffset": 308,
-            "key.bodylength": 5,
-            "key.parsed_scope.end": 19,
-            "key.accessibility": "source.lang.swift.accessibility.internal",
-            "key.fully_annotated_decl": "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extendedF</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>index</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.typealias usr=\"s:C9Extension4Base13ExtendedIndex\">ExtendedIndex</ref.typealias></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
-            "key.length": 44,
-            "key.name": "extendedF(index:)",
-            "key.typeusr": "_TtFT5indexSd_T_",
-            "key.offset": 270,
-            "key.substructure": [
-              
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 44,
+            "key.doc.type" : "Function",
+            "key.parsed_scope.start" : 22,
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.doc.full_as_xml" : "<Function file=\"Extension.swift\" line=\"22\" column=\"10\"><Name>extendedF(index:)<\/Name><USR>s:FC9Extension4Base9extendedFFT5indexSd_T_<\/USR><Declaration>func extendedF(index: ExtendedIndex)<\/Declaration><Abstract><Para>Doc for Base.extendedF<\/Para><\/Abstract><\/Function>",
+            "key.nameoffset" : 329,
+            "key.typename" : "(Base) -> (Double) -> ()",
+            "key.doc.column" : 10,
+            "key.doc.comment" : "Doc for Base.extendedF",
+            "key.bodyoffset" : 362,
+            "key.filepath" : "Extension.swift",
+            "key.doc.file" : "Extension.swift",
+            "key.annotated_decl" : "<Declaration>func extendedF(index: <Type usr=\"s:C9Extension4Base13ExtendedIndex\">ExtendedIndex<\/Type>)<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>extendedF<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>index<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.typealias usr=\"s:C9Extension4Base13ExtendedIndex\">ExtendedIndex<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.method.instance>",
+            "key.doc.declaration" : "func extendedF(index: ExtendedIndex)",
+            "key.substructure" : [
+
             ],
-            "key.kind": "source.lang.swift.decl.function.method.instance",
-            "key.parsed_declaration": "func extendedF(index: ExtendedIndex)",
-            "key.doc.comment": "Doc for Base.extendedF",
-            "key.parsed_scope.start": 18
+            "key.typeusr" : "_TtFT5indexSd_T_",
+            "key.offset" : 324,
+            "key.doc.line" : 22,
+            "key.doc.name" : "extendedF(index:)",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "extendedF(index:)",
+            "key.usr" : "s:FC9Extension4Base9extendedFFT5indexSd_T_",
+            "key.parsed_declaration" : "func extendedF(index: ExtendedIndex)",
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 23,
+            "key.namelength" : 31
           }
         ],
-        "key.kind": "source.lang.swift.decl.extension"
+        "key.doc.type" : "Class",
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.offset" : 198,
+        "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"2\" column=\"7\"><Name>Base<\/Name><USR>s:C9Extension4Base<\/USR><Declaration>class Base<\/Declaration><Abstract><Para>Doc for Base<\/Para><\/Abstract><\/Class>",
+        "key.nameoffset" : 208,
+        "key.doc.line" : 2,
+        "key.typename" : "Base.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.doc.name" : "Base",
+        "key.doc.column" : 7,
+        "key.name" : "Base",
+        "key.usr" : "s:C9Extension4Base",
+        "key.bodyoffset" : 214,
+        "key.bodylength" : 155,
+        "key.namelength" : 4
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.doc.file" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>class Nested<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>Nested<\/decl.name><\/decl.class>",
+        "key.doc.declaration" : "class Nested",
+        "key.length" : 25,
+        "key.doc.type" : "Class",
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.offset" : 413,
+        "key.doc.full_as_xml" : "<Class file=\"Extension.swift\" line=\"12\" column=\"11\"><Name>Nested<\/Name><USR>s:CC9Extension4Base6Nested<\/USR><Declaration>class Nested<\/Declaration><Abstract><Para>Doc for Base.Nested<\/Para><\/Abstract><\/Class>",
+        "key.nameoffset" : 423,
+        "key.doc.line" : 12,
+        "key.typename" : "Base.Nested.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.doc.name" : "Nested",
+        "key.doc.column" : 11,
+        "key.name" : "Base.Nested",
+        "key.usr" : "s:CC9Extension4Base6Nested",
+        "key.bodyoffset" : 436,
+        "key.bodylength" : 1,
+        "key.namelength" : 11
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.parsed_declaration" : "class 🐽",
+        "key.annotated_decl" : "<Declaration>class 🐽<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>🐽<\/decl.name><\/decl.class>",
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.length" : 38,
+        "key.substructure" : [
+          {
+            "key.filepath" : "Extension.swift",
+            "key.parsed_declaration" : "struct 🐧",
+            "key.annotated_decl" : "<Declaration>struct 🐧<\/Declaration>",
+            "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>🐧<\/decl.name><\/decl.struct>",
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.length" : 19,
+            "key.parsed_scope.start" : 32,
+            "key.typeusr" : "_Tt",
+            "key.kind" : "source.lang.swift.decl.struct",
+            "key.offset" : 457,
+            "key.nameoffset" : 464,
+            "key.typename" : "🐽.🐧.Type",
+            "key.actionable" : [
+              {
+                "key.actionname" : "Rename"
+              }
+            ],
+            "key.name" : "🐧",
+            "key.usr" : "s:VC9ExtensionX4ipIhX4voIh",
+            "key.bodyoffset" : 470,
+            "key.bodylength" : 5,
+            "key.parsed_scope.end" : 33,
+            "key.namelength" : 4
+          }
+        ],
+        "key.runtime_name" : "_TtC8__main__4🐽",
+        "key.parsed_scope.start" : 31,
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.offset" : 440,
+        "key.nameoffset" : 446,
+        "key.typename" : "🐽.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.name" : "🐽",
+        "key.usr" : "s:C9ExtensionX4ipIh",
+        "key.bodyoffset" : 452,
+        "key.bodylength" : 25,
+        "key.parsed_scope.end" : 34,
+        "key.namelength" : 4
+      },
+      {
+        "key.filepath" : "Extension.swift",
+        "key.annotated_decl" : "<Declaration>struct 🐧<\/Declaration>",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>🐧<\/decl.name><\/decl.struct>",
+        "key.length" : 23,
+        "key.typeusr" : "_Tt",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.offset" : 480,
+        "key.nameoffset" : 490,
+        "key.typename" : "🐽.🐧.Type",
+        "key.actionable" : [
+          {
+            "key.actionname" : "Rename"
+          }
+        ],
+        "key.name" : "🐽.🐧",
+        "key.usr" : "s:VC9ExtensionX4ipIhX4voIh",
+        "key.bodyoffset" : 501,
+        "key.bodylength" : 1,
+        "key.namelength" : 9
       }
     ],
-    "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
-    "key.length": 317,
-    "key.offset": 0
+    "key.offset" : 0,
+    "key.length" : 504
   }
 }


### PR DESCRIPTION
From realm/jazzy#333.  Given:

```swift
class Outer {
    class Inner {
    }
}

extension Outer.Inner {
}
```

...sourcekitten associates the extension with `Outer` -- ie. `key.name` and `key.usr` match `Outer`.  This happens because of the `source.request.cursorinfo` made for the extension against the `Outer.Inner` name: SourceKit interprets this as a request for info about the `Outer` type and diligently returns it.

This PR handles declaration names containing dots and advances the offset of the cursorinfo to the last portion, which is the actual type of the extension.