### PR TITLE
Update SWXMLHash to 4.2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,7 @@ jobs:
       - run: make test|xcpretty -r junit
       - store_test_results:
           path: build/reports/
-      # Disable until the next version of SWXMLHash is released.
-      # - run: pod lib lint
+      - run: pod lib lint
 
   swiftpm_4.0.2:
     macos:

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Carthage/Commandant" "0.12.0"
 github "antitypical/Result" "3.2.3"
-github "drmohundro/SWXMLHash" "4.2.0"
+github "drmohundro/SWXMLHash" "4.2.5"
 github "jpsim/Yams" "0.4.1"
 github "jspahrsummers/xcconfigs" "4ac967d12f72c2ccc7f34d163268d09296923a7c"


### PR DESCRIPTION
~~This is a demonstration that SWXMLHash 4.2.4 is broken.~~
This is required for `pod lib lint` on Xcode 9.1.