### PR TITLE
Use `-derivedDataPath` on `testSourceKittenFrameworkDocsAreValidJSON`

### DIFF
--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -15,7 +15,13 @@ let projectRoot = #file.bridge()
     .deletingLastPathComponent.bridge()
     .deletingLastPathComponent
 
-let sourcekittenXcodebuildArguments = ["-workspace", "SourceKitten.xcworkspace", "-scheme", "SourceKittenFramework"]
+let sourcekittenXcodebuildArguments = [
+    "-workspace", "SourceKitten.xcworkspace",
+    "-scheme", "SourceKittenFramework",
+    "-derivedDataPath",
+    URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("testSourceKittenFrameworkDocsAreValidJSON").path
+]
 
 class ModuleTests: XCTestCase {
 


### PR DESCRIPTION
By applying this, intermediate files built during the current test session will be maintained before and after `testSourceKittenFrameworkDocsAreValidJSON()` execution, and the time to test re-execution will be shorter.