### PR TITLE
Fix test failures on Linux/Swift 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 * Fix Swift declarations when generating Objective-C docs for generic types.  
   [John Fairhurst](https://github.com/johnfairh)
+* Test suite now runs without failures on Linux and the Swift 4.0 toolchain.  
+  [Alexander Lash](https://github.com/abl)
 
 ## 0.18.4
 

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -261,9 +261,12 @@ public enum Request {
             if !arguments.contains("-x") {
                 arguments.append(contentsOf: ["-x", "objective-c"])
             }
+            #if os(Linux)
+            #else
             if !arguments.contains("-isysroot") {
                 arguments.append(contentsOf: ["-isysroot", sdkPath()])
             }
+            #endif
             var compilerargs = ([file] + arguments).map({ sourcekitd_request_string_create($0) })
             dict = [
                 sourcekitd_uid_get_from_cstr("key.request")!:

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -156,6 +156,9 @@ public func parseHeaderFilesAndXcodebuildArguments(sourcekittenArguments: [Strin
     return (headerFiles, xcodebuildArguments)
 }
 
+#if os(Linux)
+/// This function should never be called on Linux.
+#else
 public func sdkPath() -> String {
     let task = Process()
     task.launchPath = "/usr/bin/xcrun"
@@ -171,3 +174,4 @@ public func sdkPath() -> String {
     file.closeFile()
     return sdkPath?.replacingOccurrences(of: "\n", with: "") ?? ""
 }
+#endif

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -55,9 +55,12 @@ struct CompleteCommand: CommandProtocol {
         var args: [String]
         if options.spmModule.isEmpty {
             args = ["-c", path] + options.compilerargs
+            #if os(Linux)
+            #else
             if args.index(of: "-sdk") == nil {
                 args.append(contentsOf: ["-sdk", sdkPath()])
             }
+            #endif
         } else {
             guard let module = Module(spmName: options.spmModule) else {
                 return .failure(.invalidArgument(description: "Bad module name"))

--- a/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
+++ b/Tests/SourceKittenFrameworkTests/CodeCompletionTests.swift
@@ -14,9 +14,14 @@ class CodeCompletionTests: XCTestCase {
 
     func testSimpleCodeCompletion() {
         let file = "\(NSUUID().uuidString).swift"
+        #if os(Linux)
+        let arguments = ["-c", file]
+        #else
+        let arguments = ["-c", file, "-sdk", sdkPath()]
+        #endif
         let completionItems = CodeCompletionItem.parse(response:
             try! Request.codeCompletionRequest(file: file, contents: "0.", offset: 2,
-                                               arguments: ["-c", file, "-sdk", sdkPath()]).send())
+                                               arguments: arguments).send())
         compareJSONString(withFixtureNamed: "SimpleCodeCompletion",
                           jsonString: completionItems)
     }

--- a/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
+++ b/Tests/SourceKittenFrameworkTests/DocInfoTests.swift
@@ -10,13 +10,19 @@ import Foundation
 import SourceKittenFramework
 import XCTest
 
+#if os(Linux)
+let sdkArgs: [String] = []
+#else
+let sdkArgs = ["-sdk", sdkPath()]
+#endif
+
 class DocInfoTests: XCTestCase {
 
     /// Validates that various doc string formats are parsed correctly.
     func testDocInfoRequest() {
         let swiftFile = File(path: fixturesDirectory + "DocInfo.swift")!
         let info = toNSDictionary(
-            try! Request.docInfo(text: swiftFile.contents, arguments: ["-sdk", sdkPath()]).send()
+            try! Request.docInfo(text: swiftFile.contents, arguments: sdkArgs).send()
         )
         compareJSONString(withFixtureNamed: "DocInfo", jsonString: toJSON(info))
     }
@@ -27,9 +33,8 @@ class DocInfoTests: XCTestCase {
             try! Request.moduleInfo(module: "",
                                     arguments: [
                                         "-c", swiftFile,
-                                        "-module-name", "DocInfo",
-                                        "-sdk", sdkPath()
-                ]).send()
+                                        "-module-name", "DocInfo"
+                ] + sdkArgs).send()
         )
         compareJSONString(withFixtureNamed: "ModuleInfo", jsonString: toJSON(info))
     }

--- a/Tests/SourceKittenFrameworkTests/Fixtures/DocInfo@swift-4.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/DocInfo@swift-4.0.json
@@ -1,0 +1,207 @@
+{
+  "key.annotations": [
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 35,
+      "key.offset": 1
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 36
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 23,
+      "key.offset": 41
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 45,
+      "key.offset": 72
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 118
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 22,
+      "key.offset": 123
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 153
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 16,
+      "key.offset": 158
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.comment",
+      "key.length": 36,
+      "key.offset": 182
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 218
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 27,
+      "key.offset": 223
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.comment",
+      "key.length": 73,
+      "key.offset": 258
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 335
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 36,
+      "key.offset": 340
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 24,
+      "key.offset": 385
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 6,
+      "key.offset": 409
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 16,
+      "key.offset": 416
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 27,
+      "key.offset": 437
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 3,
+      "key.offset": 466
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 1,
+      "key.offset": 470
+    },
+    {
+      "key.kind": "source.lang.swift.ref.struct",
+      "key.length": 6,
+      "key.name": "String",
+      "key.offset": 473,
+      "key.usr": "s:SS"
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 40,
+      "key.offset": 483
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.attribute.builtin",
+      "key.length": 11,
+      "key.offset": 526
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.keyword",
+      "key.length": 4,
+      "key.offset": 538
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.identifier",
+      "key.length": 20,
+      "key.offset": 543
+    },
+    {
+      "key.kind": "source.lang.swift.syntaxtype.doccomment",
+      "key.length": 41,
+      "key.offset": 575
+    }
+  ],
+  "key.entities": [
+    {
+      "key.doc.full_as_xml": "<Function file=\"&lt;input&gt;\" line=\"3\" column=\"6\"><Name>singleLineCommentedFunc()</Name><USR>s:8__main__23singleLineCommentedFuncyyF</USR><Declaration>func singleLineCommentedFunc()</Declaration><CommentParts><Abstract><Para>Single line commented function</Para></Abstract></CommentParts></Function>",
+      "key.fully_annotated_decl": "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>singleLineCommentedFunc</decl.name>()</decl.function.free>",
+      "key.kind": "source.lang.swift.decl.function.free",
+      "key.length": 33,
+      "key.name": "singleLineCommentedFunc()",
+      "key.offset": 36,
+      "key.usr": "s:8__main__23singleLineCommentedFuncyyF"
+    },
+    {
+      "key.doc.full_as_xml": "<Function file=\"&lt;input&gt;\" line=\"10\" column=\"6\"><Name>multiLineCommentedFunc()</Name><USR>s:8__main__22multiLineCommentedFuncyyF</USR><Declaration>func multiLineCommentedFunc()</Declaration><CommentParts><Abstract><Para>Multiple line commented function.</Para></Abstract><Discussion><List-Bullet><Item></Item></List-Bullet></Discussion></CommentParts></Function>",
+      "key.fully_annotated_decl": "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>multiLineCommentedFunc</decl.name>()</decl.function.free>",
+      "key.kind": "source.lang.swift.decl.function.free",
+      "key.length": 32,
+      "key.name": "multiLineCommentedFunc()",
+      "key.offset": 118,
+      "key.usr": "s:8__main__22multiLineCommentedFuncyyF"
+    },
+    {
+      "key.fully_annotated_decl": "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>undocumentedFunc</decl.name>()</decl.function.free>",
+      "key.kind": "source.lang.swift.decl.function.free",
+      "key.length": 26,
+      "key.name": "undocumentedFunc()",
+      "key.offset": 153,
+      "key.usr": "s:8__main__16undocumentedFuncyyF"
+    },
+    {
+      "key.fully_annotated_decl": "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonDocCommentDocumentedFunc</decl.name>()</decl.function.free>",
+      "key.kind": "source.lang.swift.decl.function.free",
+      "key.length": 37,
+      "key.name": "nonDocCommentDocumentedFunc()",
+      "key.offset": 218,
+      "key.usr": "s:8__main__27nonDocCommentDocumentedFuncyyF"
+    },
+    {
+      "key.fully_annotated_decl": "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonDocCommentMultiLineDocumentedFunc</decl.name>()</decl.function.free>",
+      "key.kind": "source.lang.swift.decl.function.free",
+      "key.length": 46,
+      "key.name": "nonDocCommentMultiLineDocumentedFunc()",
+      "key.offset": 335,
+      "key.usr": "s:8__main__36nonDocCommentMultiLineDocumentedFuncyyF"
+    },
+    {
+      "key.doc.full_as_xml": "<Class file=\"&lt;input&gt;\" line=\"28\" column=\"8\"><Name>DocumentedStruct</Name><USR>s:8__main__16DocumentedStructV</USR><Declaration>struct DocumentedStruct</Declaration><CommentParts><Abstract><Para>A documented struct</Para></Abstract></CommentParts></Class>",
+      "key.entities": [
+        {
+          "key.doc.full_as_xml": "<Other file=\"&lt;input&gt;\" line=\"30\" column=\"7\"><Name>x</Name><USR>s:8__main__16DocumentedStructV1xSSv</USR><Declaration>let x: String</Declaration><CommentParts><Abstract><Para>A documented variable.</Para></Abstract></CommentParts></Other>",
+          "key.fully_annotated_decl": "<decl.var.instance><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.type></decl.var.instance>",
+          "key.kind": "source.lang.swift.decl.var.instance",
+          "key.name": "x",
+          "key.usr": "s:8__main__16DocumentedStructV1xSSv"
+        },
+        {
+          "key.doc.full_as_xml": "<Function file=\"&lt;input&gt;\" line=\"35\" column=\"20\"><Name>documentedMemberFunc()</Name><USR>s:8__main__16DocumentedStructV20documentedMemberFunc33_CA696DCD7D5B495305F0AFDD52B692B7LLyyF</USR><Declaration>fileprivate func documentedMemberFunc()</Declaration><CommentParts><Abstract><Para>A documented member func.</Para></Abstract></CommentParts></Function>",
+          "key.fully_annotated_decl": "<decl.function.method.instance><syntaxtype.keyword>fileprivate</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>documentedMemberFunc</decl.name>()</decl.function.method.instance>",
+          "key.kind": "source.lang.swift.decl.function.method.instance",
+          "key.length": 32,
+          "key.name": "documentedMemberFunc()",
+          "key.offset": 538,
+          "key.usr": "s:8__main__16DocumentedStructV20documentedMemberFunc33_CA696DCD7D5B495305F0AFDD52B692B7LLyyF"
+        }
+      ],
+      "key.fully_annotated_decl": "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>DocumentedStruct</decl.name></decl.struct>",
+      "key.kind": "source.lang.swift.decl.struct",
+      "key.length": 163,
+      "key.name": "DocumentedStruct",
+      "key.offset": 409,
+      "key.usr": "s:8__main__16DocumentedStructV"
+    }
+  ]
+}

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -28,21 +28,7 @@ private func run(executable: String, arguments: [String]) -> String? {
 
 private let sourcekitStrings: [String] = {
     #if os(Linux)
-    let searchPaths = [
-        linuxSourceKitLibPath,
-        linuxFindSwiftenvActiveLibPath,
-        linuxFindSwiftInstallationLibPath,
-        linuxDefaultLibPath
-    ].flatMap({ $0 })
-    let sourceKitPath: String = {
-        for path in searchPaths {
-            let sopath = "\(path)/libsourcekitdInProc.so"
-            if FileManager.default.fileExists(atPath: sopath) {
-                return sopath
-            }
-        }
-        fatalError("Could not find or load libsourcekitdInProc.so")
-    }()
+    let sourceKitPath = "\(linuxSourceKitLibPath)/libsourcekitdInProc.so"
     #else
     let sourceKitPath = run(executable: "/usr/bin/xcrun", arguments: ["-f", "swiftc"])!.bridge()
         .deletingLastPathComponent.bridge()


### PR DESCRIPTION
While working on a Linux tweak I noticed that tests were failing; it turned out several were calling `sdkpath()` which will, unhelpfully, crash. I factored the call out and behind `#if os(...)` flags and then did the same for non-test code, as any code path that might call `sdkpath()` on Linux will always raise an exception. I'm happy to do another pass on this and a proper refactor - this just seemed to be the cheapest/easiest way to convert a runtime issue to a compiler-time issue.

The DocInfo fixture appears to have changed slightly from 3.2 to 4.0 - once you subtract whitespace and escaping differences all that was left was the different symbol mangling scheme.

After this, `swift test` runs 42 tests with 0 failures.