### PR TITLE
Deprecate `Request.failableSend()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 * SourceKitten now requires Xcode 9 and Swift 3.2+ to build.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* Deprecated `Request.send()`.  
+  [Norio Nomura](https://github.com/norio-nomura)
+
+* Some APIs changed to `throws`.  
+  * `File.format(trimmingTrailingWhitespace:useTabs:indentWidth:) throws`
+  * `Structure.init(file:) throws`
+  * `SyntaxMap.init(file:) throws`
+  [Norio Nomura](https://github.com/norio-nomura)
+
 ##### Enhancements
 
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * SourceKitten now requires Xcode 9 and Swift 3.2+ to build.  
   [Norio Nomura](https://github.com/norio-nomura)
 
-* Deprecated `Request.send()`.  
+* Deprecated `Request.send()`. Please use `Request.failableSend()` instead.  
   [Norio Nomura](https://github.com/norio-nomura)
 
 * Some APIs changed to `throws`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * SourceKitten now requires Xcode 9 and Swift 3.2+ to build.  
   [Norio Nomura](https://github.com/norio-nomura)
 
-* Deprecated `Request.send()`. Please use `Request.failableSend()` instead.  
+* Deprecated `Request.failableSend()`. Please use `Request.send()` instead.  
   [Norio Nomura](https://github.com/norio-nomura)
 
 * Some APIs changed to `throws`.  

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -218,12 +218,12 @@ extension CXCursor {
         }
 
         guard let cursorInfo = try? Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).failableSend() else {
-                return nil
+            return nil
         }
 
         if let annotatedDeclarationXML = cursorInfo[SwiftDocKey.annotatedDeclaration.rawValue] as? String,
-           let swiftDeclaration = SWXMLHash.parse(annotatedDeclarationXML).element?.recursiveText {
-                return swiftDeclaration
+            let swiftDeclaration = SWXMLHash.parse(annotatedDeclarationXML).element?.recursiveText {
+            return swiftDeclaration
         }
 
         return nil

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -204,15 +204,23 @@ extension CXCursor {
             swiftUUID = NSUUID().uuidString
             setUUIDString(uidString: swiftUUID, for: file)
             // Generate Swift interface, associating it with the UUID
-            _ = Request.interface(file: file, uuid: swiftUUID, arguments: compilerArguments).send()
+            do {
+                _ = try Request.interface(file: file, uuid: swiftUUID, arguments: compilerArguments).failableSend()
+            } catch {
+                return nil
+            }
         }
 
         guard let usr = usr(),
-              let usrOffset = Request.findUSR(file: swiftUUID, usr: usr).send()[SwiftDocKey.offset.rawValue] as? Int64 else {
+            let findUSR = try? Request.findUSR(file: swiftUUID, usr: usr).failableSend(),
+            let usrOffset = findUSR[SwiftDocKey.offset.rawValue] as? Int64 else {
             return nil
         }
 
-        let cursorInfo = Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).send()
+        guard let cursorInfo = try? Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).failableSend() else {
+                return nil
+        }
+
         if let annotatedDeclarationXML = cursorInfo[SwiftDocKey.annotatedDeclaration.rawValue] as? String,
            let swiftDeclaration = SWXMLHash.parse(annotatedDeclarationXML).element?.recursiveText {
                 return swiftDeclaration

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -205,19 +205,19 @@ extension CXCursor {
             setUUIDString(uidString: swiftUUID, for: file)
             // Generate Swift interface, associating it with the UUID
             do {
-                _ = try Request.interface(file: file, uuid: swiftUUID, arguments: compilerArguments).failableSend()
+                _ = try Request.interface(file: file, uuid: swiftUUID, arguments: compilerArguments).send()
             } catch {
                 return nil
             }
         }
 
         guard let usr = usr(),
-            let findUSR = try? Request.findUSR(file: swiftUUID, usr: usr).failableSend(),
+            let findUSR = try? Request.findUSR(file: swiftUUID, usr: usr).send(),
             let usrOffset = findUSR[SwiftDocKey.offset.rawValue] as? Int64 else {
             return nil
         }
 
-        guard let cursorInfo = try? Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).failableSend() else {
+        guard let cursorInfo = try? Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).send() else {
             return nil
         }
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -92,14 +92,14 @@ public final class File {
         guard let path = path else {
             return contents
         }
-        _ = try Request.editorOpen(file: self).failableSend()
+        _ = try Request.editorOpen(file: self).send()
         var newContents = [String]()
         var offset = 0
         for line in lines {
             let formatResponse = try Request.format(file: path,
                                                 line: Int64(line.index),
                                                 useTabs: useTabs,
-                                                indentWidth: Int64(indentWidth)).failableSend()
+                                                indentWidth: Int64(indentWidth)).send()
             let newText = formatResponse["key.sourcetext"] as! String
             newContents.append(newText)
 
@@ -108,7 +108,7 @@ public final class File {
             _ = try Request.replaceText(file: path,
                                     offset: Int64(line.byteRange.location + offset),
                                     length: Int64(line.byteRange.length - 1),
-                                    sourceText: newText).failableSend()
+                                    sourceText: newText).send()
             let oldLength = line.byteRange.length
             let newLength = newText.lengthOfBytes(using: .utf8)
             offset += 1 + newLength - oldLength

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -78,32 +78,37 @@ public final class File {
         lines = contents.bridge().lines()
     }
 
-    /**
-     Formats the file.
-     */
+    /// Formats the file.
+    ///
+    /// - Parameters:
+    ///   - trimmingTrailingWhitespace: Boolean
+    ///   - useTabs: Boolean
+    ///   - indentWidth: Int
+    /// - Returns: formatted String
+    /// - Throws: Request.Error
     public func format(trimmingTrailingWhitespace: Bool,
                        useTabs: Bool,
-                       indentWidth: Int) -> String {
+                       indentWidth: Int) throws -> String {
         guard let path = path else {
             return contents
         }
-        _ = Request.editorOpen(file: self).send()
+        _ = try Request.editorOpen(file: self).failableSend()
         var newContents = [String]()
         var offset = 0
         for line in lines {
-            let formatResponse = Request.format(file: path,
+            let formatResponse = try Request.format(file: path,
                                                 line: Int64(line.index),
                                                 useTabs: useTabs,
-                                                indentWidth: Int64(indentWidth)).send()
+                                                indentWidth: Int64(indentWidth)).failableSend()
             let newText = formatResponse["key.sourcetext"] as! String
             newContents.append(newText)
 
             guard newText != line.content else { continue }
 
-            _ = Request.replaceText(file: path,
+            _ = try Request.replaceText(file: path,
                                     offset: Int64(line.byteRange.location + offset),
                                     length: Int64(line.byteRange.length - 1),
-                                    sourceText: newText).send()
+                                    sourceText: newText).failableSend()
             let oldLength = line.byteRange.length
             let newLength = newText.lengthOfBytes(using: .utf8)
             offset += 1 + newLength - oldLength

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -366,6 +366,7 @@ public enum Request {
 
     - returns: SourceKit output as a dictionary.
     */
+    @available(*, deprecated, renamed: "failableSend()")
     public func send() -> [String: SourceKitRepresentable] {
         initializeSourceKit
         let response = sourcekitd_send_request_sync(sourcekitObject)

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -437,7 +437,7 @@ extension Request: CustomStringConvertible {
     public var description: String { return String(validatingUTF8: sourcekitd_request_description_copy(sourcekitObject)!)! }
 }
 
-private func interfaceForModule(_ module: String, compilerArguments: [String]) -> [String: SourceKitRepresentable] {
+private func interfaceForModule(_ module: String, compilerArguments: [String]) throws -> [String: SourceKitRepresentable] {
     var compilerargs = compilerArguments.map { sourcekitd_request_string_create($0) }
     let dict = [
         sourcekitd_uid_get_from_cstr("key.request")!: sourcekitd_request_uid_create(sourcekitd_uid_get_from_cstr("source.request.editor.open.interface")!),
@@ -447,7 +447,7 @@ private func interfaceForModule(_ module: String, compilerArguments: [String]) -
     ]
     var keys = Array(dict.keys.map({ $0 as sourcekitd_uid_t? }))
     var values = Array(dict.values)
-    return Request.customRequest(request: sourcekitd_request_dictionary_create(&keys, &values, dict.count)!).send()
+    return try Request.customRequest(request: sourcekitd_request_dictionary_create(&keys, &values, dict.count)!).failableSend()
 }
 
 extension String {
@@ -498,8 +498,8 @@ extension String {
     }
 }
 
-internal func libraryWrapperForModule(_ module: String, loadPath: String, linuxPath: String?, spmModule: String, compilerArguments: [String]) -> String {
-    let sourceKitResponse = interfaceForModule(module, compilerArguments: compilerArguments)
+internal func libraryWrapperForModule(_ module: String, loadPath: String, linuxPath: String?, spmModule: String, compilerArguments: [String]) throws -> String {
+    let sourceKitResponse = try interfaceForModule(module, compilerArguments: compilerArguments)
     let substructure = SwiftDocKey.getSubstructure(Structure(sourceKitResponse: sourceKitResponse).dictionary)!.map({ $0 as! [String: SourceKitRepresentable] })
     let source = sourceKitResponse["key.sourcetext"] as! String
     let freeFunctions = source.extractFreeFunctions(inSubstructure: substructure)

--- a/Source/SourceKittenFramework/Structure.swift
+++ b/Source/SourceKittenFramework/Structure.swift
@@ -31,7 +31,7 @@ public struct Structure {
     - throws: Request.Error
     */
     public init(file: File) throws {
-        self.init(sourceKitResponse: try Request.editorOpen(file: file).failableSend())
+        self.init(sourceKitResponse: try Request.editorOpen(file: file).send())
     }
 }
 

--- a/Source/SourceKittenFramework/Structure.swift
+++ b/Source/SourceKittenFramework/Structure.swift
@@ -28,9 +28,10 @@ public struct Structure {
     Initialize a Structure by passing in a File.
 
     - parameter file: File to parse for structural information.
+    - throws: Request.Error
     */
-    public init(file: File) {
-        self.init(sourceKitResponse: Request.editorOpen(file: file).send())
+    public init(file: File) throws {
+        self.init(sourceKitResponse: try Request.editorOpen(file: file).failableSend())
     }
 }
 

--- a/Source/SourceKittenFramework/SwiftDocs.swift
+++ b/Source/SourceKittenFramework/SwiftDocs.swift
@@ -29,7 +29,7 @@ public struct SwiftDocs {
         do {
             self.init(
                 file: file,
-                dictionary: try Request.editorOpen(file: file).failableSend(),
+                dictionary: try Request.editorOpen(file: file).send(),
                 cursorInfoRequest: Request.cursorInfoRequest(filePath: file.path, arguments: arguments)
             )
         } catch let error as Request.Error {

--- a/Source/SourceKittenFramework/SyntaxMap.swift
+++ b/Source/SourceKittenFramework/SyntaxMap.swift
@@ -50,7 +50,7 @@ public struct SyntaxMap {
     - throws: Request.Error
     */
     public init(file: File) throws {
-        self.init(sourceKitResponse: try Request.editorOpen(file: file).failableSend())
+        self.init(sourceKitResponse: try Request.editorOpen(file: file).send())
     }
 }
 

--- a/Source/SourceKittenFramework/SyntaxMap.swift
+++ b/Source/SourceKittenFramework/SyntaxMap.swift
@@ -47,9 +47,10 @@ public struct SyntaxMap {
     Create a SyntaxMap from a File to be parsed.
 
     - parameter file: File to be parsed.
+    - throws: Request.Error
     */
-    public init(file: File) {
-        self.init(sourceKitResponse: Request.editorOpen(file: file).send())
+    public init(file: File) throws {
+        self.init(sourceKitResponse: try Request.editorOpen(file: file).failableSend())
     }
 }
 

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -69,7 +69,7 @@ struct CompleteCommand: CommandProtocol {
             offset: Int64(options.offset),
             arguments: args)
         do {
-            print(CodeCompletionItem.parse(response: try request.failableSend()))
+            print(CodeCompletionItem.parse(response: try request.send()))
             return .success(())
         } catch {
             return .failure(.failed(error))

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -68,7 +68,11 @@ struct CompleteCommand: CommandProtocol {
         let request = Request.codeCompletionRequest(file: path, contents: contents,
             offset: Int64(options.offset),
             arguments: args)
-        print(CodeCompletionItem.parse(response: request.send()))
-        return .success(())
+        do {
+            print(CodeCompletionItem.parse(response: try request.failableSend()))
+            return .success(())
+        } catch {
+            return .failure(.failed(error))
+        }
     }
 }

--- a/Source/sourcekitten/Errors.swift
+++ b/Source/sourcekitten/Errors.swift
@@ -17,6 +17,9 @@ enum SourceKittenError: Error, CustomStringConvertible {
     /// Failed to generate documentation.
     case docFailed
 
+    /// failed with Error
+    case failed(Swift.Error)
+
     /// An error message corresponding to this error.
     var description: String {
         switch self {
@@ -26,6 +29,8 @@ enum SourceKittenError: Error, CustomStringConvertible {
             return "Failed to read file at '\(path)'"
         case .docFailed:
             return "Failed to generate documentation"
+        case let .failed(error):
+            return error.localizedDescription
         }
     }
 }

--- a/Source/sourcekitten/FormatCommand.swift
+++ b/Source/sourcekitten/FormatCommand.swift
@@ -40,12 +40,16 @@ struct FormatCommand: CommandProtocol {
         guard !options.file.isEmpty else {
             return .failure(.invalidArgument(description: "file must be set when calling format"))
         }
-        try! File(path: options.file)?
-            .format(trimmingTrailingWhitespace: options.trimWhitespace,
-                    useTabs: options.useTabs,
-                    indentWidth: options.indentWidth)
-            .data(using: .utf8)?
-            .write(to: URL(fileURLWithPath: options.file), options: [])
-        return .success(())
+        do {
+            try File(path: options.file)?
+                .format(trimmingTrailingWhitespace: options.trimWhitespace,
+                        useTabs: options.useTabs,
+                        indentWidth: options.indentWidth)
+                .data(using: .utf8)?
+                .write(to: URL(fileURLWithPath: options.file), options: [])
+            return .success(())
+        } catch {
+            return .failure(.failed(error))
+        }
     }
 }

--- a/Source/sourcekitten/IndexCommand.swift
+++ b/Source/sourcekitten/IndexCommand.swift
@@ -40,7 +40,7 @@ struct IndexCommand: CommandProtocol {
         let absoluteFile = options.file.bridge().absolutePathRepresentation()
         let request = Request.index(file: absoluteFile, arguments: options.compilerargs.components(separatedBy: " "))
         do {
-            print(toJSON(toNSDictionary(try request.failableSend())))
+            print(toJSON(toNSDictionary(try request.send())))
             return .success(())
         } catch {
             return .failure(.failed(error))

--- a/Source/sourcekitten/IndexCommand.swift
+++ b/Source/sourcekitten/IndexCommand.swift
@@ -39,7 +39,11 @@ struct IndexCommand: CommandProtocol {
         }
         let absoluteFile = options.file.bridge().absolutePathRepresentation()
         let request = Request.index(file: absoluteFile, arguments: options.compilerargs.components(separatedBy: " "))
-        print(toJSON(toNSDictionary(request.send())))
-        return .success(())
+        do {
+            print(toJSON(toNSDictionary(try request.failableSend())))
+            return .success(())
+        } catch {
+            return .failure(.failed(error))
+        }
     }
 }

--- a/Source/sourcekitten/StructureCommand.swift
+++ b/Source/sourcekitten/StructureCommand.swift
@@ -33,19 +33,23 @@ struct StructureCommand: CommandProtocol {
     }
 
     func run(_ options: Options) -> Result<(), SourceKittenError> {
-        if !options.file.isEmpty {
-            if let file = File(path: options.file) {
-                print(Structure(file: file))
+        do {
+            if !options.file.isEmpty {
+                if let file = File(path: options.file) {
+                    print(try Structure(file: file))
+                    return .success(())
+                }
+                return .failure(.readFailed(path: options.file))
+            }
+            if !options.text.isEmpty {
+                print(try Structure(file: File(contents: options.text)))
                 return .success(())
             }
-            return .failure(.readFailed(path: options.file))
+            return .failure(
+                .invalidArgument(description: "either file or text must be set when calling structure")
+            )
+        } catch {
+            return .failure(.failed(error))
         }
-        if !options.text.isEmpty {
-            print(Structure(file: File(contents: options.text)))
-            return .success(())
-        }
-        return .failure(
-            .invalidArgument(description: "either file or text must be set when calling structure")
-        )
     }
 }

--- a/Source/sourcekitten/SyntaxCommand.swift
+++ b/Source/sourcekitten/SyntaxCommand.swift
@@ -33,14 +33,18 @@ struct SyntaxCommand: CommandProtocol {
     }
 
     func run(_ options: Options) -> Result<(), SourceKittenError> {
-        if !options.file.isEmpty {
-            if let file = File(path: options.file) {
-                print(SyntaxMap(file: file))
-                return .success(())
+        do {
+            if !options.file.isEmpty {
+                if let file = File(path: options.file) {
+                    print(try SyntaxMap(file: file))
+                    return .success(())
+                }
+                return .failure(.readFailed(path: options.file))
             }
-            return .failure(.readFailed(path: options.file))
+            print(try SyntaxMap(file: File(contents: options.text)))
+            return .success(())
+        } catch {
+            return .failure(.failed(error))
         }
-        print(SyntaxMap(file: File(contents: options.text)))
-        return .success(())
     }
 }

--- a/Source/sourcekitten/YamlRequestCommand.swift
+++ b/Source/sourcekitten/YamlRequestCommand.swift
@@ -42,7 +42,7 @@ struct RequestCommand: CommandProtocol {
             }
 
             let request = Request.yamlRequest(yaml: yaml)
-            print(toJSON(toNSDictionary(try request.failableSend())))
+            print(toJSON(toNSDictionary(try request.send())))
             return .success(())
         } catch {
             return .failure(.failed(error))

--- a/Source/sourcekitten/YamlRequestCommand.swift
+++ b/Source/sourcekitten/YamlRequestCommand.swift
@@ -29,19 +29,23 @@ struct RequestCommand: CommandProtocol {
     }
 
     func run(_ options: Options) -> Result<(), SourceKittenError> {
-        if options.yaml.isEmpty {
-            return .failure(.invalidArgument(description: "yaml file or text must be provided"))
-        }
+        do {
+            if options.yaml.isEmpty {
+                return .failure(.invalidArgument(description: "yaml file or text must be provided"))
+            }
 
-        let yaml: String
-        if let file = File(path: options.yaml) {
-            yaml = file.contents
-        } else {
-            yaml = options.yaml
-        }
+            let yaml: String
+            if let file = File(path: options.yaml) {
+                yaml = file.contents
+            } else {
+                yaml = options.yaml
+            }
 
-        let request = Request.yamlRequest(yaml: yaml)
-        print(toJSON(toNSDictionary(request.send())))
-        return .success(())
+            let request = Request.yamlRequest(yaml: yaml)
+            print(toJSON(toNSDictionary(try request.failableSend())))
+            return .success(())
+        } catch {
+            return .failure(.failed(error))
+        }
     }
 }

--- a/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -15,8 +15,8 @@ class CodeCompletionTests: XCTestCase {
     func testSimpleCodeCompletion() {
         let file = "\(NSUUID().uuidString).swift"
         let completionItems = CodeCompletionItem.parse(response:
-            Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
-                arguments: ["-c", file, "-sdk", sdkPath()]).send())
+            try! Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
+                arguments: ["-c", file, "-sdk", sdkPath()]).failableSend())
         compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
                           jsonString: completionItems)
     }

--- a/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -16,7 +16,7 @@ class CodeCompletionTests: XCTestCase {
         let file = "\(NSUUID().uuidString).swift"
         let completionItems = CodeCompletionItem.parse(response:
             try! Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
-                arguments: ["-c", file, "-sdk", sdkPath()]).failableSend())
+                                               arguments: ["-c", file, "-sdk", sdkPath()]).failableSend())
         compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
                           jsonString: completionItems)
     }

--- a/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -16,7 +16,7 @@ class CodeCompletionTests: XCTestCase {
         let file = "\(NSUUID().uuidString).swift"
         let completionItems = CodeCompletionItem.parse(response:
             try! Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
-                                               arguments: ["-c", file, "-sdk", sdkPath()]).failableSend())
+                                               arguments: ["-c", file, "-sdk", sdkPath()]).send())
         compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
                           jsonString: completionItems)
     }

--- a/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
+++ b/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
@@ -16,8 +16,8 @@ class DocInfoTests: XCTestCase {
     func testDocInfoRequest() {
         let swiftFile = File(path: fixturesDirectory + "DocInfo.swift")!
         let info = toNSDictionary(
-            Request.docInfo(text: swiftFile.contents,
-                            arguments: ["-sdk", sdkPath()]).send()
+            try! Request.docInfo(text: swiftFile.contents,
+                            arguments: ["-sdk", sdkPath()]).failableSend()
         )
         compareJSONString(withFixtureNamed: "DocInfo", jsonString: toJSON(info))
     }
@@ -25,12 +25,12 @@ class DocInfoTests: XCTestCase {
     func testModuleInfoRequest() {
         let swiftFile = fixturesDirectory + "DocInfo.swift"
         let info = toNSDictionary(
-            Request.moduleInfo(module: "",
+            try! Request.moduleInfo(module: "",
                                arguments: [
                                    "-c", swiftFile,
                                    "-module-name", "DocInfo",
                                    "-sdk", sdkPath()
-                                ]).send()
+                                ]).failableSend()
         )
         compareJSONString(withFixtureNamed: "ModuleInfo", jsonString: toJSON(info))
     }

--- a/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
+++ b/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
@@ -16,8 +16,7 @@ class DocInfoTests: XCTestCase {
     func testDocInfoRequest() {
         let swiftFile = File(path: fixturesDirectory + "DocInfo.swift")!
         let info = toNSDictionary(
-            try! Request.docInfo(text: swiftFile.contents,
-                            arguments: ["-sdk", sdkPath()]).failableSend()
+            try! Request.docInfo(text: swiftFile.contents, arguments: ["-sdk", sdkPath()]).failableSend()
         )
         compareJSONString(withFixtureNamed: "DocInfo", jsonString: toJSON(info))
     }
@@ -26,11 +25,11 @@ class DocInfoTests: XCTestCase {
         let swiftFile = fixturesDirectory + "DocInfo.swift"
         let info = toNSDictionary(
             try! Request.moduleInfo(module: "",
-                               arguments: [
-                                   "-c", swiftFile,
-                                   "-module-name", "DocInfo",
-                                   "-sdk", sdkPath()
-                                ]).failableSend()
+                                    arguments: [
+                                        "-c", swiftFile,
+                                        "-module-name", "DocInfo",
+                                        "-sdk", sdkPath()
+                                    ]).failableSend()
         )
         compareJSONString(withFixtureNamed: "ModuleInfo", jsonString: toJSON(info))
     }

--- a/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
+++ b/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
@@ -16,7 +16,7 @@ class DocInfoTests: XCTestCase {
     func testDocInfoRequest() {
         let swiftFile = File(path: fixturesDirectory + "DocInfo.swift")!
         let info = toNSDictionary(
-            try! Request.docInfo(text: swiftFile.contents, arguments: ["-sdk", sdkPath()]).failableSend()
+            try! Request.docInfo(text: swiftFile.contents, arguments: ["-sdk", sdkPath()]).send()
         )
         compareJSONString(withFixtureNamed: "DocInfo", jsonString: toJSON(info))
     }
@@ -29,7 +29,7 @@ class DocInfoTests: XCTestCase {
                                         "-c", swiftFile,
                                         "-module-name", "DocInfo",
                                         "-sdk", sdkPath()
-                                    ]).failableSend()
+                ]).send()
         )
         compareJSONString(withFixtureNamed: "ModuleInfo", jsonString: toJSON(info))
     }

--- a/Tests/SourceKittenFrameworkTests/FileTests.swift
+++ b/Tests/SourceKittenFrameworkTests/FileTests.swift
@@ -17,9 +17,7 @@ class FileTests: XCTestCase {
 
     func testFormat() {
         let file = File(path: fixturesDirectory + "BicycleUnformatted.swift")
-        let formattedFile = try! file?.format(trimmingTrailingWhitespace: true,
-                                         useTabs: false,
-                                         indentWidth: 4)
+        let formattedFile = try! file?.format(trimmingTrailingWhitespace: true, useTabs: false, indentWidth: 4)
         XCTAssertEqual(formattedFile!, try! String(contentsOfFile: fixturesDirectory + "Bicycle.swift", encoding: .utf8))
     }
 }

--- a/Tests/SourceKittenFrameworkTests/FileTests.swift
+++ b/Tests/SourceKittenFrameworkTests/FileTests.swift
@@ -17,7 +17,7 @@ class FileTests: XCTestCase {
 
     func testFormat() {
         let file = File(path: fixturesDirectory + "BicycleUnformatted.swift")
-        let formattedFile = file?.format(trimmingTrailingWhitespace: true,
+        let formattedFile = try! file?.format(trimmingTrailingWhitespace: true,
                                          useTabs: false,
                                          indentWidth: 4)
         XCTAssertEqual(formattedFile!, try! String(contentsOfFile: fixturesDirectory + "Bicycle.swift", encoding: .utf8))

--- a/Tests/SourceKittenFrameworkTests/OffsetMapTests.swift
+++ b/Tests/SourceKittenFrameworkTests/OffsetMapTests.swift
@@ -19,7 +19,7 @@ class OffsetMapTests: XCTestCase {
             "get { return () }\nset {}\n}\n}"
         )
         let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: try! SyntaxMap(file: file))
-        let response = file.process(dictionary: try! Request.editorOpen(file: file).failableSend(), cursorInfoRequest: nil)
+        let response = file.process(dictionary: try! Request.editorOpen(file: file).send(), cursorInfoRequest: nil)
         let offsetMap = file.makeOffsetMap(documentedTokenOffsets: documentedTokenOffsets, dictionary: response)
         XCTAssertEqual(offsetMap, [46: 7], "should generate correct offset map of [(declaration offset): (parent offset)]")
     }
@@ -28,7 +28,7 @@ class OffsetMapTests: XCTestCase {
         // Struct declarations are parsed by SourceKit, so OffsetMap shouldn't contain its offset.
         let file = File(contents: "/// Doc Comment\nstruct DocumentedStruct {}")
         let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: try! SyntaxMap(file: file))
-        let response = file.process(dictionary: try! Request.editorOpen(file: file).failableSend(), cursorInfoRequest: nil)
+        let response = file.process(dictionary: try! Request.editorOpen(file: file).send(), cursorInfoRequest: nil)
         let offsetMap = file.makeOffsetMap(documentedTokenOffsets: documentedTokenOffsets, dictionary: response)
         XCTAssertEqual(offsetMap, [:], "should generate empty offset map")
     }

--- a/Tests/SourceKittenFrameworkTests/OffsetMapTests.swift
+++ b/Tests/SourceKittenFrameworkTests/OffsetMapTests.swift
@@ -18,8 +18,8 @@ class OffsetMapTests: XCTestCase {
             "struct VoidStruct {\n/// Returns or sets Void.\nsubscript(key: String) -> () {\n" +
             "get { return () }\nset {}\n}\n}"
         )
-        let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: SyntaxMap(file: file))
-        let response = file.process(dictionary: Request.editorOpen(file: file).send(), cursorInfoRequest: nil)
+        let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: try! SyntaxMap(file: file))
+        let response = file.process(dictionary: try! Request.editorOpen(file: file).failableSend(), cursorInfoRequest: nil)
         let offsetMap = file.makeOffsetMap(documentedTokenOffsets: documentedTokenOffsets, dictionary: response)
         XCTAssertEqual(offsetMap, [46: 7], "should generate correct offset map of [(declaration offset): (parent offset)]")
     }
@@ -27,8 +27,8 @@ class OffsetMapTests: XCTestCase {
     func testOffsetMapDoesntContainAlreadyDocumentedDeclarationOffset() {
         // Struct declarations are parsed by SourceKit, so OffsetMap shouldn't contain its offset.
         let file = File(contents: "/// Doc Comment\nstruct DocumentedStruct {}")
-        let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: SyntaxMap(file: file))
-        let response = file.process(dictionary: Request.editorOpen(file: file).send(), cursorInfoRequest: nil)
+        let documentedTokenOffsets = file.contents.documentedTokenOffsets(syntaxMap: try! SyntaxMap(file: file))
+        let response = file.process(dictionary: try! Request.editorOpen(file: file).failableSend(), cursorInfoRequest: nil)
         let offsetMap = file.makeOffsetMap(documentedTokenOffsets: documentedTokenOffsets, dictionary: response)
         XCTAssertEqual(offsetMap, [:], "should generate empty offset map")
     }

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -184,7 +184,7 @@ class SourceKitTests: XCTestCase {
     func testIndex() {
         let file = "\(fixturesDirectory)Bicycle.swift"
         let arguments = ["-sdk", sdkPath(), "-j4", file ]
-        let indexJSON = NSMutableString(string: toJSON(toNSDictionary(try! Request.index(file: file, arguments: arguments).failableSend())) + "\n")
+        let indexJSON = NSMutableString(string: toJSON(toNSDictionary(try! Request.index(file: file, arguments: arguments).send())) + "\n")
 
         func replace(_ pattern: String, withTemplate template: String) {
             let regex = try! NSRegularExpression(pattern: pattern, options: [])
@@ -203,7 +203,7 @@ class SourceKitTests: XCTestCase {
     func testYamlRequest() {
         let path = fixturesDirectory + "Subscript.swift"
         let yaml = "key.request: source.request.editor.open\nkey.name: \"\(path)\"\nkey.sourcefile: \"\(path)\""
-        let output = try! Request.yamlRequest(yaml: yaml).failableSend()
+        let output = try! Request.yamlRequest(yaml: yaml).send()
         let expectedStructure = try! Structure(file: File(path: path)!)
         let actualStructure = Structure(sourceKitResponse: output)
         XCTAssertEqual(expectedStructure, actualStructure)

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -171,7 +171,7 @@ class SourceKitTests: XCTestCase {
         for (module, path, linuxPath, spmModule) in modules {
             let wrapperPath = "\(projectRoot)/Source/SourceKittenFramework/library_wrapper_\(module).swift"
             let existingWrapper = try! String(contentsOfFile: wrapperPath)
-            let generatedWrapper = libraryWrapperForModule(module, loadPath: path, linuxPath: linuxPath, spmModule: spmModule,
+            let generatedWrapper = try! libraryWrapperForModule(module, loadPath: path, linuxPath: linuxPath, spmModule: spmModule,
                                                            compilerArguments: sourceKittenFrameworkModule.compilerArguments)
             XCTAssertEqual(existingWrapper, generatedWrapper)
             let overwrite = false // set this to true to overwrite existing wrappers with the generated ones
@@ -184,7 +184,7 @@ class SourceKitTests: XCTestCase {
     func testIndex() {
         let file = "\(fixturesDirectory)Bicycle.swift"
         let arguments = ["-sdk", sdkPath(), "-j4", file ]
-        let indexJSON = NSMutableString(string: toJSON(toNSDictionary(Request.index(file: file, arguments: arguments).send())) + "\n")
+        let indexJSON = NSMutableString(string: toJSON(toNSDictionary(try! Request.index(file: file, arguments: arguments).failableSend())) + "\n")
 
         func replace(_ pattern: String, withTemplate template: String) {
             let regex = try! NSRegularExpression(pattern: pattern, options: [])
@@ -203,8 +203,8 @@ class SourceKitTests: XCTestCase {
     func testYamlRequest() {
         let path = fixturesDirectory + "Subscript.swift"
         let yaml = "key.request: source.request.editor.open\nkey.name: \"\(path)\"\nkey.sourcefile: \"\(path)\""
-        let output = Request.yamlRequest(yaml: yaml).send()
-        let expectedStructure = Structure(file: File(path: path)!)
+        let output = try! Request.yamlRequest(yaml: yaml).failableSend()
+        let expectedStructure = try! Structure(file: File(path: path)!)
         let actualStructure = Structure(sourceKitResponse: output)
         XCTAssertEqual(expectedStructure, actualStructure)
     }

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -86,7 +86,7 @@ class StringTests: XCTestCase {
 
     func testIsTokenDocumentable() {
         let source = "struct A { subscript(key: String) -> Void { return () } }"
-        let actual = SyntaxMap(file: File(contents: source)).tokens.filter(source.isTokenDocumentable)
+        let actual = try! SyntaxMap(file: File(contents: source)).tokens.filter(source.isTokenDocumentable)
         let expected = [
             SyntaxToken(type: SyntaxKind.identifier.rawValue, offset: 7, length: 1), // `A`
             SyntaxToken(type: SyntaxKind.keyword.rawValue, offset: 11, length: 9),   // `subscript`
@@ -128,19 +128,19 @@ class StringTests: XCTestCase {
 
     func testGenerateDocumentedTokenOffsets() {
         let fileContents = "/// Comment\nlet global = 0"
-        let syntaxMap = SyntaxMap(file: File(contents: fileContents))
+        let syntaxMap = try! SyntaxMap(file: File(contents: fileContents))
         XCTAssertEqual(fileContents.documentedTokenOffsets(syntaxMap: syntaxMap), [16], "should generate documented token offsets")
     }
 
     func testDocumentedTokenOffsetsWithSubscript() {
         let file = File(path: fixturesDirectory + "Subscript.swift")!
-        let syntaxMap = SyntaxMap(file: file)
+        let syntaxMap = try! SyntaxMap(file: file)
         XCTAssertEqual(file.contents.documentedTokenOffsets(syntaxMap: syntaxMap), [54], "should generate documented token offsets")
     }
 
     func testGenerateDocumentedTokenOffsetsEmpty() {
         let fileContents = "// Comment\nlet global = 0"
-        let syntaxMap = SyntaxMap(file: File(contents: fileContents))
+        let syntaxMap = try! SyntaxMap(file: File(contents: fileContents))
         XCTAssertEqual(fileContents.documentedTokenOffsets(syntaxMap: syntaxMap).count, 0, "shouldn't detect any documented token offsets when there are none")
     }
 

--- a/Tests/SourceKittenFrameworkTests/StructureTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StructureTests.swift
@@ -19,19 +19,19 @@ class StructureTests: XCTestCase {
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
             "key.substructure": []
         ]
-        let structure = Structure(file: File(contents: ""))
+        let structure = try! Structure(file: File(contents: ""))
         XCTAssertEqual(toNSDictionary(structure.dictionary), expected, "should generate expected structure")
     }
 
     func testGenerateSameStructureFileAndContents() {
         let fileContents = try! String(contentsOfFile: #file, encoding: .utf8)
-        XCTAssertEqual(Structure(file: File(path: #file)!),
+        try! XCTAssertEqual(Structure(file: File(path: #file)!),
             Structure(file: File(contents: fileContents)),
             "should generate the same structure for a file as raw text")
     }
 
     func testEnum() {
-        let structure = Structure(file: File(contents: "enum MyEnum { case First }"))
+        let structure = try! Structure(file: File(contents: "enum MyEnum { case First }"))
         let expectedStructure: NSDictionary = [
             "key.substructure": [
                 [
@@ -74,7 +74,7 @@ class StructureTests: XCTestCase {
     }
 
     func testStructurePrintValidJSON() {
-        let structure = Structure(file: File(contents: "struct A { func b() {} }"))
+        let structure = try! Structure(file: File(contents: "struct A { func b() {} }"))
         let expectedStructure: NSDictionary = [
             "key.substructure": [
                 [

--- a/Tests/SourceKittenFrameworkTests/SyntaxTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SyntaxTests.swift
@@ -16,7 +16,7 @@ private func compareSyntax(file: File, expectedTokens: [TokenWrapper]) {
     let expectedSyntaxMap = SyntaxMap(tokens: expectedTokens.map { tokenWrapper in
         return SyntaxToken(type: tokenWrapper.kind.rawValue, offset: tokenWrapper.offset, length: tokenWrapper.length)
     })
-    let syntaxMap = SyntaxMap(file: file)
+    let syntaxMap = try! SyntaxMap(file: file)
     XCTAssertEqual(syntaxMap, expectedSyntaxMap, "should generate expected syntax map")
 
     let syntaxJSONData = syntaxMap.description.data(using: .utf8)!
@@ -31,12 +31,12 @@ private func compareSyntax(file: File, expectedTokens: [TokenWrapper]) {
 class SyntaxTests: XCTestCase {
 
     func testPrintEmptySyntax() {
-        XCTAssertEqual(SyntaxMap(file: File(contents: "")).description, "[\n\n]", "should print empty syntax")
+        XCTAssertEqual(try! SyntaxMap(file: File(contents: "")).description, "[\n\n]", "should print empty syntax")
     }
 
     func testGenerateSameSyntaxMapFileAndContents() {
         let fileContents = try! String(contentsOfFile: #file, encoding: .utf8)
-        XCTAssertEqual(SyntaxMap(file: File(path: #file)!),
+        try! XCTAssertEqual(SyntaxMap(file: File(path: #file)!),
             SyntaxMap(file: File(contents: fileContents)),
             "should generate the same syntax map for a file as raw text")
     }


### PR DESCRIPTION
~~Use `Request.failableSend()` instead of `Request.send()`~~
Change `Request.send()` to `throws`

Some APIs changed to `throws`:
* `File.format(trimmingTrailingWhitespace:useTabs:indentWidth:) throws`
* `Structure.init(file:) throws`
* `SyntaxMap.init(file:) throws`