### PR TITLE
Keep user alignment of multi-line Swift declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Preserve horizontal alignment in multi-line Swift declarations.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.18.2
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -136,7 +136,8 @@ public final class File {
         } else {
             substring = contents.bridge().substringLinesWithByteRange(start: start, length: 0)
         }
-        return substring?.trimmingWhitespaceAndOpeningCurlyBrace()
+        return substring?.removingCommonLeadingWhitespaceFromLines()
+                         .trimmingWhitespaceAndOpeningCurlyBrace()
     }
 
     /**

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -108,6 +108,24 @@ class StringTests: XCTestCase {
         XCTAssertEqual("class ClassA", file.parseDeclaration(dict)!, "should extract declaration from source text")
     }
 
+    func testParseMultiLineDeclaration() {
+        let dict: [String: SourceKitRepresentable] = [
+            "key.kind": "source.lang.swift.decl.function.free",
+            "key.offset": Int64(4),
+            "key.bodyoffset": Int64(40),
+            "key.annotated_decl": "",
+            "key.typename": "(Int, Int) -> ()"
+        ]
+        let contents = "    func f(a: Int,\n" +
+                       "           b: Int) {\n" +
+                       "    }\n"
+        let file = File(contents: contents)
+        let parsedDecl = file.parseDeclaration(dict)!
+        let expectedDecl = "func f(a: Int,\n" +
+                           "       b: Int)"
+        XCTAssertEqual(parsedDecl, expectedDecl, "should preserve declaration alignment")
+    }
+
     func testGenerateDocumentedTokenOffsets() {
         let fileContents = "/// Comment\nlet global = 0"
         let syntaxMap = SyntaxMap(file: File(contents: fileContents))
@@ -204,6 +222,7 @@ extension StringTests {
             ("testAbsolutePath", testAbsolutePath),
             ("testIsTokenDocumentable", testIsTokenDocumentable),
             ("testParseDeclaration", testParseDeclaration),
+            ("testParseMultiLineDeclaration", testParseMultiLineDeclaration),
             ("testGenerateDocumentedTokenOffsets", testGenerateDocumentedTokenOffsets),
             ("testDocumentedTokenOffsetsWithSubscript", testDocumentedTokenOffsetsWithSubscript),
             ("testGenerateDocumentedTokenOffsetsEmpty", testGenerateDocumentedTokenOffsetsEmpty),


### PR DESCRIPTION
For something like:
```swift
class C {
    func ff(a: String,
            b: String) {
    }
}
```
...make sure the `key.parsed_declaration` looks like:
```swift
func ff(a: String,
        b: String)
```
...instead of (current):
```swift
func ff(a: String,
            b: String)
```

From eg. realm/jazzy#836.