### PR TITLE
Fix generic Swift declaration generation from ObjC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix Swift declarations when generating Objective-C docs for generic types.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.18.4
 

--- a/Source/SourceKittenFramework/Clang+SourceKitten.swift
+++ b/Source/SourceKittenFramework/Clang+SourceKitten.swift
@@ -212,21 +212,9 @@ extension CXCursor {
             return nil
         }
 
-        // SourceKit with Xcode 9+ doesn't escape ampersands in its XML output, so let's sanitize the XML ourselves.
-        func fixAmpersandInXML(_ xml: String) -> String {
-            return xml.replacingOccurrences(of: " & ", with: " &amp; ")
-        }
-
         let cursorInfo = Request.cursorInfo(file: swiftUUID, offset: usrOffset, arguments: compilerArguments).send()
-        if let docsXML = cursorInfo[SwiftDocKey.fullXMLDocs.rawValue] as? String,
-            case let fixedDocsXML = fixAmpersandInXML(docsXML),
-           let swiftDeclaration = SWXMLHash.parse(fixedDocsXML).children.first?["Declaration"].element?.text {
-                return swiftDeclaration
-        }
-
         if let annotatedDeclarationXML = cursorInfo[SwiftDocKey.annotatedDeclaration.rawValue] as? String,
-            case let fixedAnnotatedDeclarationXML = fixAmpersandInXML(annotatedDeclarationXML),
-           let swiftDeclaration = SWXMLHash.parse(fixedAnnotatedDeclarationXML).element?.recursiveText {
+           let swiftDeclaration = SWXMLHash.parse(annotatedDeclarationXML).element?.recursiveText {
                 return swiftDeclaration
         }
 

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Realm@swift-3.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Realm@swift-3.2.json
@@ -838,7 +838,7 @@
               "key.usr" : "c:objc(cs)RLMArray(cm)new"
             }
           ],
-          "key.swift_declaration" : "class RLMArray",
+          "key.swift_declaration" : "class RLMArray<RLMObjectType> : NSObject, RLMCollection, NSFastEnumeration where RLMObjectType : RLMObject",
           "key.unavailable_message" : "",
           "key.usr" : "c:objc(cs)RLMArray"
         },
@@ -5487,7 +5487,7 @@
               "key.parsed_declaration" : "- (nonnull RLMResults<RLMObjectType> *)objectsWithPredicate:\n    (nonnull NSPredicate *)predicate;",
               "key.parsed_scope.end" : 132,
               "key.parsed_scope.start" : 132,
-              "key.swift_declaration" : "func objects(with predicate: NSPredicate) -> RLMResults",
+              "key.swift_declaration" : "func objects(with predicate: NSPredicate) -> RLMResults<RLMObjectType>",
               "key.unavailable_message" : "",
               "key.usr" : "c:objc(cs)RLMResults(im)objectsWithPredicate:"
             },
@@ -5532,7 +5532,7 @@
               "key.parsed_declaration" : "- (nonnull RLMResults<RLMObjectType> *)\nsortedResultsUsingProperty:(nonnull NSString *)property\n                 ascending:(BOOL)ascending;",
               "key.parsed_scope.end" : 142,
               "key.parsed_scope.start" : 142,
-              "key.swift_declaration" : "func sortedResults(usingProperty property: String, ascending: Bool) -> RLMResults",
+              "key.swift_declaration" : "func sortedResults(usingProperty property: String, ascending: Bool) -> RLMResults<RLMObjectType>",
               "key.unavailable_message" : "",
               "key.usr" : "c:objc(cs)RLMResults(im)sortedResultsUsingProperty:ascending:"
             },
@@ -5568,7 +5568,7 @@
               "key.parsed_declaration" : "- (nonnull RLMResults<RLMObjectType> *)sortedResultsUsingDescriptors:\n    (nonnull NSArray *)properties;",
               "key.parsed_scope.end" : 151,
               "key.parsed_scope.start" : 151,
-              "key.swift_declaration" : "func sortedResults(usingDescriptors properties: [Any]) -> RLMResults",
+              "key.swift_declaration" : "func sortedResults(usingDescriptors properties: [Any]) -> RLMResults<RLMObjectType>",
               "key.unavailable_message" : "",
               "key.usr" : "c:objc(cs)RLMResults(im)sortedResultsUsingDescriptors:"
             },
@@ -5790,7 +5790,7 @@
               "key.usr" : "c:objc(cs)RLMResults(cm)new"
             }
           ],
-          "key.swift_declaration" : "class RLMResults",
+          "key.swift_declaration" : "class RLMResults<RLMObjectType> : NSObject, RLMCollection, NSFastEnumeration where RLMObjectType : RLMObject",
           "key.unavailable_message" : "",
           "key.usr" : "c:objc(cs)RLMResults"
         }


### PR DESCRIPTION
Spotted by a patient jazzy user in realm/jazzy#910.  When SourceKit produces the full_as_xml as part of a cursorinfo request for a decl *imported from ObjC*, it forgets to XML-escape the ‘Declaration’.  SourceKitten had a fix for ‘&’ but not ‘<’ ‘>’ (generics) - causes truncation of the Swift decl.

This PR changes SourceKitten to always use the annotated_declaration_xml instead of trying to work around the Swift bug -- this XML is generated using different code that has always been escaped properly.  For ObjC, the contents of the two declarations are identical.

Testcase change show Realm ObjC was suffering from this -- various generic declarations missing pieces in Swift.
