### PR TITLE
Add tabWidth parameter (default: 1) for lineAndCharacter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Add `tabWidth` parameter (default: `1`) for `lineAndCharacter`.  
+  [Marcel Jackwerth](https://github.com/sirlantis)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -160,7 +160,7 @@ extension NSString {
             return line.byteRange.location + byteDiff
         }
 
-        func lineAndCharacter(forCharacterOffset offset: Int, tabWidth: Int) -> (line: Int, character: Int)? {
+        func lineAndCharacter(forCharacterOffset offset: Int, expandingTabsToWidth tabWidth: Int) -> (line: Int, character: Int)? {
             assert(tabWidth > 0)
 
             let index = lines.index(where: { NSLocationInRange(offset, $0.range) })
@@ -186,9 +186,9 @@ extension NSString {
             }
         }
 
-        func lineAndCharacter(forByteOffset offset: Int, tabWidth: Int) -> (line: Int, character: Int)? {
+        func lineAndCharacter(forByteOffset offset: Int, expandingTabsToWidth tabWidth: Int) -> (line: Int, character: Int)? {
             let characterOffset = location(fromByteOffset: offset)
-            return lineAndCharacter(forCharacterOffset: characterOffset, tabWidth: tabWidth)
+            return lineAndCharacter(forCharacterOffset: characterOffset, expandingTabsToWidth: tabWidth)
         }
     }
 
@@ -213,20 +213,20 @@ extension NSString {
     Returns line number and character for utf16 based offset.
 
     - parameter offset: utf16 based index.
-    - parameter tabWidth: the assumed tab width.
+    - parameter tabWidth: the width in spaces to expand tabs to.
     */
-    public func lineAndCharacter(forCharacterOffset offset: Int, tabWidth: Int = 1) -> (line: Int, character: Int)? {
-        return cacheContainer.lineAndCharacter(forCharacterOffset: offset, tabWidth: tabWidth)
+    public func lineAndCharacter(forCharacterOffset offset: Int, expandingTabsToWidth tabWidth: Int = 1) -> (line: Int, character: Int)? {
+        return cacheContainer.lineAndCharacter(forCharacterOffset: offset, expandingTabsToWidth: tabWidth)
     }
 
     /**
     Returns line number and character for byte offset.
 
     - parameter offset: byte offset.
-    - parameter tabWidth: the assumed tab width.
+    - parameter tabWidth: the width in spaces to expand tabs to.
     */
-    public func lineAndCharacter(forByteOffset offset: Int, tabWidth: Int = 1) -> (line: Int, character: Int)? {
-        return cacheContainer.lineAndCharacter(forByteOffset: offset, tabWidth: tabWidth)
+    public func lineAndCharacter(forByteOffset offset: Int, expandingTabsToWidth tabWidth: Int = 1) -> (line: Int, character: Int)? {
+        return cacheContainer.lineAndCharacter(forByteOffset: offset, expandingTabsToWidth: tabWidth)
     }
 
     /**

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -160,17 +160,35 @@ extension NSString {
             return line.byteRange.location + byteDiff
         }
 
-        func lineAndCharacter(forCharacterOffset offset: Int) -> (line: Int, character: Int)? {
+        func lineAndCharacter(forCharacterOffset offset: Int, tabWidth: Int) -> (line: Int, character: Int)? {
+            assert(tabWidth > 0)
+
             let index = lines.index(where: { NSLocationInRange(offset, $0.range) })
             return index.map {
                 let line = lines[$0]
-                return (line: line.index, character: offset - line.range.location + 1)
+
+                let prefixLength = offset - line.range.location
+                let character: Int
+
+                if tabWidth == 1 {
+                    character = prefixLength
+                } else {
+                    character = line.content.characters.prefix(prefixLength).reduce(0) { sum, character in
+                        if character == "\t" {
+                            return sum - (sum % tabWidth) + tabWidth
+                        } else {
+                            return sum + 1
+                        }
+                    }
+                }
+
+                return (line: line.index, character: character + 1)
             }
         }
 
-        func lineAndCharacter(forByteOffset offset: Int) -> (line: Int, character: Int)? {
+        func lineAndCharacter(forByteOffset offset: Int, tabWidth: Int) -> (line: Int, character: Int)? {
             let characterOffset = location(fromByteOffset: offset)
-            return lineAndCharacter(forCharacterOffset: characterOffset)
+            return lineAndCharacter(forCharacterOffset: characterOffset, tabWidth: tabWidth)
         }
     }
 
@@ -195,18 +213,20 @@ extension NSString {
     Returns line number and character for utf16 based offset.
 
     - parameter offset: utf16 based index.
+    - parameter tabWidth: the assumed tab width.
     */
-    public func lineAndCharacter(forCharacterOffset offset: Int) -> (line: Int, character: Int)? {
-        return cacheContainer.lineAndCharacter(forCharacterOffset: offset)
+    public func lineAndCharacter(forCharacterOffset offset: Int, tabWidth: Int = 1) -> (line: Int, character: Int)? {
+        return cacheContainer.lineAndCharacter(forCharacterOffset: offset, tabWidth: tabWidth)
     }
 
     /**
     Returns line number and character for byte offset.
 
     - parameter offset: byte offset.
+    - parameter tabWidth: the assumed tab width.
     */
-    public func lineAndCharacter(forByteOffset offset: Int) -> (line: Int, character: Int)? {
-        return cacheContainer.lineAndCharacter(forByteOffset: offset)
+    public func lineAndCharacter(forByteOffset offset: Int, tabWidth: Int = 1) -> (line: Int, character: Int)? {
+        return cacheContainer.lineAndCharacter(forByteOffset: offset, tabWidth: tabWidth)
     }
 
     /**

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -164,18 +164,18 @@ class StringTests: XCTestCase {
         "\ttest()\n" +     // t+  06+1 characters
         "}"
 
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset:  4, tabWidth: 1), (1, 5))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 17, tabWidth: 1), (2, 5))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27 /* tabWidth: default */), (3, 4))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 1), (3, 4))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 2), (3, 5))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 4), (3, 5))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 8), (3, 9))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset:  4, expandingTabsToWidth: 1), (1, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 17, expandingTabsToWidth: 1), (2, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27 /* expandingTabsToWidth: default */), (3, 4))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, expandingTabsToWidth: 1), (3, 4))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, expandingTabsToWidth: 2), (3, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, expandingTabsToWidth: 4), (3, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, expandingTabsToWidth: 8), (3, 9))
         XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35 /* tabWidth: default */), (4, 2))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 1), (4, 2))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 2), (4, 3))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 4), (4, 5))
-        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 8), (4, 9))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 1), (4, 2))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 2), (4, 3))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 4), (4, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 8), (4, 9))
     }
 }
 

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -155,6 +155,22 @@ class StringTests: XCTestCase {
         let string = "public typealias 🔳 = QRCode"
         XCTAssert(string.bridge().lineAndCharacter(forByteOffset: 17)! == (1, 18))
     }
+
+    func testLineAndCharacterForCharacterOffset() {
+        let string = "" +
+        "func foo() {\n" + // 13 characters
+        "    test()\n" +   // 11 characters
+        "  \ttest()\n" +   // 10 characters
+        "\ttest()\n" +     // 8 characters
+        "}"
+
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 4)! == (1, 5))
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 17)! == (2, 5))
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 27)! == (3, 5))
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 2)! == (3, 5))
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 35)! == (4, 5))
+        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 2)! == (4, 3))
+    }
 }
 
 typealias LineRangeType = (start: Int, end: Int)
@@ -180,7 +196,8 @@ extension StringTests {
             ("testSubstringWithByteRange", testSubstringWithByteRange),
             ("testSubstringLinesWithByteRange", testSubstringLinesWithByteRange),
             ("testLineRangeWithByteRange", testLineRangeWithByteRange),
-            ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset)
+            ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset),
+            ("testLineAndCharacterForCharacterOffset", testLineAndCharacterForCharacterOffset)
         ]
     }
 }

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -144,32 +144,38 @@ class StringTests: XCTestCase {
     func testLineRangeWithByteRange() {
         XCTAssert("".bridge().lineRangeWithByteRange(start: 0, length: 0) == nil)
         let string = "👨‍👩‍👧‍👧\n123"
-        XCTAssert(string.bridge().lineRangeWithByteRange(start: 0, length: 0)! == (1, 1))
-        XCTAssert(string.bridge().lineRangeWithByteRange(start: 0, length: 25)! == (1, 1))
-        XCTAssert(string.bridge().lineRangeWithByteRange(start: 0, length: 26)! == (1, 2))
-        XCTAssert(string.bridge().lineRangeWithByteRange(start: 0, length: 27)! == (1, 2))
-        XCTAssert(string.bridge().lineRangeWithByteRange(start: 27, length: 0)! == (2, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 0), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 25), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 26), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 27), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 27, length: 0), (2, 2))
     }
 
     func testLineAndCharacterForByteOffset() {
         let string = "public typealias 🔳 = QRCode"
-        XCTAssert(string.bridge().lineAndCharacter(forByteOffset: 17)! == (1, 18))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: 17), (1, 18))
     }
 
     func testLineAndCharacterForCharacterOffset() {
         let string = "" +
-        "func foo() {\n" + // 13 characters
-        "    test()\n" +   // 11 characters
-        "  \ttest()\n" +   // 10 characters
-        "\ttest()\n" +     // 8 characters
+        "func foo() {\n" + //     12+1 characters, start=0
+        "    test()\n" +   //     10+1 characters, start=13
+        "  \ttest()\n" +   // 2+t+06+1 characters, start=24
+        "\ttest()\n" +     // t+  06+1 characters
         "}"
 
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 4)! == (1, 5))
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 17)! == (2, 5))
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 27)! == (3, 5))
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 2)! == (3, 5))
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 35)! == (4, 5))
-        XCTAssert(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 2)! == (4, 3))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset:  4, tabWidth: 1), (1, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 17, tabWidth: 1), (2, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27 /* tabWidth: default */), (3, 4))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 1), (3, 4))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 2), (3, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 4), (3, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 27, tabWidth: 8), (3, 9))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35 /* tabWidth: default */), (4, 2))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 1), (4, 2))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 2), (4, 3))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 4), (4, 5))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, tabWidth: 8), (4, 9))
     }
 }
 
@@ -177,6 +183,14 @@ typealias LineRangeType = (start: Int, end: Int)
 
 func == (lhs: LineRangeType, rhs: LineRangeType) -> Bool {
     return lhs.start == rhs.start && lhs.end == rhs.end
+}
+
+private func XCTAssertEqual(_ actual: (Int, Int)?, _ expected: (Int, Int), file: StaticString = #file, line: UInt = #line) {
+    XCTAssertNotNil(actual, file: file, line: line)
+
+    if let actual = actual {
+        XCTAssertEqual([actual.0, actual.1], [expected.0, expected.1], file: file, line: line)
+    }
 }
 
 extension StringTests {


### PR DESCRIPTION
The line/column information normally takes tab width into account. The `W` in the following example would be reported to be at character 9 (for a tab width of 4), but currently it is reported as 6.

```
Hello\tWorld!
```

I picked 1 as a default value to make this a non-breaking change, but as stated above `4` is probably more reasonable. Let me know how you feel about the change in general and what your preference on the default value is.

P.S. This is in preparation of a PR I wanted to do on SwiftLint, to make the vertical parameter alignment rule handle tabs better.