### PR TITLE
Improved searching for libsourcekitdInProc.so on Linux for library_wrapper.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 * Return `SWIFT_NAME` when generating Objective-C docs.  
   [Ibrahim Ulukaya](https://github.com/ulukaya)
+* libsourcekitdInProc search strategy improved on Linux. Supports swiftenv.  
+  [Alexander Lash](https://github.com/abl)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -22,7 +22,12 @@ struct DynamicLinkLibrary {
 }
 
 #if os(Linux)
-let toolchainLoader = Loader(searchPaths: [linuxSourceKitLibPath])
+let toolchainLoader = Loader(searchPaths: [
+    linuxSourceKitLibPath,
+    linuxFindSwiftenvActiveLibPath,
+    linuxFindSwiftInstallationLibPath,
+    linuxDefaultLibPath
+].flatMap({ $0 }))
 #else
 let toolchainLoader = Loader(searchPaths: [
     xcodeDefaultToolchainOverride,
@@ -66,9 +71,70 @@ private func env(_ name: String) -> String? {
     return ProcessInfo.processInfo.environment[name]
 }
 
-/// Returns "LINUX_SOURCEKIT_LIB_PATH" environment variable,
-/// or "/usr/lib" if unspecified.
-internal let linuxSourceKitLibPath = env("LINUX_SOURCEKIT_LIB_PATH") ?? "/usr/lib"
+/// Run a process at the given (absolute) path, capture output, return outupt.
+private func runCommand(_ path: String, _ args: String...) -> String? {
+    let process = Process()
+    process.launchPath = path
+    process.arguments = args
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.launch()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard let encoded = String(data: data, encoding: String.Encoding.utf8) else {
+        return nil
+    }
+
+    let trimmed = encoded.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+    if trimmed.isEmpty {
+        return nil
+    }
+    return trimmed
+}
+
+/// Returns "LINUX_SOURCEKIT_LIB_PATH" environment variable.
+internal let linuxSourceKitLibPath = env("LINUX_SOURCEKIT_LIB_PATH")
+
+/// If available, uses `swiftenv` to determine the user's active Swift root.
+internal let linuxFindSwiftenvActiveLibPath: String? = {
+    guard let swiftenvPath = runCommand("/usr/bin/which", "swiftenv") else {
+        return nil
+    }
+
+    guard let swiftenvRoot = runCommand(swiftenvPath, "prefix") else {
+        return nil
+    }
+
+    return swiftenvRoot + "/usr/lib"
+}()
+
+/// Attempts to discover the location of libsourcekitdInProc.so by looking at
+/// the `swift` binary on the path.
+internal let linuxFindSwiftInstallationLibPath: String? = {
+    guard let swiftPath = runCommand("/usr/bin/which", "swift") else {
+        return nil
+    }
+
+    if linuxSourceKitLibPath == nil && linuxFindSwiftenvActiveLibPath == nil &&
+       swiftPath.hasSuffix("/shims/swift") {
+        /// If we hit this path, the user is invoking Swift via swiftenv shims and has not set the
+        /// environment variable; this means we're going to end up trying to load from `/usr/lib`
+        /// which will fail - and instead, we can give a more useful error message.
+        fatalError("Swift is installed via swiftenv but swiftenv is not initialized.")
+    }
+
+    if !swiftPath.hasSuffix("/bin/swift") {
+        return nil
+    }
+
+    /// .../bin/swift -> .../lib
+    return swiftPath.deleting(lastPathComponents: 2) + "lib"
+}()
+
+/// Fallback path on Linux if no better option is available.
+internal let linuxDefaultLibPath = "/usr/lib"
 
 /// Returns "XCODE_DEFAULT_TOOLCHAIN_OVERRIDE" environment variable
 ///

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -28,7 +28,21 @@ private func run(executable: String, arguments: [String]) -> String? {
 
 private let sourcekitStrings: [String] = {
     #if os(Linux)
-    let sourceKitPath = "\(linuxSourceKitLibPath)/libsourcekitdInProc.so"
+    let searchPaths = [
+        linuxSourceKitLibPath,
+        linuxFindSwiftenvActiveLibPath,
+        linuxFindSwiftInstallationLibPath,
+        linuxDefaultLibPath
+    ].flatMap({ $0 })
+    let sourceKitPath: String = {
+        for path in searchPaths {
+            let sopath = "\(path)/libsourcekitdInProc.so"
+            if FileManager.default.fileExists(atPath: sopath) {
+                return sopath
+            }
+        }
+        fatalError("Could not find or load libsourcekitdInProc.so")
+    }()
     #else
     let sourceKitPath = run(executable: "/usr/bin/xcrun", arguments: ["-f", "swiftc"])!.bridge()
         .deletingLastPathComponent.bridge()


### PR DESCRIPTION
These commits add two new search strategies for Linux to the two existing strategies.

The first one checks to see if swiftenv is configured; if so, it uses `swiftenv prefix` to find the lib directory of the current active Swift environment - which is likely what the user is expecting.

The second one checks to see if `swift` is on `$PATH`; if it is, it's likely that the user is building their own toolchain and that's probably the libsourcekitdInProc.so the user is expecting.

This required a little duplication in SourceKitTests.swift that I'm happy to refactor out.