### PR TITLE
Do not attempt to run `/usr/bin/xcrun` on Linux

### DIFF
--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -157,6 +157,10 @@ public func parseHeaderFilesAndXcodebuildArguments(sourcekittenArguments: [Strin
 }
 
 public func sdkPath() -> String {
+    #if os(Linux)
+    // xcrun does not exist on Linux
+    return ""
+    #else
     let task = Process()
     task.launchPath = "/usr/bin/xcrun"
     task.arguments = ["--show-sdk-path"]
@@ -170,4 +174,5 @@ public func sdkPath() -> String {
     let sdkPath = String(data: file.readDataToEndOfFile(), encoding: .utf8)
     file.closeFile()
     return sdkPath?.replacingOccurrences(of: "\n", with: "") ?? ""
+    #endif
 }


### PR DESCRIPTION
I'm still following up on Foundation but it really looks like `task.launch()` is supposed to do something exceptional - currently on Linux there's no way to tell your launch failed.

https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/Process.swift#L409 _should_ yield a fatalError.

I started https://forums.swift.org/t/unexpected-inconsistent-behavior-in-process-launch/9398 to discuss this because if that's fixed, code like this will start breaking, and from a reading of `posix_spawn` it's not entirely clear what the behavior should be.

Regardless of the decision made with Foundation, this change is safe - `/usr/bin/xcrun` will never exist on Linux, so there's no point trying to launch it. This unblocks users/tests on non-Ubuntu platforms and has no effect on existing platforms.