### PR TITLE
Cache NSString.CacheContainer on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ##### Enhancements
 
-* None.
+* Cache `NSString.CacheContainer` on Linux, matching behavior on Darwin,
+  speeding up many repeated operations on `NSString` on Linux.  
+  [JP Simard](https://github.com/jpsim)
+  [realm/SwiftLint#1577](https://github.com/realm/SwiftLint/issues/1577)
 
 ##### Bug Fixes
 


### PR DESCRIPTION
Speeds up SwiftLint linting itself on Linux by ~13x (15s vs 3m23s).