### PR TITLE
Sort `sourcefiles` on producing `Module.docs`

### DIFF
--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -22,7 +22,7 @@ public struct Module {
     public var docs: [SwiftDocs] {
         var fileIndex = 1
         let sourceFilesCount = sourceFiles.count
-        return sourceFiles.flatMap {
+        return sourceFiles.sorted().flatMap {
             let filename = $0.bridge().lastPathComponent
             if let file = File(path: $0) {
                 fputs("Parsing \(filename) (\(fileIndex)/\(sourceFilesCount))\n", stderr)

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-3.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-3.2.json
@@ -1,773 +1,4 @@
 [{
-  "Sources\/Commandant\/OrderedSet.swift" : {
-    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
-    "key.length" : 921,
-    "key.offset" : 0,
-    "key.substructure" : [
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.internal",
-        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
-        "key.bodylength" : 343,
-        "key.bodyoffset" : 71,
-        "key.doc.column" : 17,
-        "key.doc.comment" : "A poor man's ordered set.",
-        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
-        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 2,
-        "key.doc.name" : "OrderedSet",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 376,
-        "key.name" : "OrderedSet",
-        "key.namelength" : 10,
-        "key.nameoffset" : 46,
-        "key.offset" : 39,
-        "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable>",
-        "key.parsed_scope.end" : 19,
-        "key.parsed_scope.start" : 2,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
-            "key.annotated_decl" : "<Declaration>fileprivate var values: [T]<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>values<\/decl.name>: <decl.var.type>[T]<\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 20,
-            "key.name" : "values",
-            "key.namelength" : 6,
-            "key.nameoffset" : 89,
-            "key.offset" : 85,
-            "key.parsed_declaration" : "fileprivate var values: [T] = []",
-            "key.parsed_scope.end" : 3,
-            "key.parsed_scope.start" : 3,
-            "key.setter_accessibility" : "source.lang.swift.accessibility.fileprivate",
-            "key.typename" : "[T]",
-            "key.typeusr" : "_T0SayxGD",
-            "key.usr" : "s:10Commandant10OrderedSetV6values33_E700A43BE27995F7283A44882E2B4A42LLSayxGv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>init&lt;S&gt;(_ sequence: <Type usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\">S<\/Type>) where T == S.Element, S : <Type usr=\"s:s8SequenceP\">Sequence<\/Type><\/Declaration>",
-            "key.bodylength" : 74,
-            "key.bodyoffset" : 163,
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\"><decl.generic_type_param.name>S<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>sequence<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T == S.Element<\/decl.generic_type_requirement>, <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 130,
-            "key.name" : "init(_:)",
-            "key.namelength" : 32,
-            "key.nameoffset" : 108,
-            "key.offset" : 108,
-            "key.parsed_declaration" : "init<S: Sequence>(_ sequence: S) where S.Element == T",
-            "key.parsed_scope.end" : 9,
-            "key.parsed_scope.start" : 5,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<T, S where T : Hashable, T == S.Element, S : Sequence> (OrderedSet<T>.Type) -> (S) -> OrderedSet<T>",
-            "key.typeusr" : "_T010Commandant10OrderedSetVyxGqd__c7ElementQyd__Rszs8SequenceRd__luD",
-            "key.usr" : "s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>@discardableResult mutating func remove(_ member: <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>?<\/Declaration>",
-            "key.attributes" : [
-              {
-                "key.attribute" : "source.decl.attribute.mutating"
-              },
-              {
-                "key.attribute" : "source.decl.attribute.discardableResult"
-              }
-            ],
-            "key.bodylength" : 110,
-            "key.bodyoffset" : 302,
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>remove<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>member<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 143,
-            "key.name" : "remove(_:)",
-            "key.namelength" : 19,
-            "key.nameoffset" : 275,
-            "key.offset" : 270,
-            "key.parsed_declaration" : "mutating func remove(_ member: T) -> T?",
-            "key.parsed_scope.end" : 18,
-            "key.parsed_scope.start" : 12,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<T where T : Hashable> (inout OrderedSet<T>) -> (T) -> T?",
-            "key.typeusr" : "_T0xSgxcD",
-            "key.usr" : "s:10Commandant10OrderedSetV6removexSgxF"
-          }
-        ],
-        "key.typename" : "OrderedSet<T>.Type",
-        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
-        "key.usr" : "s:10Commandant10OrderedSetV"
-      },
-      {
-        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
-        "key.bodylength" : 101,
-        "key.bodyoffset" : 450,
-        "key.doc.column" : 17,
-        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
-        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 2,
-        "key.doc.name" : "OrderedSet",
-        "key.doc.type" : "Class",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 9,
-            "key.offset" : 439
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "Equatable"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 135,
-        "key.name" : "OrderedSet",
-        "key.namelength" : 10,
-        "key.nameoffset" : 427,
-        "key.offset" : 417,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>static func ==(lhs: <Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>, rhs: <Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
-            "key.bodylength" : 36,
-            "key.bodyoffset" : 513,
-            "key.doc.declaration" : "static func ==(lhs: Self, rhs: Self) -> Bool",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Equality is the inverse of inequality. For any values `a` and `b`, `a == b` implies that `a != b` is `false`."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Function><Name>==(_:_:)<\/Name><USR>s:s9EquatableP2eeoiSbx_xtFZ<\/USR><Declaration>static func ==(lhs: Self, rhs: Self) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are equal.<\/Para><\/Abstract><Parameters><Parameter><Name>lhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A value to compare.<\/Para><\/Discussion><\/Parameter><Parameter><Name>rhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>Another value to compare.<\/Para><\/Discussion><\/Parameter><\/Parameters><Discussion><Para>Equality is the inverse of inequality. For any values <codeVoice>a<\/codeVoice> and <codeVoice>b<\/codeVoice>, <codeVoice>a == b<\/codeVoice> implies that <codeVoice>a != b<\/codeVoice> is <codeVoice>false<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.name" : "==(_:_:)",
-            "key.doc.parameters" : [
-              {
-                "discussion" : [
-                  {
-                    "Para" : "A value to compare."
-                  }
-                ],
-                "name" : "lhs"
-              },
-              {
-                "discussion" : [
-                  {
-                    "Para" : "Another value to compare."
-                  }
-                ],
-                "name" : "rhs"
-              }
-            ],
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>==<\/decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 98,
-            "key.name" : "==(_:_:)",
-            "key.namelength" : 39,
-            "key.nameoffset" : 464,
-            "key.offset" : 452,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s9EquatableP2eeoiSbx_xtFZ"
-              }
-            ],
-            "key.parsed_declaration" : "static func == (_ lhs: OrderedSet, rhs: OrderedSet) -> Bool",
-            "key.parsed_scope.end" : 24,
-            "key.parsed_scope.start" : 22,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation15AffineTransformV2eeoiSbAC_ACtFZ\">==(_: AffineTransform, _: AffineTransform) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8CalendarV2eeoiSbAC_ACtFZ\">==(_: Calendar, _: Calendar) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12CharacterSetV2eeoiSbAC_ACtFZ\">==(_: CharacterSet, _: CharacterSet) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DataV2eeoiSbAC_ACtFZ\">==(_: Data, _: Data) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DateV2eeoiSbAC_ACtFZ\">==(_: Date, _: Date) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation14DateComponentsV2eeoiSbAC_ACtFZ\">==(_: DateComponents, _: DateComponents) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12DateIntervalV2eeoiSbAC_ACtFZ\">==(_: DateInterval, _: DateInterval) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC7DecimalV10FoundationE2eeoiSbAB_ABtFZ\">==(_: Decimal, _: Decimal) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation9IndexPathV2eeoiSbAC_ACtFZ\">==(_: IndexPath, _: IndexPath) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV0B0V2eeoiSbAE_AEtFZ\">==(_: IndexSet.Index, _: IndexSet.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV9RangeViewV2eeoiSbAE_AEtFZ\">==(_: IndexSet.RangeView, _: IndexSet.RangeView) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV2eeoiSbAC_ACtFZ\">==(_: IndexSet, _: IndexSet) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation6LocaleV2eeoiSbAC_ACtFZ\">==(_: Locale, _: Locale) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation11MeasurementV2eeoiSbACyqd__G_ACyqd_0_GtSo4UnitCRbd__AHRbd_0_r0_lFZ\">==&lt;LeftHandSideType, RightHandSideType&gt;(_: Measurement&lt;LeftHandSideType&gt;, _: Measurement&lt;RightHandSideType&gt;) -&gt; Bool where LeftHandSideType : Unit, RightHandSideType : Unit<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12NotificationV2eeoiSbAC_ACtFZ\">==(_: Notification, _: Notification) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs13SignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs15UnsignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation21_BridgedStoredNSErrorPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC8_NSRangeV10FoundationE2eeoiSbAB_ABtFZ\">==(_: NSRange, _: NSRange) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SS10FoundationE8EncodingV2eeoiSbAC_ACtFZ\">==(_: String.Encoding, _: String.Encoding) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation20PersonNameComponentsV2eeoiSbAC_ACtFZ\">==(_: PersonNameComponents, _: PersonNameComponents) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8TimeZoneV2eeoiSbAC_ACtFZ\">==(_: TimeZone, _: TimeZone) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation3URLV2eeoiSbAC_ACtFZ\">==(_: URL, _: URL) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation13URLComponentsV2eeoiSbAC_ACtFZ\">==(_: URLComponents, _: URLComponents) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12URLQueryItemV2eeoiSbAC_ACtFZ\">==(_: URLQueryItem, _: URLQueryItem) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation10URLRequestV2eeoiSbAC_ACtFZ\">==(_: URLRequest, _: URLRequest) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4UUIDV2eeoiSbAC_ACtFZ\">==(_: UUID, _: UUID) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:14CoreFoundation9_CFObjectPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:6Darwin2eeoiSbAA0A7BooleanV_ADtF\">==(_: DarwinBoolean, _: DarwinBoolean) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch2eeoiSbAA0A3QoSV_ADtF\">==(_: DispatchQoS, _: DispatchQoS) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A4TimeV2eeoiSbAC_ACtFZ\">==(_: DispatchTime, _: DispatchTime) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A8WallTimeV2eeoiSbAC_ACtFZ\">==(_: DispatchWallTime, _: DispatchWallTime) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A12TimeIntervalO2eeoiSbAC_ACtFZ\">==(_: DispatchTimeInterval, _: DispatchTimeInterval) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbAA8SelectorV_ADtF\">==(_: Selector, _: Selector) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbSo8NSObjectC_ADtF\">==(_: NSObject, _: NSObject) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC17CGAffineTransformV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGAffineTransform, _: CGAffineTransform) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC7CGPointV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGPoint, _: CGPoint) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGSizeV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGSize, _: CGSize) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC8CGVectorV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGVector, _: CGVector) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGRectV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGRect, _: CGRect) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs15ContiguousArrayVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ContiguousArray&lt;Element&gt;, _: ContiguousArray&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs10ArraySliceVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ArraySlice&lt;Element&gt;, _: ArraySlice&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbSayxG_ABts9EquatableRzlF\">==&lt;Element&gt;(_: Array&lt;Element&gt;, _: Array&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbypXpSg_ABtF\">==(_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_ABts9EquatableRzlF\">==&lt;T&gt;(_: T?, _: T?) -&gt; Bool where T : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_s26_OptionalNilComparisonTypeVtlF\">==&lt;T&gt;(_: T?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs26_OptionalNilComparisonTypeV_xSgtlF\">==&lt;T&gt;(_: _OptionalNilComparisonType, _: T?) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbyt_yttF\">==(_: (), _: ()) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_t_x_q_tts9EquatableRzsABR_r0_lF\">==&lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_t_x_q_q0_tts9EquatableRzsABR_sABR0_r1_lF\">==&lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_t_x_q_q0_q1_tts9EquatableRzsABR_sABR0_sABR1_r2_lF\">==&lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_t_x_q_q0_q1_q2_tts9EquatableRzsABR_sABR0_sABR1_sABR2_r3_lF\">==&lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_tts9EquatableRzsABR_sABR0_sABR1_sABR2_sABR3_r4_lF\">==&lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiS2b_SbtFZ\">==(_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s33AutoreleasingUnsafeMutablePointerV2eeoiSbAByxG_ADtFZ\">==(_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV2eeoiSbAB_ABtFZ\">==(_: Character, _: Character) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV17UnicodeScalarViewV5IndexV2eeoiSbAF_AFtFZ\">==(_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiSbAB_ABtFZ\">==(_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s16ClosedRangeIndexV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRangeIndex&lt;Bound&gt;, _: ClosedRangeIndex&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiSbAB_ABtFZ\">==(_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s18LazyDropWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyDropWhileIndex&lt;Base&gt;, _: LazyDropWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiSbAByxG_ADtFZ\">==(_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s9EquatableP2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s22FlattenCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenCollectionIndex&lt;BaseElements&gt;, _: FlattenCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s35FlattenBidirectionalCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;, _: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s13FloatingPointPsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV2eeoiSbAByxG_ADtFZ\">==(_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV4KeysV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryVss8HashableRzs9EquatableR_r0_lE2eeoiSbAByxq_G_AFtFZ\">==(_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiSbAB_ABtFZ\">==(_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s13BinaryIntegerPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiSbAB_ABtFZ\">==(_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiSbAB_ABtFZ\">==(_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiSbAB_ABtFZ\">==(_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiSbAB_ABtFZ\">==(_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiSbAB_ABtFZ\">==(_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiSbAB_ABtFZ\">==(_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiSbAB_ABtFZ\">==(_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiSbAB_ABtFZ\">==(_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiSbSu_SutFZ\">==(_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiSbSi_SitFZ\">==(_: Int, _: Int) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiSbAB_ABtFZ\">==(_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiSbAByxq_G_ADtFZ\">==(_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiSbAD_ADtFZ\">==(_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s16ObjectIdentifierV2eeoiSbAB_ABtFZ\">==(_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s20LazyPrefixWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyPrefixWhileIndex&lt;Base&gt;, _: LazyPrefixWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s5RangeV2eeoiSbAByxG_ADtFZ\">==(_: Range&lt;Bound&gt;, _: Range&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s14CountableRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableRange&lt;Bound&gt;, _: CountableRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s11ClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s20CountableClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableClosedRange&lt;Bound&gt;, _: CountableClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s13ReversedIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedIndex&lt;Base&gt;, _: ReversedIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s25ReversedRandomAccessIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedRandomAccessIndex&lt;Base&gt;, _: ReversedRandomAccessIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s10StrideablePsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiSbSS_SStFZ\">==(_: String, _: String) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiSbAB_ABtFZ\">==(_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s14StringProtocolPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;R&gt;(_: Self, _: R) -&gt; Bool where R : StringProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiSbSpyxG_ABtFZ\">==(_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiSbSPyxG_ABtFZ\">==(_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiSbSv_SvtFZ\">==(_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiSbSV_SVtFZ\">==(_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiSbAB_ABtFZ\">==(_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:SC30_SwiftNSOperatingSystemVersionVsE2eeoiSbAB_ABtFZ\">==(_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiSbAB_ABtFZ\">==(_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<T where T : Hashable> (OrderedSet<T>.Type) -> (OrderedSet<T>, OrderedSet<T>) -> Bool",
-            "key.typeusr" : "_T0Sb10Commandant10OrderedSetVyxG_ADtcD",
-            "key.usr" : "s:s9EquatableP2eeoiSbx_xtFZ"
-          }
-        ],
-        "key.typename" : "OrderedSet<T>.Type",
-        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
-        "key.usr" : "s:10Commandant10OrderedSetV"
-      },
-      {
-        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
-        "key.bodylength" : 331,
-        "key.bodyoffset" : 588,
-        "key.doc.column" : 17,
-        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
-        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 2,
-        "key.doc.name" : "OrderedSet",
-        "key.doc.type" : "Class",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 10,
-            "key.offset" : 576
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "Collection"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 366,
-        "key.name" : "OrderedSet",
-        "key.namelength" : 10,
-        "key.nameoffset" : 564,
-        "key.offset" : 554,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>var count: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 24,
-            "key.bodyoffset" : 669,
-            "key.doc.declaration" : "var count: Self.IndexDistance { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "To check whether a collection is empty, use its `isEmpty` property instead of comparing `count` to zero. Unless the collection guarantees random-access performance, calculating `count` can be an O() operation."
-              },
-              {
-                "Complexity" : ""
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>count<\/Name><USR>s:s10CollectionP5count13IndexDistanceQzv<\/USR><Declaration>var count: Self.IndexDistance { get }<\/Declaration><CommentParts><Abstract><Para>The number of elements in the collection.<\/Para><\/Abstract><Discussion><Para>To check whether a collection is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing <codeVoice>count<\/codeVoice> to zero. Unless the collection guarantees random-access performance, calculating <codeVoice>count<\/codeVoice> can be an O(<emphasis>n<\/emphasis>) operation.<\/Para><Complexity><Para>O(1) if the collection conforms to <codeVoice>RandomAccessCollection<\/codeVoice>; otherwise, O(<emphasis>n<\/emphasis>), where <emphasis>n<\/emphasis> is the length of the collection.<\/Para><\/Complexity><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "count",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>count<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 41,
-            "key.name" : "count",
-            "key.namelength" : 5,
-            "key.nameoffset" : 657,
-            "key.offset" : 653,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s10CollectionP5count13IndexDistanceQzv"
-              }
-            ],
-            "key.parsed_declaration" : "var count: Int",
-            "key.parsed_scope.end" : 34,
-            "key.parsed_scope.start" : 32,
-            "key.typename" : "Int",
-            "key.typeusr" : "_T0SiD",
-            "key.usr" : "s:s10CollectionP5count13IndexDistanceQzv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>var isEmpty: <Type usr=\"s:Sb\">Bool<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 26,
-            "key.bodyoffset" : 716,
-            "key.doc.declaration" : "var isEmpty: Bool { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "When you need to check whether your collection is empty, use the `isEmpty` property instead of checking that the `count` property is equal to zero. For collections that don’t conform to `RandomAccessCollection`, accessing the `count` property iterates through the elements of the collection."
-              },
-              {
-                "CodeListing" : ""
-              },
-              {
-                "Complexity" : ""
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>isEmpty<\/Name><USR>s:s10CollectionP7isEmptySbv<\/USR><Declaration>var isEmpty: Bool { get }<\/Declaration><CommentParts><Abstract><Para>A Boolean value indicating whether the collection is empty.<\/Para><\/Abstract><Discussion><Para>When you need to check whether your collection is empty, use the <codeVoice>isEmpty<\/codeVoice> property instead of checking that the <codeVoice>count<\/codeVoice> property is equal to zero. For collections that don’t conform to <codeVoice>RandomAccessCollection<\/codeVoice>, accessing the <codeVoice>count<\/codeVoice> property iterates through the elements of the collection.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let horseName = \"Silver\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if horseName.isEmpty {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"I've been through the desert on a horse with no name.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Hi ho, \\(horseName)!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Hi ho, Silver!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Complexity><Para>O(1)<\/Para><\/Complexity><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "isEmpty",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>isEmpty<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 46,
-            "key.name" : "isEmpty",
-            "key.namelength" : 7,
-            "key.nameoffset" : 701,
-            "key.offset" : 697,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s10CollectionP7isEmptySbv"
-              }
-            ],
-            "key.parsed_declaration" : "var isEmpty: Bool",
-            "key.parsed_scope.end" : 38,
-            "key.parsed_scope.start" : 36,
-            "key.typename" : "Bool",
-            "key.typeusr" : "_T0SbD",
-            "key.usr" : "s:s10CollectionP7isEmptySbv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>var startIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 29,
-            "key.bodyoffset" : 767,
-            "key.doc.declaration" : "var startIndex: Self.Index { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If the collection is empty, `startIndex` is equal to `endIndex`."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>startIndex<\/Name><USR>s:s14_IndexableBaseP10startIndex0D0Qzv<\/USR><Declaration>var startIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The position of the first element in a nonempty collection.<\/Para><\/Abstract><Discussion><Para>If the collection is empty, <codeVoice>startIndex<\/codeVoice> is equal to <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "startIndex",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>startIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 51,
-            "key.name" : "startIndex",
-            "key.namelength" : 10,
-            "key.nameoffset" : 750,
-            "key.offset" : 746,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s14_IndexableBaseP10startIndex0D0Qzv"
-              }
-            ],
-            "key.parsed_declaration" : "var startIndex: Int",
-            "key.parsed_scope.end" : 42,
-            "key.parsed_scope.start" : 40,
-            "key.typename" : "Int",
-            "key.typeusr" : "_T0SiD",
-            "key.usr" : "s:s14_IndexableBaseP10startIndex0D0Qzv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>var endIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 27,
-            "key.bodyoffset" : 819,
-            "key.doc.declaration" : "var endIndex: Self.Index { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "When you need a range that includes the last element of a collection, use the half-open range operator (`..<`) with `endIndex`. The `..<` operator creates a range that doesn’t include the upper bound, so it’s always safe to use with `endIndex`. For example:"
-              },
-              {
-                "CodeListing" : ""
-              },
-              {
-                "Para" : "If the collection is empty, `endIndex` is equal to `startIndex`."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>endIndex<\/Name><USR>s:s14_IndexableBaseP8endIndex0D0Qzv<\/USR><Declaration>var endIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The collection’s “past the end” position—that is, the position one greater than the last valid subscript argument.<\/Para><\/Abstract><Discussion><Para>When you need a range that includes the last element of a collection, use the half-open range operator (<codeVoice>..&lt;<\/codeVoice>) with <codeVoice>endIndex<\/codeVoice>. The <codeVoice>..&lt;<\/codeVoice> operator creates a range that doesn’t include the upper bound, so it’s always safe to use with <codeVoice>endIndex<\/codeVoice>. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let numbers = [10, 20, 30, 40, 50]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if let index = numbers.index(of: 30) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(numbers[index ..< numbers.endIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[30, 40, 50]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If the collection is empty, <codeVoice>endIndex<\/codeVoice> is equal to <codeVoice>startIndex<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "endIndex",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>endIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 47,
-            "key.name" : "endIndex",
-            "key.namelength" : 8,
-            "key.nameoffset" : 804,
-            "key.offset" : 800,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s14_IndexableBaseP8endIndex0D0Qzv"
-              }
-            ],
-            "key.parsed_declaration" : "var endIndex: Int",
-            "key.parsed_scope.end" : 46,
-            "key.parsed_scope.start" : 44,
-            "key.typename" : "Int",
-            "key.typeusr" : "_T0SiD",
-            "key.usr" : "s:s14_IndexableBaseP8endIndex0D0Qzv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>func index(after i: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
-            "key.bodylength" : 34,
-            "key.bodyoffset" : 883,
-            "key.doc.declaration" : "func index(after i: Self.Index) -> Self.Index",
-            "key.doc.discussion" : [
-              {
-                "Para" : "The successor of an index must be well defined. For an index `i` into a collection `c`, calling `c.index(after: i)` returns the same index every time."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Function><Name>index(after:)<\/Name><USR>s:s14_IndexableBaseP5index5IndexQzAE5after_tF<\/USR><Declaration>func index(after i: Self.Index) -&gt; Self.Index<\/Declaration><CommentParts><Abstract><Para>Returns the position immediately after the given index.<\/Para><\/Abstract><Parameters><Parameter><Name>i<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A valid index of the collection. <codeVoice>i<\/codeVoice> must be less than <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/Parameter><\/Parameters><ResultDiscussion><Para>The index value immediately after <codeVoice>i<\/codeVoice>.<\/Para><\/ResultDiscussion><Discussion><Para>The successor of an index must be well defined. For an index <codeVoice>i<\/codeVoice> into a collection <codeVoice>c<\/codeVoice>, calling <codeVoice>c.index(after: i)<\/codeVoice> returns the same index every time.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.name" : "index(after:)",
-            "key.doc.parameters" : [
-              {
-                "discussion" : [
-                  {
-                    "Para" : "A valid index of the collection. `i` must be less than `endIndex`."
-                  }
-                ],
-                "name" : "i"
-              }
-            ],
-            "key.doc.result_discussion" : [
-              {
-                "Para" : "The index value immediately after `i`."
-              }
-            ],
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>index<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>after<\/decl.var.parameter.argument_label> <decl.var.parameter.name>i<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 68,
-            "key.name" : "index(after:)",
-            "key.namelength" : 19,
-            "key.nameoffset" : 855,
-            "key.offset" : 850,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s14_IndexableBaseP5index5IndexQzAE5after_tF"
-              }
-            ],
-            "key.parsed_declaration" : "func index(after i: Int) -> Int",
-            "key.parsed_scope.end" : 50,
-            "key.parsed_scope.start" : 48,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<T where T : Hashable> (OrderedSet<T>) -> (Int) -> Int",
-            "key.typeusr" : "_T0S2i5after_tcD",
-            "key.usr" : "s:s14_IndexableBaseP5index5IndexQzAE5after_tF"
-          }
-        ],
-        "key.typename" : "OrderedSet<T>.Type",
-        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
-        "key.usr" : "s:10Commandant10OrderedSetV"
-      }
-    ]
-  }
-}, {
   "Sources\/Commandant\/Argument.swift" : {
     "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
     "key.length" : 2979,
@@ -1088,342 +319,889 @@
     ]
   }
 }, {
-  "Sources\/Commandant\/HelpCommand.swift" : {
+  "Sources\/Commandant\/ArgumentParser.swift" : {
     "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
-    "key.length" : 2157,
+    "key.length" : 4956,
     "key.offset" : 0,
     "key.substructure" : [
       {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public struct HelpCommand&lt;ClientError&gt; : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.bodylength" : 1066,
-        "key.bodyoffset" : 615,
-        "key.doc.column" : 15,
-        "key.doc.comment" : "A basic implementation of a `help` command, using information available in a\n`CommandRegistry`.\n\nIf you want to use this command, initialize it with the registry, then add\nit to that same registry:\n\n\tlet commands: CommandRegistry<MyErrorType> = …\n\tlet helpCommand = HelpCommand(registry: commands)\n\tcommands.register(helpCommand)",
-        "key.doc.declaration" : "public struct HelpCommand<ClientError> : CommandProtocol where ClientError : Error",
-        "key.doc.discussion" : [
-          {
-            "Para" : "If you want to use this command, initialize it with the registry, then add it to that same registry:"
-          },
-          {
-            "CodeListing" : ""
-          }
-        ],
-        "key.doc.file" : "Sources\/Commandant\/HelpCommand.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/HelpCommand.swift\" line=\"21\" column=\"15\"><Name>HelpCommand<\/Name><USR>s:10Commandant11HelpCommandV<\/USR><Declaration>public struct HelpCommand&lt;ClientError&gt; : CommandProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A basic implementation of a <codeVoice>help<\/codeVoice> command, using information available in a <codeVoice>CommandRegistry<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>If you want to use this command, initialize it with the registry, then add it to that same registry:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let commands: CommandRegistry<MyErrorType> = …]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let helpCommand = HelpCommand(registry: commands)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[commands.register(helpCommand)]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
-        "key.doc.line" : 21,
-        "key.doc.name" : "HelpCommand",
-        "key.doc.type" : "Class",
+        "key.accessibility" : "source.lang.swift.accessibility.private",
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:s9EquatableP\">Equatable<\/Type><\/Declaration>",
+        "key.bodylength" : 296,
+        "key.bodyoffset" : 280,
+        "key.doc.column" : 14,
+        "key.doc.comment" : "Represents an argument passed on the command line.",
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"13\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
         "key.elements" : [
           {
             "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 15,
-            "key.offset" : 598
+            "key.length" : 9,
+            "key.offset" : 269
           }
         ],
-        "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpCommand<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:s9EquatableP\">Equatable<\/ref.protocol><\/decl.enum>",
         "key.inheritedtypes" : [
           {
-            "key.name" : "CommandProtocol"
+            "key.name" : "Equatable"
           }
         ],
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 1124,
-        "key.name" : "HelpCommand",
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 326,
+        "key.name" : "RawArgument",
         "key.namelength" : 11,
-        "key.nameoffset" : 565,
-        "key.offset" : 558,
-        "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error>: CommandProtocol",
-        "key.parsed_scope.end" : 59,
-        "key.parsed_scope.start" : 21,
+        "key.nameoffset" : 256,
+        "key.offset" : 251,
+        "key.parsed_declaration" : "private enum RawArgument: Equatable",
+        "key.parsed_scope.end" : 23,
+        "key.parsed_scope.start" : 13,
         "key.substructure" : [
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.doc.column" : 6,
-            "key.doc.declaration" : "var verb: String { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"22\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSv<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 22,
-            "key.doc.name" : "verb",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 17,
-            "key.name" : "verb",
-            "key.namelength" : 4,
-            "key.nameoffset" : 682,
-            "key.offset" : 678,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
-              }
-            ],
-            "key.parsed_declaration" : "public let verb = \"help\"",
-            "key.parsed_scope.end" : 24,
-            "key.parsed_scope.start" : 24,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.doc.column" : 6,
-            "key.doc.declaration" : "var function: String { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"26\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSv<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 26,
-            "key.doc.name" : "function",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 57,
-            "key.name" : "function",
-            "key.namelength" : 8,
-            "key.nameoffset" : 708,
-            "key.offset" : 704,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
-              }
-            ],
-            "key.parsed_declaration" : "public let function = \"Display general or command-specific help\"",
-            "key.parsed_scope.end" : 25,
-            "key.parsed_scope.start" : 25,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private let registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>registry<\/decl.name>: <decl.var.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 42,
-            "key.name" : "registry",
-            "key.namelength" : 8,
-            "key.nameoffset" : 776,
-            "key.offset" : 772,
-            "key.parsed_declaration" : "private let registry: CommandRegistry<ClientError>",
-            "key.parsed_scope.end" : 27,
-            "key.parsed_scope.start" : 27,
-            "key.typename" : "CommandRegistry<ClientError>",
-            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGD",
-            "key.usr" : "s:10Commandant11HelpCommandV8registry33_38F61CE0DF9D73793CEDF5D1C3140331LLAA0C8RegistryCyxGv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public init(registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;)<\/Declaration>",
-            "key.bodylength" : 29,
-            "key.bodyoffset" : 957,
-            "key.doc.column" : 9,
-            "key.doc.comment" : "Initializes the command to provide help from the given registry of\ncommands.",
-            "key.doc.declaration" : "public init(registry: CommandRegistry<ClientError>)",
-            "key.doc.file" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/HelpCommand.swift\" line=\"31\" column=\"9\"><Name>init(registry:)<\/Name><USR>s:10Commandant11HelpCommandVACyxGAA0C8RegistryCyxG8registry_tcfc<\/USR><Declaration>public init(registry: CommandRegistry&lt;ClientError&gt;)<\/Declaration><CommentParts><Abstract><Para>Initializes the command to provide help from the given registry of commands.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 31,
-            "key.doc.name" : "init(registry:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>registry<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 76,
-            "key.name" : "init(registry:)",
-            "key.namelength" : 44,
-            "key.nameoffset" : 911,
-            "key.offset" : 911,
-            "key.parsed_declaration" : "public init(registry: CommandRegistry<ClientError>)",
-            "key.parsed_scope.end" : 33,
-            "key.parsed_scope.start" : 31,
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 16,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 355,
             "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>.Type) -> (CommandRegistry<ClientError>) -> HelpCommand<ClientError>",
-            "key.typeusr" : "_T010Commandant11HelpCommandVyxGAA0C8RegistryCyxG8registry_tcD",
-            "key.usr" : "s:10Commandant11HelpCommandVACyxGAA0C8RegistryCyxG8registry_tcfc"
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>case key(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A key corresponding to an option (e.g., `verbose` for `--verbose`).",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"15\" column=\"7\"><Name>key<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A key corresponding to an option (e.g., <codeVoice>verbose<\/codeVoice> for <codeVoice>--verbose<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 15,
+                "key.doc.name" : "key",
+                "key.doc.type" : "Other",
+                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>key<\/decl.name>(<ref.struct usr=\"s:SS\">String<\/ref.struct>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 11,
+                "key.name" : "key",
+                "key.namelength" : 3,
+                "key.nameoffset" : 360,
+                "key.offset" : 360,
+                "key.parsed_declaration" : "case key(String)",
+                "key.parsed_scope.end" : 15,
+                "key.parsed_scope.start" : 15,
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyADSScADmF"
+              }
+            ]
           },
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public func run(_ options: <Type usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
-            "key.bodylength" : 625,
-            "key.bodyoffset" : 1054,
-            "key.doc.column" : 7,
-            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"29\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 29,
-            "key.doc.name" : "run(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 683,
-            "key.name" : "run(_:)",
-            "key.namelength" : 23,
-            "key.nameoffset" : 1002,
-            "key.offset" : 997,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
-              }
-            ],
-            "key.parsed_declaration" : "public func run(_ options: Options) -> Result<(), ClientError>",
-            "key.parsed_scope.end" : 58,
-            "key.parsed_scope.start" : 35,
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 18,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 462,
             "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>) -> (HelpOptions<ClientError>) -> Result<(), ClientError>",
-            "key.typeusr" : "_T06ResultAAOyytxG10Commandant11HelpOptionsVyxGcD",
-            "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>case value(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A value, either associated with an option or passed as a positional\nargument.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"19\" column=\"7\"><Name>value<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A value, either associated with an option or passed as a positional argument.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 19,
+                "key.doc.name" : "value",
+                "key.doc.type" : "Other",
+                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>value<\/decl.name>(<ref.struct usr=\"s:SS\">String<\/ref.struct>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 13,
+                "key.name" : "value",
+                "key.namelength" : 5,
+                "key.nameoffset" : 467,
+                "key.offset" : 467,
+                "key.parsed_declaration" : "case value(String)",
+                "key.parsed_scope.end" : 19,
+                "key.parsed_scope.start" : 19,
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueADSScADmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 32,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 543,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>case flag(<Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>&lt;<Type usr=\"s:s9CharacterV\">Character<\/Type>&gt;)<\/Declaration>",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "One or more flag arguments (e.g 'r' and 'f' for `-rf`)",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"22\" column=\"7\"><Name>flag<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagAdA10OrderedSetVys9CharacterVGcADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>One or more flag arguments (e.g ‘r’ and ‘f’ for <codeVoice>-rf<\/codeVoice>)<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 22,
+                "key.doc.name" : "flag",
+                "key.doc.type" : "Other",
+                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>(<ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct>&lt;<ref.struct usr=\"s:s9CharacterV\">Character<\/ref.struct>&gt;)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 27,
+                "key.name" : "flag",
+                "key.namelength" : 4,
+                "key.nameoffset" : 548,
+                "key.offset" : 548,
+                "key.parsed_declaration" : "case flag(OrderedSet<Character>)",
+                "key.parsed_scope.end" : 22,
+                "key.parsed_scope.start" : 22,
+                "key.typename" : "(RawArgument.Type) -> (OrderedSet<Character>) -> RawArgument",
+                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOAA10OrderedSetVys9CharacterVGcADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagAdA10OrderedSetVys9CharacterVGcADmF"
+              }
+            ]
           }
         ],
-        "key.typename" : "HelpCommand<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant11HelpCommandVyxGmD",
-        "key.usr" : "s:10Commandant11HelpCommandV"
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
       },
       {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public struct HelpOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.bodylength" : 407,
-        "key.bodyoffset" : 1748,
+        "key.accessibility" : "source.lang.swift.accessibility.private",
+        "key.annotated_decl" : "<Declaration>private func ==(lhs: <Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>, rhs: <Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+        "key.bodylength" : 239,
+        "key.bodyoffset" : 640,
+        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>==<\/decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 293,
+        "key.name" : "==(_:_:)",
+        "key.namelength" : 38,
+        "key.nameoffset" : 592,
+        "key.offset" : 587,
+        "key.parsed_declaration" : "private func ==(lhs: RawArgument, rhs: RawArgument) -> Bool",
+        "key.parsed_scope.end" : 39,
+        "key.parsed_scope.start" : 25,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant10OrderedSetV2eeoiSbACyxG_AEtFZ\">==(_: OrderedSet, _: OrderedSet) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation15AffineTransformV2eeoiSbAC_ACtFZ\">==(_: AffineTransform, _: AffineTransform) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8CalendarV2eeoiSbAC_ACtFZ\">==(_: Calendar, _: Calendar) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12CharacterSetV2eeoiSbAC_ACtFZ\">==(_: CharacterSet, _: CharacterSet) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DataV2eeoiSbAC_ACtFZ\">==(_: Data, _: Data) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DateV2eeoiSbAC_ACtFZ\">==(_: Date, _: Date) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation14DateComponentsV2eeoiSbAC_ACtFZ\">==(_: DateComponents, _: DateComponents) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12DateIntervalV2eeoiSbAC_ACtFZ\">==(_: DateInterval, _: DateInterval) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC7DecimalV10FoundationE2eeoiSbAB_ABtFZ\">==(_: Decimal, _: Decimal) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation9IndexPathV2eeoiSbAC_ACtFZ\">==(_: IndexPath, _: IndexPath) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV0B0V2eeoiSbAE_AEtFZ\">==(_: IndexSet.Index, _: IndexSet.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV9RangeViewV2eeoiSbAE_AEtFZ\">==(_: IndexSet.RangeView, _: IndexSet.RangeView) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV2eeoiSbAC_ACtFZ\">==(_: IndexSet, _: IndexSet) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation6LocaleV2eeoiSbAC_ACtFZ\">==(_: Locale, _: Locale) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation11MeasurementV2eeoiSbACyqd__G_ACyqd_0_GtSo4UnitCRbd__AHRbd_0_r0_lFZ\">==&lt;LeftHandSideType, RightHandSideType&gt;(_: Measurement&lt;LeftHandSideType&gt;, _: Measurement&lt;RightHandSideType&gt;) -&gt; Bool where LeftHandSideType : Unit, RightHandSideType : Unit<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12NotificationV2eeoiSbAC_ACtFZ\">==(_: Notification, _: Notification) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs13SignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs15UnsignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation21_BridgedStoredNSErrorPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC8_NSRangeV10FoundationE2eeoiSbAB_ABtFZ\">==(_: NSRange, _: NSRange) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SS10FoundationE8EncodingV2eeoiSbAC_ACtFZ\">==(_: String.Encoding, _: String.Encoding) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation20PersonNameComponentsV2eeoiSbAC_ACtFZ\">==(_: PersonNameComponents, _: PersonNameComponents) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8TimeZoneV2eeoiSbAC_ACtFZ\">==(_: TimeZone, _: TimeZone) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation3URLV2eeoiSbAC_ACtFZ\">==(_: URL, _: URL) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation13URLComponentsV2eeoiSbAC_ACtFZ\">==(_: URLComponents, _: URLComponents) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12URLQueryItemV2eeoiSbAC_ACtFZ\">==(_: URLQueryItem, _: URLQueryItem) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation10URLRequestV2eeoiSbAC_ACtFZ\">==(_: URLRequest, _: URLRequest) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4UUIDV2eeoiSbAC_ACtFZ\">==(_: UUID, _: UUID) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:14CoreFoundation9_CFObjectPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:6Darwin2eeoiSbAA0A7BooleanV_ADtF\">==(_: DarwinBoolean, _: DarwinBoolean) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch2eeoiSbAA0A3QoSV_ADtF\">==(_: DispatchQoS, _: DispatchQoS) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A4TimeV2eeoiSbAC_ACtFZ\">==(_: DispatchTime, _: DispatchTime) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A8WallTimeV2eeoiSbAC_ACtFZ\">==(_: DispatchWallTime, _: DispatchWallTime) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A12TimeIntervalO2eeoiSbAC_ACtFZ\">==(_: DispatchTimeInterval, _: DispatchTimeInterval) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbAA8SelectorV_ADtF\">==(_: Selector, _: Selector) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbSo8NSObjectC_ADtF\">==(_: NSObject, _: NSObject) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC17CGAffineTransformV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGAffineTransform, _: CGAffineTransform) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC7CGPointV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGPoint, _: CGPoint) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGSizeV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGSize, _: CGSize) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC8CGVectorV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGVector, _: CGVector) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGRectV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGRect, _: CGRect) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs15ContiguousArrayVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ContiguousArray&lt;Element&gt;, _: ContiguousArray&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs10ArraySliceVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ArraySlice&lt;Element&gt;, _: ArraySlice&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbSayxG_ABts9EquatableRzlF\">==&lt;Element&gt;(_: Array&lt;Element&gt;, _: Array&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbypXpSg_ABtF\">==(_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_ABts9EquatableRzlF\">==&lt;T&gt;(_: T?, _: T?) -&gt; Bool where T : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_s26_OptionalNilComparisonTypeVtlF\">==&lt;T&gt;(_: T?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs26_OptionalNilComparisonTypeV_xSgtlF\">==&lt;T&gt;(_: _OptionalNilComparisonType, _: T?) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbyt_yttF\">==(_: (), _: ()) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_t_x_q_tts9EquatableRzsABR_r0_lF\">==&lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_t_x_q_q0_tts9EquatableRzsABR_sABR0_r1_lF\">==&lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_t_x_q_q0_q1_tts9EquatableRzsABR_sABR0_sABR1_r2_lF\">==&lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_t_x_q_q0_q1_q2_tts9EquatableRzsABR_sABR0_sABR1_sABR2_r3_lF\">==&lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_tts9EquatableRzsABR_sABR0_sABR1_sABR2_sABR3_r4_lF\">==&lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiS2b_SbtFZ\">==(_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s33AutoreleasingUnsafeMutablePointerV2eeoiSbAByxG_ADtFZ\">==(_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV2eeoiSbAB_ABtFZ\">==(_: Character, _: Character) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV17UnicodeScalarViewV5IndexV2eeoiSbAF_AFtFZ\">==(_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiSbAB_ABtFZ\">==(_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s16ClosedRangeIndexV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRangeIndex&lt;Bound&gt;, _: ClosedRangeIndex&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiSbAB_ABtFZ\">==(_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s18LazyDropWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyDropWhileIndex&lt;Base&gt;, _: LazyDropWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiSbAByxG_ADtFZ\">==(_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s9EquatableP2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s22FlattenCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenCollectionIndex&lt;BaseElements&gt;, _: FlattenCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s35FlattenBidirectionalCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;, _: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s13FloatingPointPsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV2eeoiSbAByxG_ADtFZ\">==(_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV4KeysV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryVss8HashableRzs9EquatableR_r0_lE2eeoiSbAByxq_G_AFtFZ\">==(_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiSbAB_ABtFZ\">==(_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s13BinaryIntegerPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiSbAB_ABtFZ\">==(_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiSbAB_ABtFZ\">==(_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiSbAB_ABtFZ\">==(_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiSbAB_ABtFZ\">==(_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiSbAB_ABtFZ\">==(_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiSbAB_ABtFZ\">==(_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiSbAB_ABtFZ\">==(_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiSbAB_ABtFZ\">==(_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiSbSu_SutFZ\">==(_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiSbSi_SitFZ\">==(_: Int, _: Int) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiSbAB_ABtFZ\">==(_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiSbAByxq_G_ADtFZ\">==(_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiSbAD_ADtFZ\">==(_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s16ObjectIdentifierV2eeoiSbAB_ABtFZ\">==(_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s20LazyPrefixWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyPrefixWhileIndex&lt;Base&gt;, _: LazyPrefixWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s5RangeV2eeoiSbAByxG_ADtFZ\">==(_: Range&lt;Bound&gt;, _: Range&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s14CountableRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableRange&lt;Bound&gt;, _: CountableRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s11ClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s20CountableClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableClosedRange&lt;Bound&gt;, _: CountableClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s13ReversedIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedIndex&lt;Base&gt;, _: ReversedIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s25ReversedRandomAccessIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedRandomAccessIndex&lt;Base&gt;, _: ReversedRandomAccessIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s10StrideablePsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiSbSS_SStFZ\">==(_: String, _: String) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiSbAB_ABtFZ\">==(_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s14StringProtocolPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;R&gt;(_: Self, _: R) -&gt; Bool where R : StringProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiSbSpyxG_ABtFZ\">==(_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiSbSPyxG_ABtFZ\">==(_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiSbSv_SvtFZ\">==(_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiSbSV_SVtFZ\">==(_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiSbAB_ABtFZ\">==(_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:SC30_SwiftNSOperatingSystemVersionVsE2eeoiSbAB_ABtFZ\">==(_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiSbAB_ABtFZ\">==(_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:6Result2eeoiSbx_xtAA0A8ProtocolRzs9Equatable5ErrorRpzsAD5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : ResultProtocol, T.Error : Equatable, T.Value : Equatable<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:6Result7NoErrorO2eeoiSbAC_ACtFZ\">==(_: NoError, _: NoError) -&gt; Bool<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+
+        ],
+        "key.typename" : "(RawArgument, RawArgument) -> Bool",
+        "key.typeusr" : "_T0Sb10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO_ADtcD",
+        "key.usr" : "s:10Commandant2eeoi33_BA859BFBBE9DF3838A11641CB273713ELLSbAA11RawArgumentACLLO_AEtF"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:s9EquatableP\">Equatable<\/Type><\/Declaration>",
+        "key.bodylength" : 214,
+        "key.bodyoffset" : 930,
+        "key.doc.column" : 14,
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"13\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
         "key.elements" : [
           {
             "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 15,
-            "key.offset" : 1731
+            "key.length" : 23,
+            "key.offset" : 905
           }
         ],
-        "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:s9EquatableP\">Equatable<\/ref.protocol><\/decl.enum>",
         "key.inheritedtypes" : [
           {
-            "key.name" : "OptionsProtocol"
+            "key.name" : "CustomStringConvertible"
           }
         ],
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 465,
-        "key.name" : "HelpOptions",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 263,
+        "key.name" : "RawArgument",
         "key.namelength" : 11,
-        "key.nameoffset" : 1698,
-        "key.offset" : 1691,
-        "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error>: OptionsProtocol",
-        "key.parsed_scope.end" : 76,
-        "key.parsed_scope.start" : 61,
+        "key.nameoffset" : 892,
+        "key.offset" : 882,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
-            "key.annotated_decl" : "<Declaration>fileprivate let verb: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.annotated_decl" : "<Declaration>fileprivate var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 173,
+            "key.bodyoffset" : 969,
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Instead of accessing this property directly, convert an instance of any type to a string by using the `String(describing:)` initializer. For example:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSv<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Instead of accessing this property directly, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
             "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 17,
-            "key.name" : "verb",
-            "key.namelength" : 4,
-            "key.nameoffset" : 1766,
-            "key.offset" : 1762,
-            "key.parsed_declaration" : "fileprivate let verb: String?",
-            "key.parsed_scope.end" : 62,
-            "key.parsed_scope.start" : 62,
-            "key.typename" : "String?",
-            "key.typeusr" : "_T0SSSgD",
-            "key.usr" : "s:10Commandant11HelpOptionsV4verb33_38F61CE0DF9D73793CEDF5D1C3140331LLSSSgv"
-          },
+            "key.length" : 199,
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 948,
+            "key.offset" : 944,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
+              }
+            ],
+            "key.parsed_declaration" : "fileprivate var description: String",
+            "key.parsed_scope.end" : 53,
+            "key.parsed_scope.start" : 42,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
+          }
+        ],
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class ArgumentParser<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final"
+          }
+        ],
+        "key.bodylength" : 3713,
+        "key.bodyoffset" : 1241,
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Destructively parses a list of command-line arguments.",
+        "key.doc.declaration" : "public final class ArgumentParser",
+        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"57\" column=\"20\"><Name>ArgumentParser<\/Name><USR>s:10Commandant14ArgumentParserC<\/USR><Declaration>public final class ArgumentParser<\/Declaration><CommentParts><Abstract><Para>Destructively parses a list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 57,
+        "key.doc.name" : "ArgumentParser",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>ArgumentParser<\/decl.name><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 3736,
+        "key.name" : "ArgumentParser",
+        "key.namelength" : 14,
+        "key.nameoffset" : 1225,
+        "key.offset" : 1219,
+        "key.parsed_declaration" : "public final class ArgumentParser",
+        "key.parsed_scope.end" : 192,
+        "key.parsed_scope.start" : 57,
+        "key.runtime_name" : "_TtC8__main__14ArgumentParser",
+        "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private init(verb: <Type usr=\"s:SS\">String<\/Type>?)<\/Declaration>",
-            "key.bodylength" : 21,
-            "key.bodyoffset" : 1812,
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 43,
-            "key.name" : "init(verb:)",
-            "key.namelength" : 19,
-            "key.nameoffset" : 1791,
-            "key.offset" : 1791,
-            "key.parsed_declaration" : "private init(verb: String?)",
-            "key.parsed_scope.end" : 66,
-            "key.parsed_scope.start" : 64,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String?) -> HelpOptions<ClientError>",
-            "key.typeusr" : "_T010Commandant11HelpOptionsVyxGSSSg4verb_tcD",
-            "key.usr" : "s:10Commandant11HelpOptionsVACyxGSSSg4verb_tc33_38F61CE0DF9D73793CEDF5D1C3140331Llfc"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private static func create(_ verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type><\/Declaration>",
-            "key.bodylength" : 54,
-            "key.bodyoffset" : 1896,
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>create<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct><\/decl.function.returntype><\/decl.function.method.static>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 106,
-            "key.name" : "create(_:)",
-            "key.namelength" : 22,
-            "key.nameoffset" : 1857,
-            "key.offset" : 1845,
-            "key.parsed_declaration" : "private static func create(_ verb: String) -> HelpOptions",
-            "key.parsed_scope.end" : 70,
-            "key.parsed_scope.start" : 68,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String) -> HelpOptions<ClientError>",
-            "key.typeusr" : "_T010Commandant11HelpOptionsVyxGSScD",
-            "key.usr" : "s:10Commandant11HelpOptionsV6create33_38F61CE0DF9D73793CEDF5D1C3140331LLACyxGSSFZ"
+            "key.annotated_decl" : "<Declaration>private var rawArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "The remaining arguments to be extracted, in their raw form.",
+            "key.doc.declaration" : "private var rawArguments: [Commandant.RawArgument]",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"59\" column=\"14\"><Name>rawArguments<\/Name><USR>s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGv<\/USR><Declaration>private var rawArguments: [Commandant.RawArgument]<\/Declaration><CommentParts><Abstract><Para>The remaining arguments to be extracted, in their raw form.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 59,
+            "key.doc.name" : "rawArguments",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>rawArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 36,
+            "key.name" : "rawArguments",
+            "key.namelength" : 12,
+            "key.nameoffset" : 1320,
+            "key.offset" : 1316,
+            "key.parsed_declaration" : "private var rawArguments: [RawArgument] = []",
+            "key.parsed_scope.end" : 59,
+            "key.parsed_scope.start" : 59,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[RawArgument]",
+            "key.typeusr" : "_T0Say10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGv"
           },
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.bodylength" : 99,
-            "key.bodyoffset" : 2054,
-            "key.doc.column" : 14,
-            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Returns the parsed options or a `UsageError`."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 44,
-            "key.doc.name" : "evaluate(_:)",
+            "key.annotated_decl" : "<Declaration>public init(_ arguments: [<Type usr=\"s:SS\">String<\/Type>])<\/Declaration>",
+            "key.bodylength" : 741,
+            "key.bodyoffset" : 1468,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the generator from a simple list of command-line arguments.",
+            "key.doc.declaration" : "public init(_ arguments: [String])",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"62\" column=\"9\"><Name>init(_:)<\/Name><USR>s:10Commandant14ArgumentParserCACSaySSGcfc<\/USR><Declaration>public init(_ arguments: [String])<\/Declaration><CommentParts><Abstract><Para>Initializes the generator from a simple list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 62,
+            "key.doc.name" : "init(_:)",
             "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 193,
-            "key.name" : "evaluate(_:)",
-            "key.namelength" : 26,
-            "key.nameoffset" : 1973,
-            "key.offset" : 1961,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
-              }
-            ],
-            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 75,
-            "key.parsed_scope.start" : 72,
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>arguments<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 771,
+            "key.name" : "init(_:)",
+            "key.namelength" : 27,
+            "key.nameoffset" : 1439,
+            "key.offset" : 1439,
+            "key.parsed_declaration" : "public init(_ arguments: [String])",
+            "key.parsed_scope.end" : 87,
+            "key.parsed_scope.start" : 62,
             "key.substructure" : [
 
             ],
-            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (CommandMode) -> Result<HelpOptions<ClientError>, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOy10Commandant11HelpOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
-            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+            "key.typename" : "(ArgumentParser.Type) -> ([String]) -> ArgumentParser",
+            "key.typeusr" : "_T010Commandant14ArgumentParserCSaySSGcD",
+            "key.usr" : "s:10Commandant14ArgumentParserCACSaySSGcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var remainingArguments: [<Type usr=\"s:SS\">String<\/Type>]? { get }<\/Declaration>",
+            "key.bodylength" : 76,
+            "key.bodyoffset" : 2295,
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Returns the remaining arguments.",
+            "key.doc.declaration" : "internal var remainingArguments: [String]? { get }",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"90\" column=\"15\"><Name>remainingArguments<\/Name><USR>s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgv<\/USR><Declaration>internal var remainingArguments: [String]? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the remaining arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 90,
+            "key.doc.name" : "remainingArguments",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>remainingArguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 112,
+            "key.name" : "remainingArguments",
+            "key.namelength" : 18,
+            "key.nameoffset" : 2264,
+            "key.offset" : 2260,
+            "key.parsed_declaration" : "internal var remainingArguments: [String]?",
+            "key.parsed_scope.end" : 92,
+            "key.parsed_scope.start" : 90,
+            "key.typename" : "[String]?",
+            "key.typeusr" : "_T0SaySSGSgD",
+            "key.usr" : "s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
+            "key.bodylength" : 281,
+            "key.bodyoffset" : 2640,
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was enabled or disabled, or nil if it\nwas not given at all.\n\nIf the key is found, it is then removed from the list of arguments\nremaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the key is found, it is then removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"99\" column=\"16\"><Name>consumeBoolean(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF<\/USR><Declaration>internal func consumeBoolean(forKey key: String) -&gt; Bool?<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was enabled or disabled, or nil if it was not given at all.<\/Para><\/Abstract><Discussion><Para>If the key is found, it is then removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 99,
+            "key.doc.name" : "consumeBoolean(forKey:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 332,
+            "key.name" : "consumeBoolean(forKey:)",
+            "key.namelength" : 34,
+            "key.nameoffset" : 2595,
+            "key.offset" : 2590,
+            "key.parsed_declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.parsed_scope.end" : 115,
+            "key.parsed_scope.start" : 99,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF\">consumeBoolean(flag:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool?",
+            "key.typeusr" : "_T0SbSgSS6forKey_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeValue(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:6Result7NoErrorO\">NoError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.bodylength" : 503,
+            "key.bodyoffset" : 3318,
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the value associated with the given flag, or nil if the flag was\nnot specified. If the key is presented, but no value was given, an error\nis returned.\n\nIf a value is found, the key and the value are both removed from the\nlist of arguments remaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<NoError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"123\" column=\"16\"><Name>consumeValue(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC12consumeValue6ResultAEOySSSgAA0A5ErrorOyAE02NoG0OGGSS6forKey_tF<\/USR><Declaration>internal func consumeValue(forKey key: String) -&gt; Result&lt;String?, CommandantError&lt;NoError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the value associated with the given flag, or nil if the flag was not specified. If the key is presented, but no value was given, an error is returned.<\/Para><\/Abstract><Discussion><Para>If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 123,
+            "key.doc.name" : "consumeValue(forKey:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeValue<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.enum usr=\"s:6Result7NoErrorO\">NoError<\/ref.enum>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 588,
+            "key.name" : "consumeValue(forKey:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 3239,
+            "key.offset" : 3234,
+            "key.parsed_declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<NoError>>",
+            "key.parsed_scope.end" : 148,
+            "key.parsed_scope.start" : 123,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Result<String?, CommandantError<NoError>>",
+            "key.typeusr" : "_T06ResultAAOySSSg10Commandant0B5ErrorOyAA02NoC0OGGSS6forKey_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6ResultAEOySSSgAA0A5ErrorOyAE02NoG0OGGSS6forKey_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumePositionalArgument() -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.bodylength" : 164,
+            "key.bodyoffset" : 4007,
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the next positional argument that hasn't yet been returned, or\nnil if there are no more positional arguments.",
+            "key.doc.declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"152\" column=\"16\"><Name>consumePositionalArgument()<\/Name><USR>s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF<\/USR><Declaration>internal func consumePositionalArgument() -&gt; String?<\/Declaration><CommentParts><Abstract><Para>Returns the next positional argument that hasn’t yet been returned, or nil if there are no more positional arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 152,
+            "key.doc.name" : "consumePositionalArgument()",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumePositionalArgument<\/decl.name>() -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 210,
+            "key.name" : "consumePositionalArgument()",
+            "key.namelength" : 27,
+            "key.nameoffset" : 3967,
+            "key.offset" : 3962,
+            "key.parsed_declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.parsed_scope.end" : 161,
+            "key.parsed_scope.start" : 152,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> () -> String?",
+            "key.typeusr" : "_T0SSSgycD",
+            "key.usr" : "s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consume(key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.bodylength" : 143,
+            "key.bodyoffset" : 4326,
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consume(key: String) -> Bool",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"165\" column=\"16\"><Name>consume(key:)<\/Name><USR>s:10Commandant14ArgumentParserC7consumeSbSS3key_tF<\/USR><Declaration>internal func consume(key: String) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 165,
+            "key.doc.name" : "consume(key:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consume<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 179,
+            "key.name" : "consume(key:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 4296,
+            "key.offset" : 4291,
+            "key.parsed_declaration" : "internal func consume(key: String) -> Bool",
+            "key.parsed_scope.end" : 170,
+            "key.parsed_scope.start" : 165,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool",
+            "key.typeusr" : "_T0SbSS3key_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC7consumeSbSS3key_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(flag: <Type usr=\"s:s9CharacterV\">Character<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.bodylength" : 316,
+            "key.bodyoffset" : 4636,
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given flag was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"174\" column=\"16\"><Name>consumeBoolean(flag:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF<\/USR><Declaration>internal func consumeBoolean(flag: Character) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given flag was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 174,
+            "key.doc.name" : "consumeBoolean(flag:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s9CharacterV\">Character<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 363,
+            "key.name" : "consumeBoolean(flag:)",
+            "key.namelength" : 31,
+            "key.nameoffset" : 4595,
+            "key.offset" : 4590,
+            "key.parsed_declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.parsed_scope.end" : 191,
+            "key.parsed_scope.start" : 174,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF\">consumeBoolean(forKey:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (Character) -> Bool",
+            "key.typeusr" : "_T0Sbs9CharacterV4flag_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF"
           }
         ],
-        "key.typename" : "HelpOptions<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant11HelpOptionsVyxGmD",
-        "key.usr" : "s:10Commandant11HelpOptionsV"
+        "key.typename" : "ArgumentParser.Type",
+        "key.typeusr" : "_T010Commandant14ArgumentParserCmD",
+        "key.usr" : "s:10Commandant14ArgumentParserC"
       }
     ]
   }
@@ -2089,525 +1867,290 @@
     ]
   }
 }, {
-  "Sources\/Commandant\/Option.swift" : {
+  "Sources\/Commandant\/Command.swift" : {
     "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
-    "key.length" : 9680,
+    "key.length" : 7159,
     "key.offset" : 0,
     "key.substructure" : [
       {
         "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public protocol OptionsProtocol<\/Declaration>",
-        "key.bodylength" : 233,
-        "key.bodyoffset" : 1435,
+        "key.annotated_decl" : "<Declaration>public protocol CommandProtocol<\/Declaration>",
+        "key.bodylength" : 473,
+        "key.bodyoffset" : 294,
         "key.doc.column" : 17,
-        "key.doc.comment" : "Represents a record of options for a command, which can be parsed from\na list of command-line arguments.\n\nThis is most helpful when used in conjunction with the `Option` and `Switch`\ntypes, and `<*>` and `<|` combinators.\n\nExample:\n\n\tstruct LogOptions: OptionsProtocol {\n\t\tlet verbosity: Int\n\t\tlet outputFilename: String\n\t\tlet shouldDelete: Bool\n\t\tlet logName: String\n\n\t\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {\n\t\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }\n\t\t}\n\n\t\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {\n\t\t\treturn create\n\t\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")\n\t\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")\n\t\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")\n\t\t\t\t<*> m <| Argument(usage: \"the log to read\")\n\t\t}\n\t}",
-        "key.doc.declaration" : "public protocol OptionsProtocol",
-        "key.doc.discussion" : [
-          {
-            "Para" : "This is most helpful when used in conjunction with the `Option` and `Switch` types, and `<*>` and `<|` combinators."
-          },
-          {
-            "Para" : "Example:"
-          },
-          {
-            "CodeListing" : ""
-          }
-        ],
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"38\" column=\"17\"><Name>OptionsProtocol<\/Name><USR>s:10Commandant15OptionsProtocolP<\/USR><Declaration>public protocol OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a record of options for a command, which can be parsed from a list of command-line arguments.<\/Para><\/Abstract><Discussion><Para>This is most helpful when used in conjunction with the <codeVoice>Option<\/codeVoice> and <codeVoice>Switch<\/codeVoice> types, and <codeVoice>&lt;*&gt;<\/codeVoice> and <codeVoice>&lt;|<\/codeVoice> combinators.<\/Para><Para>Example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct LogOptions: OptionsProtocol {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet verbosity: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet outputFilename: String]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet shouldDelete: Bool]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet logName: String]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn create]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Argument(usage: \"the log to read\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
-        "key.doc.line" : 38,
-        "key.doc.name" : "OptionsProtocol",
+        "key.doc.comment" : "Represents a subcommand that can be executed with its own set of arguments.",
+        "key.doc.declaration" : "public protocol CommandProtocol",
+        "key.doc.file" : "Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"13\" column=\"17\"><Name>CommandProtocol<\/Name><USR>s:10Commandant15CommandProtocolP<\/USR><Declaration>public protocol CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a subcommand that can be executed with its own set of arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "CommandProtocol",
         "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>OptionsProtocol<\/decl.name><\/decl.protocol>",
+        "key.filepath" : "Sources\/Commandant\/Command.swift",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>CommandProtocol<\/decl.name><\/decl.protocol>",
         "key.kind" : "source.lang.swift.decl.protocol",
-        "key.length" : 260,
-        "key.name" : "OptionsProtocol",
+        "key.length" : 500,
+        "key.name" : "CommandProtocol",
         "key.namelength" : 15,
-        "key.nameoffset" : 1418,
-        "key.offset" : 1409,
-        "key.parsed_declaration" : "public protocol OptionsProtocol",
-        "key.parsed_scope.end" : 45,
-        "key.parsed_scope.start" : 38,
-        "key.runtime_name" : "_TtP8__main__15OptionsProtocol_",
+        "key.nameoffset" : 277,
+        "key.offset" : 268,
+        "key.parsed_declaration" : "public protocol CommandProtocol",
+        "key.parsed_scope.end" : 30,
+        "key.parsed_scope.start" : 13,
+        "key.runtime_name" : "_TtP8__main__15CommandProtocol_",
         "key.substructure" : [
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP11ClientError\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Evaluates this set of options in the given mode.\n\nReturns the parsed options or a `UsageError`.",
-            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Returns the parsed options or a `UsageError`."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 44,
-            "key.doc.name" : "evaluate(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientError\">ClientError<\/ref.associatedtype>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 84,
-            "key.name" : "evaluate(_:)",
-            "key.namelength" : 26,
-            "key.nameoffset" : 1595,
-            "key.offset" : 1583,
-            "key.parsed_declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 44,
-            "key.parsed_scope.start" : 44,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<Self where Self : OptionsProtocol> (Self.Type) -> (CommandMode) -> Result<Self, CommandantError<Self.ClientError>>",
-            "key.typeusr" : "_T06ResultAAOyx10Commandant0B5ErrorOy06ClientC0QzGGAC11CommandModeOcD",
-            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
-          }
-        ],
-        "key.typename" : "OptionsProtocol.Protocol",
-        "key.typeusr" : "_T010Commandant15OptionsProtocol_pmD",
-        "key.usr" : "s:10Commandant15OptionsProtocolP"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public struct NoOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.bodylength" : 155,
-        "key.bodyoffset" : 1779,
-        "key.doc.column" : 15,
-        "key.doc.comment" : "An `OptionsProtocol` that has no options.",
-        "key.doc.declaration" : "public struct NoOptions<ClientError> : OptionsProtocol where ClientError : Error",
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"48\" column=\"15\"><Name>NoOptions<\/Name><USR>s:10Commandant9NoOptionsV<\/USR><Declaration>public struct NoOptions&lt;ClientError&gt; : OptionsProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>An <codeVoice>OptionsProtocol<\/codeVoice> that has no options.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 48,
-        "key.doc.name" : "NoOptions",
-        "key.doc.type" : "Class",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 15,
-            "key.offset" : 1762
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>NoOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "OptionsProtocol"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 211,
-        "key.name" : "NoOptions",
-        "key.namelength" : 9,
-        "key.nameoffset" : 1731,
-        "key.offset" : 1724,
-        "key.parsed_declaration" : "public struct NoOptions<ClientError: Error>: OptionsProtocol",
-        "key.parsed_scope.end" : 54,
-        "key.parsed_scope.start" : 48,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
-            "key.bodylength" : 0,
-            "key.bodyoffset" : 1796,
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 9,
-            "key.name" : "init()",
-            "key.namelength" : 6,
-            "key.nameoffset" : 1788,
-            "key.offset" : 1788,
-            "key.parsed_declaration" : "public init()",
-            "key.parsed_scope.end" : 49,
-            "key.parsed_scope.start" : 49,
-            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> () -> NoOptions<ClientError>",
-            "key.typeusr" : "_T010Commandant9NoOptionsVyxGycD",
-            "key.usr" : "s:10Commandant9NoOptionsVACyxGycfc"
+            "key.annotated_decl" : "<Declaration>associatedtype Options : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type><\/Declaration>",
+            "key.doc.column" : 17,
+            "key.doc.comment" : "The command's options type.",
+            "key.doc.declaration" : "associatedtype Options : OptionsProtocol",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"16\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7Options<\/USR><Declaration>associatedtype Options : OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 16,
+            "key.doc.name" : "Options",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Options<\/decl.name> : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 7,
+            "key.name" : "Options",
+            "key.offset" : 346,
+            "key.parsed_declaration" : "associatedtype Options: OptionsProtocol",
+            "key.parsed_scope.end" : 16,
+            "key.parsed_scope.start" : 16,
+            "key.typename" : "Self.Options.Type",
+            "key.typeusr" : "_T07Options10Commandant15CommandProtocolPQzmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP7Options"
           },
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.bodylength" : 33,
-            "key.bodyoffset" : 1899,
-            "key.doc.column" : 14,
-            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Returns the parsed options or a `UsageError`."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 44,
-            "key.doc.name" : "evaluate(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 125,
-            "key.name" : "evaluate(_:)",
-            "key.namelength" : 26,
-            "key.nameoffset" : 1820,
-            "key.offset" : 1808,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
-              }
-            ],
-            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 53,
-            "key.parsed_scope.start" : 51,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> (CommandMode) -> Result<NoOptions<ClientError>, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOy10Commandant9NoOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
-            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
-          }
-        ],
-        "key.typename" : "NoOptions<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant9NoOptionsVyxGmD",
-        "key.usr" : "s:10Commandant9NoOptionsV"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
-        "key.bodylength" : 786,
-        "key.bodyoffset" : 2028,
-        "key.doc.column" : 15,
-        "key.doc.comment" : "Describes an option that can be provided on the command line.",
-        "key.doc.declaration" : "public struct Option<T>",
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"57\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 57,
-        "key.doc.name" : "Option",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 805,
-        "key.name" : "Option",
-        "key.namelength" : 6,
-        "key.nameoffset" : 2017,
-        "key.offset" : 2010,
-        "key.parsed_declaration" : "public struct Option<T>",
-        "key.parsed_scope.end" : 79,
-        "key.parsed_scope.start" : 57,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.doc.column" : 13,
-            "key.doc.comment" : "The key that controls this option. For example, a key of `verbose` would\nbe used for a `--verbose` option.",
-            "key.doc.declaration" : "public let key: String",
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"60\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6OptionV3keySSv<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that controls this option. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 60,
-            "key.doc.name" : "key",
+            "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 536,
+            "key.doc.column" : 6,
+            "key.doc.comment" : "The action that users should specify to use this subcommand (e.g.,\n`help`).",
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"22\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSv<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 22,
+            "key.doc.name" : "verb",
             "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
             "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 15,
-            "key.name" : "key",
-            "key.namelength" : 3,
-            "key.nameoffset" : 2158,
-            "key.offset" : 2154,
-            "key.parsed_declaration" : "public let key: String",
-            "key.parsed_scope.end" : 60,
-            "key.parsed_scope.start" : 60,
+            "key.length" : 24,
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 522,
+            "key.offset" : 518,
+            "key.parsed_declaration" : "var verb: String",
+            "key.parsed_scope.end" : 22,
+            "key.parsed_scope.start" : 22,
             "key.typename" : "String",
             "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant6OptionV3keySSv"
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
           },
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type><\/Declaration>",
-            "key.doc.column" : 13,
-            "key.doc.comment" : "The default value for this option. This is the value that will be used\nif the option is never explicitly specified on the command line.",
-            "key.doc.declaration" : "public let defaultValue: T",
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"64\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant6OptionV12defaultValuexv<\/USR><Declaration>public let defaultValue: T<\/Declaration><CommentParts><Abstract><Para>The default value for this option. This is the value that will be used if the option is never explicitly specified on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 64,
-            "key.doc.name" : "defaultValue",
+            "key.annotated_decl" : "<Declaration>var function: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 652,
+            "key.doc.column" : 6,
+            "key.doc.comment" : "A human-readable, high-level description of what this command is used\nfor.",
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"26\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSv<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 26,
+            "key.doc.name" : "function",
             "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.type><\/decl.var.instance>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
             "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 19,
-            "key.name" : "defaultValue",
-            "key.namelength" : 12,
-            "key.nameoffset" : 2329,
-            "key.offset" : 2325,
-            "key.parsed_declaration" : "public let defaultValue: T",
-            "key.parsed_scope.end" : 64,
-            "key.parsed_scope.start" : 64,
-            "key.typename" : "T",
-            "key.typeusr" : "_T0xD",
-            "key.usr" : "s:10Commandant6OptionV12defaultValuexv"
+            "key.length" : 28,
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 634,
+            "key.offset" : 630,
+            "key.parsed_declaration" : "var function: String",
+            "key.parsed_scope.end" : 26,
+            "key.parsed_scope.start" : 26,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
           },
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.doc.column" : 13,
-            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.\n\nFor boolean operations, this should describe the effect of _not_ using\nthe default value (i.e., what will happen if you disable\/enable the flag\ndifferently from the default).",
-            "key.doc.declaration" : "public let usage: String",
-            "key.doc.discussion" : [
-              {
-                "Para" : "For boolean operations, this should describe the effect of  using the default value (i.e., what will happen if you disable\/enable the flag differently from the default)."
-              }
+            "key.annotated_decl" : "<Declaration>func run(_ options: <Type usr=\"s:10Commandant15CommandProtocolP7Options\">Options<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant15CommandProtocolP11ClientError\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.doc.column" : 7,
+            "key.doc.comment" : "Runs this subcommand with the given options.",
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"29\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 29,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7Options\">Options<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientError\">ClientError<\/ref.associatedtype>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 55,
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 716,
+            "key.offset" : 711,
+            "key.parsed_declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 29,
+            "key.parsed_scope.start" : 29,
+            "key.substructure" : [
+
             ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"72\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6OptionV5usageSSv<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><Discussion><Para>For boolean operations, this should describe the effect of <emphasis>not<\/emphasis> using the default value (i.e., what will happen if you disable\/enable the flag differently from the default).<\/Para><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.line" : 72,
-            "key.doc.name" : "usage",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.typename" : "<Self where Self : CommandProtocol> (Self) -> (Self.Options) -> Result<(), Self.ClientError>",
+            "key.typeusr" : "_T06ResultAAOyyt11ClientErrorQzG7OptionsQzcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "CommandProtocol.Protocol",
+        "key.typeusr" : "_T010Commandant15CommandProtocol_pmD",
+        "key.usr" : "s:10Commandant15CommandProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 997,
+        "key.bodyoffset" : 847,
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A type-erased command.",
+        "key.doc.declaration" : "public struct CommandWrapper<ClientError> where ClientError : Error",
+        "key.doc.file" : "Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"33\" column=\"15\"><Name>CommandWrapper<\/Name><USR>s:10Commandant14CommandWrapperV<\/USR><Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A type-erased command.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 33,
+        "key.doc.name" : "CommandWrapper",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/Command.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>CommandWrapper<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1041,
+        "key.name" : "CommandWrapper",
+        "key.namelength" : 14,
+        "key.nameoffset" : 811,
+        "key.offset" : 804,
+        "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error>",
+        "key.parsed_scope.end" : 66,
+        "key.parsed_scope.start" : 33,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
             "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 17,
+            "key.length" : 16,
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 860,
+            "key.offset" : 856,
+            "key.parsed_declaration" : "public let verb: String",
+            "key.parsed_scope.end" : 34,
+            "key.parsed_scope.start" : 34,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV4verbSSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 885,
+            "key.offset" : 881,
+            "key.parsed_declaration" : "public let function: String",
+            "key.parsed_scope.end" : 35,
+            "key.parsed_scope.start" : 35,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV8functionSSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let run: (<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>run<\/decl.name>: <decl.var.type>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 69,
+            "key.name" : "run",
+            "key.namelength" : 3,
+            "key.nameoffset" : 916,
+            "key.offset" : 912,
+            "key.parsed_declaration" : "public let run: (ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 37,
+            "key.typename" : "(ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOyyt10Commandant0B5ErrorOyxGGAC14ArgumentParserCcD",
+            "key.usr" : "s:10Commandant14CommandWrapperV3run6ResultAEOyytAA0A5ErrorOyxGGAA14ArgumentParserCcv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: () -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;?<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type>() -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
             "key.name" : "usage",
             "key.namelength" : 5,
-            "key.nameoffset" : 2663,
-            "key.offset" : 2659,
-            "key.parsed_declaration" : "public let usage: String",
-            "key.parsed_scope.end" : 72,
-            "key.parsed_scope.start" : 72,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant6OptionV5usageSSv"
+            "key.nameoffset" : 996,
+            "key.offset" : 992,
+            "key.parsed_declaration" : "public let usage: () -> CommandantError<ClientError>?",
+            "key.parsed_scope.end" : 39,
+            "key.parsed_scope.start" : 39,
+            "key.typename" : "() -> CommandantError<ClientError>?",
+            "key.typeusr" : "_T010Commandant0A5ErrorOyxGSgycD",
+            "key.usr" : "s:10Commandant14CommandWrapperV5usageAA0A5ErrorOyxGSgycv"
           },
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public init(key: <Type usr=\"s:SS\">String<\/Type>, defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
-            "key.bodylength" : 75,
-            "key.bodyoffset" : 2737,
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate init&lt;C&gt;(_ command: <Type usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>) where ClientError == C.ClientError, C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type>, C.ClientError == C.Options.ClientError<\/Declaration>",
+            "key.bodylength" : 633,
+            "key.bodyoffset" : 1209,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Creates a command that wraps another.",
+            "key.doc.declaration" : "fileprivate init<C>(_ command: C) where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"42\" column=\"14\"><Name>init(_:)<\/Name><USR>s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc<\/USR><Declaration>fileprivate init&lt;C&gt;(_ command: C) where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError<\/Declaration><CommentParts><Abstract><Para>Creates a command that wraps another.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 42,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>command<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError == C.ClientError<\/decl.generic_type_requirement>, <decl.generic_type_requirement>C : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement>, <decl.generic_type_requirement>C.ClientError == C.Options.ClientError<\/decl.generic_type_requirement><\/decl.function.constructor>",
             "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 127,
-            "key.name" : "init(key:defaultValue:usage:)",
-            "key.namelength" : 49,
-            "key.nameoffset" : 2686,
-            "key.offset" : 2686,
-            "key.parsed_declaration" : "public init(key: String, defaultValue: T, usage: String)",
-            "key.parsed_scope.end" : 78,
-            "key.parsed_scope.start" : 74,
+            "key.length" : 747,
+            "key.name" : "init(_:)",
+            "key.namelength" : 38,
+            "key.nameoffset" : 1096,
+            "key.offset" : 1096,
+            "key.parsed_declaration" : "fileprivate init<C: CommandProtocol>(_ command: C) where C.ClientError == ClientError, C.Options.ClientError == ClientError",
+            "key.parsed_scope.end" : 65,
+            "key.parsed_scope.start" : 42,
             "key.substructure" : [
 
             ],
-            "key.typename" : "<T> (Option<T>.Type) -> (String, T, String) -> Option<T>",
-            "key.typeusr" : "_T010Commandant6OptionVyxGSS3key_x12defaultValueSS5usagetcD",
-            "key.usr" : "s:10Commandant6OptionVACyxGSS3key_x12defaultValueSS5usagetcfc"
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError> (CommandWrapper<ClientError>.Type) -> (C) -> CommandWrapper<ClientError>",
+            "key.typeusr" : "_T010Commandant14CommandWrapperVyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSluD",
+            "key.usr" : "s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc"
           }
         ],
-        "key.typename" : "Option<T>.Type",
-        "key.typeusr" : "_T010Commandant6OptionVyxGmD",
-        "key.usr" : "s:10Commandant6OptionV"
-      },
-      {
-        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
-        "key.bodylength" : 58,
-        "key.bodyoffset" : 2860,
-        "key.doc.column" : 15,
-        "key.doc.declaration" : "public struct Option<T>",
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"57\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 57,
-        "key.doc.name" : "Option",
-        "key.doc.type" : "Class",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 23,
-            "key.offset" : 2835
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "CustomStringConvertible"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 102,
-        "key.name" : "Option",
-        "key.namelength" : 6,
-        "key.nameoffset" : 2827,
-        "key.offset" : 2817,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 22,
-            "key.bodyoffset" : 2894,
-            "key.doc.declaration" : "var description: String { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Instead of accessing this property directly, convert an instance of any type to a string by using the `String(describing:)` initializer. For example:"
-              },
-              {
-                "CodeListing" : ""
-              },
-              {
-                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSv<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Instead of accessing this property directly, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "description",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 48,
-            "key.name" : "description",
-            "key.namelength" : 11,
-            "key.nameoffset" : 2873,
-            "key.offset" : 2869,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
-              }
-            ],
-            "key.parsed_declaration" : "public var description: String",
-            "key.parsed_scope.end" : 84,
-            "key.parsed_scope.start" : 82,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
-          }
-        ],
-        "key.typename" : "Option<T>.Type",
-        "key.typeusr" : "_T010Commandant6OptionVyxGmD",
-        "key.usr" : "s:10Commandant6OptionV"
-      },
-      {
-        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
-        "key.length" : 17,
-        "key.name" : "MARK: - Operators",
-        "key.namelength" : 0,
-        "key.nameoffset" : 0,
-        "key.offset" : 2924
+        "key.typename" : "CommandWrapper<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant14CommandWrapperVyxGmD",
+        "key.usr" : "s:10Commandant14CommandWrapperV"
       },
       {
         "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: (<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, value: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-        "key.bodylength" : 22,
-        "key.bodyoffset" : 4560,
-        "key.doc.column" : 13,
-        "key.doc.comment" : "Applies `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
-        "key.doc.declaration" : "public func <*><T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.doc.discussion" : [
-          {
-            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
-          }
-        ],
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"123\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: (T) -&gt; U, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-        "key.doc.line" : 123,
-        "key.doc.name" : "<*>(_:_:)",
-        "key.doc.type" : "Function",
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt;<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
-        "key.kind" : "source.lang.swift.decl.function.free",
-        "key.length" : 157,
-        "key.name" : "<*>(_:_:)",
-        "key.namelength" : 84,
-        "key.nameoffset" : 4431,
-        "key.offset" : 4426,
-        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.parsed_scope.end" : 125,
-        "key.parsed_scope.start" : 123,
-        "key.related_decls" : [
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF\">&lt;*&gt;&lt;T, U, ClientError&gt;(_: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-          }
-        ],
-        "key.substructure" : [
-          {
-            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
-            "key.kind" : "source.lang.swift.decl.generic_type_param",
-            "key.length" : 1,
-            "key.name" : "T",
-            "key.offset" : 4436,
-            "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 123,
-            "key.parsed_scope.start" : 123,
-            "key.typename" : "T.Type",
-            "key.typeusr" : "_T0xmD",
-            "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp"
-          }
-        ],
-        "key.typename" : "<T, U, ClientError> ((T) -> U, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.typeusr" : "_T06ResultAAOyq_10Commandant0B5ErrorOyq0_GGq_xc_AByxAFGtcr1_luD",
-        "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;((<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;, value: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-        "key.bodylength" : 346,
-        "key.bodyoffset" : 4993,
-        "key.doc.column" : 13,
-        "key.doc.comment" : "Applies the function in `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
-        "key.doc.declaration" : "public func <*><T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.doc.discussion" : [
-          {
-            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
-          }
-        ],
-        "key.doc.file" : "Sources\/Commandant\/Option.swift",
-        "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"131\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies the function in <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-        "key.doc.line" : 131,
-        "key.doc.name" : "<*>(_:_:)",
-        "key.doc.type" : "Function",
-        "key.filepath" : "Sources\/Commandant\/Option.swift",
-        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt;<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>(<tuple.element><tuple.element.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/tuple.element.type><\/tuple.element>)<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
-        "key.kind" : "source.lang.swift.decl.function.free",
-        "key.length" : 521,
-        "key.name" : "<*>(_:_:)",
-        "key.namelength" : 124,
-        "key.nameoffset" : 4824,
-        "key.offset" : 4819,
-        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.parsed_scope.end" : 146,
-        "key.parsed_scope.start" : 131,
-        "key.related_decls" : [
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF\">&lt;*&gt;&lt;T, U, ClientError&gt;(_: (T) -&gt; U, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-          }
-        ],
-        "key.substructure" : [
-          {
-            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
-            "key.kind" : "source.lang.swift.decl.generic_type_param",
-            "key.length" : 1,
-            "key.name" : "T",
-            "key.offset" : 4829,
-            "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 131,
-            "key.parsed_scope.start" : 131,
-            "key.typename" : "T.Type",
-            "key.typeusr" : "_T0xmD",
-            "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp"
-          }
-        ],
-        "key.typename" : "<T, U, ClientError> (Result<((T) -> U), CommandantError<ClientError>>, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
-        "key.typeusr" : "_T06ResultAAOyq_10Commandant0B5ErrorOyq0_GGAByq_xcAFG_AByxAFGtcr1_luD",
-        "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF"
-      },
-      {
         "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
-        "key.bodylength" : 4313,
-        "key.bodyoffset" : 5365,
+        "key.bodylength" : 216,
+        "key.bodyoffset" : 1928,
         "key.doc.column" : 13,
+        "key.doc.comment" : "Describes the \"mode\" in which a command should run.",
         "key.doc.declaration" : "public enum CommandMode",
         "key.doc.file" : "Sources\/Commandant\/Command.swift",
         "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"69\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
@@ -2616,382 +2159,475 @@
         "key.doc.type" : "Other",
         "key.filepath" : "Sources\/Commandant\/Command.swift",
         "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 4337,
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 235,
         "key.name" : "CommandMode",
         "key.namelength" : 11,
-        "key.nameoffset" : 5352,
-        "key.offset" : 5342,
+        "key.nameoffset" : 1915,
+        "key.offset" : 1910,
+        "key.parsed_declaration" : "public enum CommandMode",
+        "key.parsed_scope.end" : 76,
+        "key.parsed_scope.start" : 69,
         "key.substructure" : [
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-            "key.bodylength" : 230,
-            "key.bodyoffset" : 5692,
-            "key.doc.column" : 21,
-            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
-            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>> where T : ArgumentProtocol",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"153\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 153,
-            "key.doc.name" : "<|(_:_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 363,
-            "key.name" : "<|(_:_:)",
-            "key.namelength" : 75,
-            "key.nameoffset" : 5572,
-            "key.offset" : 5560,
-            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 158,
-            "key.parsed_scope.start" : 153,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              }
-            ],
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 30,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 1999,
             "key.substructure" : [
               {
-                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-                "key.filepath" : "Sources\/Commandant\/Option.swift",
-                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
-                "key.kind" : "source.lang.swift.decl.generic_type_param",
-                "key.length" : 1,
-                "key.name" : "T",
-                "key.offset" : 5576,
-                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
-                "key.parsed_scope.end" : 153,
-                "key.parsed_scope.start" : 153,
-                "key.typename" : "T.Type",
-                "key.typeusr" : "_T0xmD",
-                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case arguments(<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>)<\/Declaration>",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Options should be parsed from the given command-line arguments.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"71\" column=\"7\"><Name>arguments<\/Name><USR>s:10Commandant11CommandModeO9argumentsAcA14ArgumentParserCcACmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Options should be parsed from the given command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 71,
+                "key.doc.name" : "arguments",
+                "key.doc.type" : "Other",
+                "key.filepath" : "Sources\/Commandant\/Command.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>(<ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 25,
+                "key.name" : "arguments",
+                "key.namelength" : 9,
+                "key.nameoffset" : 2004,
+                "key.offset" : 2004,
+                "key.parsed_declaration" : "case arguments(ArgumentParser)",
+                "key.parsed_scope.end" : 71,
+                "key.parsed_scope.start" : 71,
+                "key.typename" : "(CommandMode.Type) -> (ArgumentParser) -> CommandMode",
+                "key.typeusr" : "_T010Commandant11CommandModeOAA14ArgumentParserCcACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO9argumentsAcA14ArgumentParserCcACmF"
               }
-            ],
-            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T>) -> Result<T, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC6OptionVyxGtcAC16ArgumentProtocolRzr0_luD",
-            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ"
+            ]
           },
           {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-            "key.bodylength" : 856,
-            "key.bodyoffset" : 6231,
-            "key.doc.column" : 21,
-            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
-            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>> where T : ArgumentProtocol",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"164\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 164,
-            "key.doc.name" : "<|(_:_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 991,
-            "key.name" : "<|(_:_:)",
-            "key.namelength" : 76,
-            "key.nameoffset" : 6109,
-            "key.offset" : 6097,
-            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 197,
-            "key.parsed_scope.start" : 164,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              }
-            ],
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 10,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 2133,
             "key.substructure" : [
               {
-                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-                "key.filepath" : "Sources\/Commandant\/Option.swift",
-                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
-                "key.kind" : "source.lang.swift.decl.generic_type_param",
-                "key.length" : 1,
-                "key.name" : "T",
-                "key.offset" : 6113,
-                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
-                "key.parsed_scope.end" : 164,
-                "key.parsed_scope.start" : 164,
-                "key.typename" : "T.Type",
-                "key.typeusr" : "_T0xmD",
-                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case usage<\/Declaration>",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Each option should record its usage information in an error, for\npresentation to the user.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"75\" column=\"7\"><Name>usage<\/Name><USR>s:10Commandant11CommandModeO5usageA2CmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Each option should record its usage information in an error, for presentation to the user.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 75,
+                "key.doc.name" : "usage",
+                "key.doc.type" : "Other",
+                "key.filepath" : "Sources\/Commandant\/Command.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usage<\/decl.name><\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 5,
+                "key.name" : "usage",
+                "key.namelength" : 5,
+                "key.nameoffset" : 2138,
+                "key.offset" : 2138,
+                "key.parsed_declaration" : "case usage",
+                "key.parsed_scope.end" : 75,
+                "key.parsed_scope.start" : 75,
+                "key.typename" : "(CommandMode.Type) -> CommandMode",
+                "key.typeusr" : "_T010Commandant11CommandModeOACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO5usageA2CmF"
               }
-            ],
-            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T?>) -> Result<T?, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOyxSg10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
-            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-            "key.bodylength" : 232,
-            "key.bodyoffset" : 7420,
-            "key.doc.column" : 21,
-            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
-            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>> where T : ArgumentProtocol",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"203\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 203,
-            "key.doc.name" : "<|(_:_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 369,
-            "key.name" : "<|(_:_:)",
-            "key.namelength" : 77,
-            "key.nameoffset" : 7296,
-            "key.offset" : 7284,
-            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 208,
-            "key.parsed_scope.start" : 203,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-              {
-                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-                "key.filepath" : "Sources\/Commandant\/Option.swift",
-                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
-                "key.kind" : "source.lang.swift.decl.generic_type_param",
-                "key.length" : 1,
-                "key.name" : "T",
-                "key.offset" : 7300,
-                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
-                "key.parsed_scope.end" : 203,
-                "key.parsed_scope.start" : 203,
-                "key.typename" : "T.Type",
-                "key.typeusr" : "_T0xmD",
-                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
-              }
-            ],
-            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
-            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-            "key.bodylength" : 1117,
-            "key.bodyoffset" : 7965,
-            "key.doc.column" : 21,
-            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
-            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>> where T : ArgumentProtocol",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"214\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 214,
-            "key.doc.name" : "<|(_:_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 1256,
-            "key.name" : "<|(_:_:)",
-            "key.namelength" : 78,
-            "key.nameoffset" : 7839,
-            "key.offset" : 7827,
-            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 255,
-            "key.parsed_scope.start" : 214,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-              {
-                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
-                "key.filepath" : "Sources\/Commandant\/Option.swift",
-                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
-                "key.kind" : "source.lang.swift.decl.generic_type_param",
-                "key.length" : 1,
-                "key.name" : "T",
-                "key.offset" : 7843,
-                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
-                "key.parsed_scope.end" : 214,
-                "key.parsed_scope.start" : 214,
-                "key.typename" : "T.Type",
-                "key.typeusr" : "_T0xmD",
-                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
-              }
-            ],
-            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOySayxGSg10Commandant0B5ErrorOyq_GGAE11CommandModeO_AE6OptionVyADGtcAE16ArgumentProtocolRzr0_luD",
-            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.bodylength" : 272,
-            "key.bodyoffset" : 9404,
-            "key.doc.column" : 21,
-            "key.doc.comment" : "Evaluates the given boolean option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
-            "key.doc.declaration" : "public static func <|<ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Option.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"261\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ<\/USR><Declaration>public static func &lt;|&lt;ClientError&gt;(mode: CommandMode, option: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 261,
-            "key.doc.name" : "<|(_:_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Option.swift",
-            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
-            "key.kind" : "source.lang.swift.decl.function.method.static",
-            "key.length" : 390,
-            "key.name" : "<|(_:_:)",
-            "key.namelength" : 57,
-            "key.nameoffset" : 9299,
-            "key.offset" : 9287,
-            "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 273,
-            "key.parsed_scope.start" : 261,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
-              },
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-              {
-                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
-                "key.filepath" : "Sources\/Commandant\/Option.swift",
-                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
-                "key.kind" : "source.lang.swift.decl.generic_type_param",
-                "key.length" : 11,
-                "key.name" : "ClientError",
-                "key.offset" : 9303,
-                "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
-                "key.parsed_scope.end" : 261,
-                "key.parsed_scope.start" : 261,
-                "key.typename" : "ClientError.Type",
-                "key.typeusr" : "_T0xmD",
-                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp"
-              }
-            ],
-            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6OptionVySbGtcluD",
-            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ"
+            ]
           }
         ],
         "key.typename" : "CommandMode.Type",
         "key.typeusr" : "_T010Commandant11CommandModeOmD",
         "key.usr" : "s:10Commandant11CommandModeO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final"
+          }
+        ],
+        "key.bodylength" : 1242,
+        "key.bodyoffset" : 2256,
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Maintains the list of commands available to run.",
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"79\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 79,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/Command.swift",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 1286,
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 2219,
+        "key.offset" : 2213,
+        "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error>",
+        "key.parsed_scope.end" : 117,
+        "key.parsed_scope.start" : 79,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private var commandsByVerb: [<Type usr=\"s:SS\">String<\/Type> : <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;ClientError&gt;]<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commandsByVerb<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct> : <ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;ClientError&gt;]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 63,
+            "key.name" : "commandsByVerb",
+            "key.namelength" : 14,
+            "key.nameoffset" : 2270,
+            "key.offset" : 2266,
+            "key.parsed_declaration" : "private var commandsByVerb: [String: CommandWrapper<ClientError>] = [:]",
+            "key.parsed_scope.end" : 80,
+            "key.parsed_scope.start" : 80,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[String : CommandWrapper<ClientError>]",
+            "key.typeusr" : "_T0s10DictionaryVySS10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC14commandsByVerb33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs10DictionaryVySSAA0B7WrapperVyxGGv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var commands: [<Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;] { get }<\/Declaration>",
+            "key.bodylength" : 69,
+            "key.bodyoffset" : 2413,
+            "key.doc.column" : 13,
+            "key.doc.comment" : "All available commands.",
+            "key.doc.declaration" : "public var commands: [CommandWrapper<ClientError>] { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"83\" column=\"13\"><Name>commands<\/Name><USR>s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGv<\/USR><Declaration>public var commands: [CommandWrapper&lt;ClientError&gt;] { get }<\/Declaration><CommentParts><Abstract><Para>All available commands.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 83,
+            "key.doc.name" : "commands",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commands<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 115,
+            "key.name" : "commands",
+            "key.namelength" : 8,
+            "key.nameoffset" : 2372,
+            "key.offset" : 2368,
+            "key.parsed_declaration" : "public var commands: [CommandWrapper<ClientError>]",
+            "key.parsed_scope.end" : 85,
+            "key.parsed_scope.start" : 83,
+            "key.typename" : "[CommandWrapper<ClientError>]",
+            "key.typeusr" : "_T0Say10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 2501,
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 2493,
+            "key.offset" : 2493,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 87,
+            "key.parsed_scope.start" : 87,
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>.Type) -> () -> CommandRegistry<ClientError>",
+            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGycD",
+            "key.usr" : "s:10Commandant15CommandRegistryCACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>@discardableResult public func register&lt;C&gt;(_ commands: <Type usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\">C<\/Type>...) -&gt; <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type> where ClientError == C.ClientError, C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type>, C.ClientError == C.Options.ClientError<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult"
+              }
+            ],
+            "key.bodylength" : 106,
+            "key.bodyoffset" : 2857,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Registers the given commands, making those available to run.\n\nIf another commands were already registered with the same `verb`s, those\nwill be overwritten.",
+            "key.doc.declaration" : "public func register<C>(_ commands: C...) -> CommandRegistry where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If another commands were already registered with the same `verb`s, those will be overwritten."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"94\" column=\"14\"><Name>register(_:)<\/Name><USR>s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF<\/USR><Declaration>public func register&lt;C&gt;(_ commands: C...) -&gt; CommandRegistry where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError<\/Declaration><CommentParts><Abstract><Para>Registers the given commands, making those available to run.<\/Para><\/Abstract><Discussion><Para>If another commands were already registered with the same <codeVoice>verb<\/codeVoice>s, those will be overwritten.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 94,
+            "key.doc.name" : "register(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>register<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>commands<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type>...<\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class><\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError == C.ClientError<\/decl.generic_type_requirement>, <decl.generic_type_requirement>C : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement>, <decl.generic_type_requirement>C.ClientError == C.Options.ClientError<\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 257,
+            "key.name" : "register(_:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 2712,
+            "key.offset" : 2707,
+            "key.parsed_declaration" : "public func register<C: CommandProtocol>(_ commands: C...)\n\t-> CommandRegistry\n\twhere C.ClientError == ClientError, C.Options.ClientError == ClientError",
+            "key.parsed_scope.end" : 102,
+            "key.parsed_scope.start" : 94,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError> (CommandRegistry<ClientError>) -> (C...) -> CommandRegistry<ClientError>",
+            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGSayqd__Gd_tc11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AFQYd__AGRSluD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(command verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;?<\/Declaration>",
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 3246,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Runs the command corresponding to the given verb, passing it the given\narguments.\n\nReturns the results of the execution, or nil if no such command exists.",
+            "key.doc.declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the results of the execution, or nil if no such command exists."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"108\" column=\"14\"><Name>run(command:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC3run6ResultAEOyytAA0A5ErrorOyxGGSgSS7command_SaySSG9argumentstF<\/USR><Declaration>public func run(command verb: String, arguments: [String]) -&gt; Result&lt;(), CommandantError&lt;ClientError&gt;&gt;?<\/Declaration><CommentParts><Abstract><Para>Runs the command corresponding to the given verb, passing it the given arguments.<\/Para><\/Abstract><Discussion><Para>Returns the results of the execution, or nil if no such command exists.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 108,
+            "key.doc.name" : "run(command:arguments:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>command<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 153,
+            "key.name" : "run(command:arguments:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 3153,
+            "key.offset" : 3148,
+            "key.parsed_declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.parsed_scope.end" : 110,
+            "key.parsed_scope.start" : 108,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.typeusr" : "_T06ResultAAOyyt10Commandant0B5ErrorOyxGGSgSS7command_SaySSG9argumentstcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC3run6ResultAEOyytAA0A5ErrorOyxGGSgSS7command_SaySSG9argumentstF"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>public subscript(verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;? { get }<\/Declaration>",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Returns the command matching the given verb, or nil if no such command\nis registered.",
+            "key.doc.declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>? { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"114\" column=\"9\"><Name>subscript(_:)<\/Name><USR>s:10Commandant15CommandRegistryC9subscriptAA0B7WrapperVyxGSgSSci<\/USR><Declaration>public subscript(verb: String) -&gt; CommandWrapper&lt;ClientError&gt;? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the command matching the given verb, or nil if no such command is registered.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 114,
+            "key.doc.name" : "subscript(_:)",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
+            "key.kind" : "source.lang.swift.decl.function.subscript",
+            "key.length" : 9,
+            "key.name" : "subscript(_:)",
+            "key.offset" : 3407,
+            "key.parsed_declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>?",
+            "key.parsed_scope.end" : 114,
+            "key.parsed_scope.start" : 114,
+            "key.typename" : "<ClientError where ClientError : Error> (String) -> CommandWrapper<ClientError>?",
+            "key.typeusr" : "_T010Commandant14CommandWrapperVyxGSgSScD",
+            "key.usr" : "s:10Commandant15CommandRegistryC9subscriptAA0B7WrapperVyxGSgSSci"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 3629,
+        "key.bodyoffset" : 3528,
+        "key.doc.column" : 20,
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"79\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 79,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/Command.swift",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 3657,
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 3511,
+        "key.offset" : 3501,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; ()) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 4412,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing CommandLine.arguments\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"137\" column=\"14\"><Name>main(defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF<\/USR><Declaration>public func main(defaultVerb: String, errorHandler: (ClientError) -&gt; ()) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing CommandLine.arguments and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 137,
+            "key.doc.name" : "main(defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><tuple>()<\/tuple><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 175,
+            "key.name" : "main(defaultVerb:errorHandler:)",
+            "key.namelength" : 60,
+            "key.nameoffset" : 4340,
+            "key.offset" : 4335,
+            "key.parsed_declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
+            "key.parsed_scope.end" : 139,
+            "key.parsed_scope.start" : 137,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF\">main(arguments:defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "_T0s5NeverOSS11defaultVerb_yxc12errorHandlertcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(arguments: [<Type usr=\"s:SS\">String<\/Type>], defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; ()) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.bodylength" : 947,
+            "key.bodyoffset" : 5407,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing `arguments`\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"158\" column=\"14\"><Name>main(arguments:defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF<\/USR><Declaration>public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -&gt; ()) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing <codeVoice>arguments<\/codeVoice> and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 158,
+            "key.doc.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><tuple>()<\/tuple><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 1046,
+            "key.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.namelength" : 81,
+            "key.nameoffset" : 5314,
+            "key.offset" : 5309,
+            "key.parsed_declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
+            "key.parsed_scope.end" : 197,
+            "key.parsed_scope.start" : 158,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF\">main(defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> ([String], String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "_T0s5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private func executeSubcommandIfExists(_ executableName: <Type usr=\"s:SS\">String<\/Type>, verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type>?<\/Declaration>",
+            "key.bodylength" : 489,
+            "key.bodyoffset" : 6666,
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Finds and executes a subcommand which exists in your $PATH. The executable\nname must be in the form of `executable-verb`.\n\n- Returns: The exit status of found subcommand or nil.",
+            "key.doc.declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"203\" column=\"15\"><Name>executeSubcommandIfExists(_:verb:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF<\/USR><Declaration>private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -&gt; Int32?<\/Declaration><CommentParts><Abstract><Para>Finds and executes a subcommand which exists in your $PATH. The executable name must be in the form of <codeVoice>executable-verb<\/codeVoice>.<\/Para><\/Abstract><ResultDiscussion><Para>The exit status of found subcommand or nil.<\/Para><\/ResultDiscussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 203,
+            "key.doc.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The exit status of found subcommand or nil."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Command.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>executeSubcommandIfExists<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>executableName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 593,
+            "key.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.namelength" : 86,
+            "key.nameoffset" : 6568,
+            "key.offset" : 6563,
+            "key.parsed_declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.parsed_scope.end" : 222,
+            "key.parsed_scope.start" : 203,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>func launchTask(_ path: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type><\/Declaration>",
+                "key.bodylength" : 159,
+                "key.bodyoffset" : 6816,
+                "key.filepath" : "Sources\/Commandant\/Command.swift",
+                "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>launchTask<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>path<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct><\/decl.function.returntype><\/decl.function.free>",
+                "key.kind" : "source.lang.swift.decl.function.free",
+                "key.length" : 223,
+                "key.name" : "launchTask(_:arguments:)",
+                "key.namelength" : 47,
+                "key.nameoffset" : 6758,
+                "key.offset" : 6753,
+                "key.parsed_declaration" : "func launchTask(_ path: String, arguments: [String]) -> Int32",
+                "key.parsed_scope.end" : 215,
+                "key.parsed_scope.start" : 206,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "<ClientError where ClientError : Error> (String, arguments: [String]) -> Int32",
+                "key.typeusr" : "_T0s5Int32VSS_SaySSG9argumentstcs5ErrorRzluD",
+                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF10launchTaskL_AGSS_AjKts5ErrorRzlF"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, String, [String]) -> Int32?",
+            "key.typeusr" : "_T0s5Int32VSgSS_SS4verbSaySSG9argumentstcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
       }
     ]
   }
@@ -3912,6 +3548,2022 @@
     ]
   }
 }, {
+  "Sources\/Commandant\/HelpCommand.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 2157,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpCommand&lt;ClientError&gt; : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 1066,
+        "key.bodyoffset" : 615,
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A basic implementation of a `help` command, using information available in a\n`CommandRegistry`.\n\nIf you want to use this command, initialize it with the registry, then add\nit to that same registry:\n\n\tlet commands: CommandRegistry<MyErrorType> = …\n\tlet helpCommand = HelpCommand(registry: commands)\n\tcommands.register(helpCommand)",
+        "key.doc.declaration" : "public struct HelpCommand<ClientError> : CommandProtocol where ClientError : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "If you want to use this command, initialize it with the registry, then add it to that same registry:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "Sources\/Commandant\/HelpCommand.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/HelpCommand.swift\" line=\"21\" column=\"15\"><Name>HelpCommand<\/Name><USR>s:10Commandant11HelpCommandV<\/USR><Declaration>public struct HelpCommand&lt;ClientError&gt; : CommandProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A basic implementation of a <codeVoice>help<\/codeVoice> command, using information available in a <codeVoice>CommandRegistry<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>If you want to use this command, initialize it with the registry, then add it to that same registry:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let commands: CommandRegistry<MyErrorType> = …]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let helpCommand = HelpCommand(registry: commands)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[commands.register(helpCommand)]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 21,
+        "key.doc.name" : "HelpCommand",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 598
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpCommand<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CommandProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1124,
+        "key.name" : "HelpCommand",
+        "key.namelength" : 11,
+        "key.nameoffset" : 565,
+        "key.offset" : 558,
+        "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error>: CommandProtocol",
+        "key.parsed_scope.end" : 59,
+        "key.parsed_scope.start" : 21,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"22\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSv<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 22,
+            "key.doc.name" : "verb",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 682,
+            "key.offset" : 678,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
+              }
+            ],
+            "key.parsed_declaration" : "public let verb = \"help\"",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"26\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSv<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 26,
+            "key.doc.name" : "function",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 57,
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 708,
+            "key.offset" : 704,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
+              }
+            ],
+            "key.parsed_declaration" : "public let function = \"Display general or command-specific help\"",
+            "key.parsed_scope.end" : 25,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private let registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>registry<\/decl.name>: <decl.var.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 42,
+            "key.name" : "registry",
+            "key.namelength" : 8,
+            "key.nameoffset" : 776,
+            "key.offset" : 772,
+            "key.parsed_declaration" : "private let registry: CommandRegistry<ClientError>",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 27,
+            "key.typename" : "CommandRegistry<ClientError>",
+            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGD",
+            "key.usr" : "s:10Commandant11HelpCommandV8registry33_38F61CE0DF9D73793CEDF5D1C3140331LLAA0C8RegistryCyxGv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;)<\/Declaration>",
+            "key.bodylength" : 29,
+            "key.bodyoffset" : 957,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the command to provide help from the given registry of\ncommands.",
+            "key.doc.declaration" : "public init(registry: CommandRegistry<ClientError>)",
+            "key.doc.file" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/HelpCommand.swift\" line=\"31\" column=\"9\"><Name>init(registry:)<\/Name><USR>s:10Commandant11HelpCommandVACyxGAA0C8RegistryCyxG8registry_tcfc<\/USR><Declaration>public init(registry: CommandRegistry&lt;ClientError&gt;)<\/Declaration><CommentParts><Abstract><Para>Initializes the command to provide help from the given registry of commands.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 31,
+            "key.doc.name" : "init(registry:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>registry<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 76,
+            "key.name" : "init(registry:)",
+            "key.namelength" : 44,
+            "key.nameoffset" : 911,
+            "key.offset" : 911,
+            "key.parsed_declaration" : "public init(registry: CommandRegistry<ClientError>)",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 31,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>.Type) -> (CommandRegistry<ClientError>) -> HelpCommand<ClientError>",
+            "key.typeusr" : "_T010Commandant11HelpCommandVyxGAA0C8RegistryCyxG8registry_tcD",
+            "key.usr" : "s:10Commandant11HelpCommandVACyxGAA0C8RegistryCyxG8registry_tcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(_ options: <Type usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.bodylength" : 625,
+            "key.bodyoffset" : 1054,
+            "key.doc.column" : 7,
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.file" : "Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"29\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 29,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 683,
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 1002,
+            "key.offset" : 997,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
+              }
+            ],
+            "key.parsed_declaration" : "public func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 58,
+            "key.parsed_scope.start" : 35,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>) -> (HelpOptions<ClientError>) -> Result<(), ClientError>",
+            "key.typeusr" : "_T06ResultAAOyytxG10Commandant11HelpOptionsVyxGcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "HelpCommand<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant11HelpCommandVyxGmD",
+        "key.usr" : "s:10Commandant11HelpCommandV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 407,
+        "key.bodyoffset" : 1748,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1731
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 465,
+        "key.name" : "HelpOptions",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1698,
+        "key.offset" : 1691,
+        "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 76,
+        "key.parsed_scope.start" : 61,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate let verb: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 1766,
+            "key.offset" : 1762,
+            "key.parsed_declaration" : "fileprivate let verb: String?",
+            "key.parsed_scope.end" : 62,
+            "key.parsed_scope.start" : 62,
+            "key.typename" : "String?",
+            "key.typeusr" : "_T0SSSgD",
+            "key.usr" : "s:10Commandant11HelpOptionsV4verb33_38F61CE0DF9D73793CEDF5D1C3140331LLSSSgv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private init(verb: <Type usr=\"s:SS\">String<\/Type>?)<\/Declaration>",
+            "key.bodylength" : 21,
+            "key.bodyoffset" : 1812,
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 43,
+            "key.name" : "init(verb:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 1791,
+            "key.offset" : 1791,
+            "key.parsed_declaration" : "private init(verb: String?)",
+            "key.parsed_scope.end" : 66,
+            "key.parsed_scope.start" : 64,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String?) -> HelpOptions<ClientError>",
+            "key.typeusr" : "_T010Commandant11HelpOptionsVyxGSSSg4verb_tcD",
+            "key.usr" : "s:10Commandant11HelpOptionsVACyxGSSSg4verb_tc33_38F61CE0DF9D73793CEDF5D1C3140331Llfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private static func create(_ verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type><\/Declaration>",
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 1896,
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>create<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 106,
+            "key.name" : "create(_:)",
+            "key.namelength" : 22,
+            "key.nameoffset" : 1857,
+            "key.offset" : 1845,
+            "key.parsed_declaration" : "private static func create(_ verb: String) -> HelpOptions",
+            "key.parsed_scope.end" : 70,
+            "key.parsed_scope.start" : 68,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String) -> HelpOptions<ClientError>",
+            "key.typeusr" : "_T010Commandant11HelpOptionsVyxGSScD",
+            "key.usr" : "s:10Commandant11HelpOptionsV6create33_38F61CE0DF9D73793CEDF5D1C3140331LLACyxGSSFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.bodylength" : 99,
+            "key.bodyoffset" : 2054,
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 44,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/HelpCommand.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 193,
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1973,
+            "key.offset" : 1961,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 72,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (CommandMode) -> Result<HelpOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOy10Commandant11HelpOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "HelpOptions<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant11HelpOptionsVyxGmD",
+        "key.usr" : "s:10Commandant11HelpOptionsV"
+      }
+    ]
+  }
+}, {
+  "Sources\/Commandant\/Option.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 9680,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol OptionsProtocol<\/Declaration>",
+        "key.bodylength" : 233,
+        "key.bodyoffset" : 1435,
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a record of options for a command, which can be parsed from\na list of command-line arguments.\n\nThis is most helpful when used in conjunction with the `Option` and `Switch`\ntypes, and `<*>` and `<|` combinators.\n\nExample:\n\n\tstruct LogOptions: OptionsProtocol {\n\t\tlet verbosity: Int\n\t\tlet outputFilename: String\n\t\tlet shouldDelete: Bool\n\t\tlet logName: String\n\n\t\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {\n\t\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }\n\t\t}\n\n\t\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {\n\t\t\treturn create\n\t\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")\n\t\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")\n\t\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")\n\t\t\t\t<*> m <| Argument(usage: \"the log to read\")\n\t\t}\n\t}",
+        "key.doc.declaration" : "public protocol OptionsProtocol",
+        "key.doc.discussion" : [
+          {
+            "Para" : "This is most helpful when used in conjunction with the `Option` and `Switch` types, and `<*>` and `<|` combinators."
+          },
+          {
+            "Para" : "Example:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"38\" column=\"17\"><Name>OptionsProtocol<\/Name><USR>s:10Commandant15OptionsProtocolP<\/USR><Declaration>public protocol OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a record of options for a command, which can be parsed from a list of command-line arguments.<\/Para><\/Abstract><Discussion><Para>This is most helpful when used in conjunction with the <codeVoice>Option<\/codeVoice> and <codeVoice>Switch<\/codeVoice> types, and <codeVoice>&lt;*&gt;<\/codeVoice> and <codeVoice>&lt;|<\/codeVoice> combinators.<\/Para><Para>Example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct LogOptions: OptionsProtocol {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet verbosity: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet outputFilename: String]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet shouldDelete: Bool]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet logName: String]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn create]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Argument(usage: \"the log to read\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 38,
+        "key.doc.name" : "OptionsProtocol",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>OptionsProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 260,
+        "key.name" : "OptionsProtocol",
+        "key.namelength" : 15,
+        "key.nameoffset" : 1418,
+        "key.offset" : 1409,
+        "key.parsed_declaration" : "public protocol OptionsProtocol",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 38,
+        "key.runtime_name" : "_TtP8__main__15OptionsProtocol_",
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP11ClientError\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Evaluates this set of options in the given mode.\n\nReturns the parsed options or a `UsageError`.",
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 44,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientError\">ClientError<\/ref.associatedtype>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 84,
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1595,
+            "key.offset" : 1583,
+            "key.parsed_declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 44,
+            "key.parsed_scope.start" : 44,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : OptionsProtocol> (Self.Type) -> (CommandMode) -> Result<Self, CommandantError<Self.ClientError>>",
+            "key.typeusr" : "_T06ResultAAOyx10Commandant0B5ErrorOy06ClientC0QzGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "OptionsProtocol.Protocol",
+        "key.typeusr" : "_T010Commandant15OptionsProtocol_pmD",
+        "key.usr" : "s:10Commandant15OptionsProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct NoOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 155,
+        "key.bodyoffset" : 1779,
+        "key.doc.column" : 15,
+        "key.doc.comment" : "An `OptionsProtocol` that has no options.",
+        "key.doc.declaration" : "public struct NoOptions<ClientError> : OptionsProtocol where ClientError : Error",
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"48\" column=\"15\"><Name>NoOptions<\/Name><USR>s:10Commandant9NoOptionsV<\/USR><Declaration>public struct NoOptions&lt;ClientError&gt; : OptionsProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>An <codeVoice>OptionsProtocol<\/codeVoice> that has no options.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 48,
+        "key.doc.name" : "NoOptions",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1762
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>NoOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 211,
+        "key.name" : "NoOptions",
+        "key.namelength" : 9,
+        "key.nameoffset" : 1731,
+        "key.offset" : 1724,
+        "key.parsed_declaration" : "public struct NoOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 1796,
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 1788,
+            "key.offset" : 1788,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 49,
+            "key.parsed_scope.start" : 49,
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> () -> NoOptions<ClientError>",
+            "key.typeusr" : "_T010Commandant9NoOptionsVyxGycD",
+            "key.usr" : "s:10Commandant9NoOptionsVACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 1899,
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"44\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 44,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 125,
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1820,
+            "key.offset" : 1808,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 53,
+            "key.parsed_scope.start" : 51,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> (CommandMode) -> Result<NoOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOy10Commandant9NoOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluate6ResultAEOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "NoOptions<ClientError>.Type",
+        "key.typeusr" : "_T010Commandant9NoOptionsVyxGmD",
+        "key.usr" : "s:10Commandant9NoOptionsV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 786,
+        "key.bodyoffset" : 2028,
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes an option that can be provided on the command line.",
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"57\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 57,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 805,
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2017,
+        "key.offset" : 2010,
+        "key.parsed_declaration" : "public struct Option<T>",
+        "key.parsed_scope.end" : 79,
+        "key.parsed_scope.start" : 57,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The key that controls this option. For example, a key of `verbose` would\nbe used for a `--verbose` option.",
+            "key.doc.declaration" : "public let key: String",
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"60\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6OptionV3keySSv<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that controls this option. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 60,
+            "key.doc.name" : "key",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 15,
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 2158,
+            "key.offset" : 2154,
+            "key.parsed_declaration" : "public let key: String",
+            "key.parsed_scope.end" : 60,
+            "key.parsed_scope.start" : 60,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant6OptionV3keySSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type><\/Declaration>",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The default value for this option. This is the value that will be used\nif the option is never explicitly specified on the command line.",
+            "key.doc.declaration" : "public let defaultValue: T",
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"64\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant6OptionV12defaultValuexv<\/USR><Declaration>public let defaultValue: T<\/Declaration><CommentParts><Abstract><Para>The default value for this option. This is the value that will be used if the option is never explicitly specified on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 64,
+            "key.doc.name" : "defaultValue",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 19,
+            "key.name" : "defaultValue",
+            "key.namelength" : 12,
+            "key.nameoffset" : 2329,
+            "key.offset" : 2325,
+            "key.parsed_declaration" : "public let defaultValue: T",
+            "key.parsed_scope.end" : 64,
+            "key.parsed_scope.start" : 64,
+            "key.typename" : "T",
+            "key.typeusr" : "_T0xD",
+            "key.usr" : "s:10Commandant6OptionV12defaultValuexv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.\n\nFor boolean operations, this should describe the effect of _not_ using\nthe default value (i.e., what will happen if you disable\/enable the flag\ndifferently from the default).",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.discussion" : [
+              {
+                "Para" : "For boolean operations, this should describe the effect of  using the default value (i.e., what will happen if you disable\/enable the flag differently from the default)."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Option.swift\" line=\"72\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6OptionV5usageSSv<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><Discussion><Para>For boolean operations, this should describe the effect of <emphasis>not<\/emphasis> using the default value (i.e., what will happen if you disable\/enable the flag differently from the default).<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 72,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 2663,
+            "key.offset" : 2659,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 72,
+            "key.parsed_scope.start" : 72,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:10Commandant6OptionV5usageSSv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(key: <Type usr=\"s:SS\">String<\/Type>, defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+            "key.bodylength" : 75,
+            "key.bodyoffset" : 2737,
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 127,
+            "key.name" : "init(key:defaultValue:usage:)",
+            "key.namelength" : 49,
+            "key.nameoffset" : 2686,
+            "key.offset" : 2686,
+            "key.parsed_declaration" : "public init(key: String, defaultValue: T, usage: String)",
+            "key.parsed_scope.end" : 78,
+            "key.parsed_scope.start" : 74,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T> (Option<T>.Type) -> (String, T, String) -> Option<T>",
+            "key.typeusr" : "_T010Commandant6OptionVyxGSS3key_x12defaultValueSS5usagetcD",
+            "key.usr" : "s:10Commandant6OptionVACyxGSS3key_x12defaultValueSS5usagetcfc"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "_T010Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 58,
+        "key.bodyoffset" : 2860,
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Option.swift\" line=\"57\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 57,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 2835
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 102,
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2827,
+        "key.offset" : 2817,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 22,
+            "key.bodyoffset" : 2894,
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Instead of accessing this property directly, convert an instance of any type to a string by using the `String(describing:)` initializer. For example:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSv<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Instead of accessing this property directly, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 48,
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2873,
+            "key.offset" : 2869,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 84,
+            "key.parsed_scope.start" : 82,
+            "key.typename" : "String",
+            "key.typeusr" : "_T0SSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "_T010Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 2924
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: (<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, value: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.bodylength" : 22,
+        "key.bodyoffset" : 4560,
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*><T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"123\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: (T) -&gt; U, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 123,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt;<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 157,
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 84,
+        "key.nameoffset" : 4431,
+        "key.offset" : 4426,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 125,
+        "key.parsed_scope.start" : 123,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF\">&lt;*&gt;&lt;T, U, ClientError&gt;(_: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.offset" : 4436,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 123,
+            "key.parsed_scope.start" : 123,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "_T0xmD",
+            "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> ((T) -> U, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "_T06ResultAAOyq_10Commandant0B5ErrorOyq0_GGq_xc_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;((<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;, value: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.bodylength" : 346,
+        "key.bodyoffset" : 4993,
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies the function in `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*><T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"131\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt;&lt;T, U, ClientError&gt;(f: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies the function in <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 131,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.filepath" : "Sources\/Commandant\/Option.swift",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt;<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>(<tuple.element><tuple.element.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/tuple.element.type><\/tuple.element>)<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 521,
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 124,
+        "key.nameoffset" : 4824,
+        "key.offset" : 4819,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 146,
+        "key.parsed_scope.start" : 131,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGq_xc_ADyxAGGtr1_lF\">&lt;*&gt;&lt;T, U, ClientError&gt;(_: (T) -&gt; U, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.offset" : 4829,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 131,
+            "key.parsed_scope.start" : 131,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "_T0xmD",
+            "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> (Result<((T) -> U), CommandantError<ClientError>>, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "_T06ResultAAOyq_10Commandant0B5ErrorOyq0_GGAByq_xcAFG_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoi6ResultACOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 4313,
+        "key.bodyoffset" : 5365,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"69\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 69,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Sources\/Commandant\/Command.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 4337,
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 5352,
+        "key.offset" : 5342,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.bodylength" : 230,
+            "key.bodyoffset" : 5692,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>> where T : ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"153\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 153,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 363,
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 75,
+            "key.nameoffset" : 5572,
+            "key.offset" : 5560,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 158,
+            "key.parsed_scope.start" : 153,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.filepath" : "Sources\/Commandant\/Option.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "T",
+                "key.offset" : 5576,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
+                "key.parsed_scope.end" : 153,
+                "key.parsed_scope.start" : 153,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "_T0xmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC6OptionVyxGtcAC16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.bodylength" : 856,
+            "key.bodyoffset" : 6231,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>> where T : ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"164\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 164,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 991,
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 76,
+            "key.nameoffset" : 6109,
+            "key.offset" : 6097,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 197,
+            "key.parsed_scope.start" : 164,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.filepath" : "Sources\/Commandant\/Option.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "T",
+                "key.offset" : 6113,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+                "key.parsed_scope.end" : 164,
+                "key.parsed_scope.start" : 164,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "_T0xmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOyxSg10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.bodylength" : 232,
+            "key.bodyoffset" : 7420,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>> where T : ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"203\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 203,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 369,
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 77,
+            "key.nameoffset" : 7296,
+            "key.offset" : 7284,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 208,
+            "key.parsed_scope.start" : 203,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.filepath" : "Sources\/Commandant\/Option.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "T",
+                "key.offset" : 7300,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+                "key.parsed_scope.end" : 203,
+                "key.parsed_scope.start" : 203,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "_T0xmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.bodylength" : 1117,
+            "key.bodyoffset" : 7965,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <|<T, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>> where T : ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"214\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;|&lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 214,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 1256,
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 78,
+            "key.nameoffset" : 7839,
+            "key.offset" : 7827,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 255,
+            "key.parsed_scope.start" : 214,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.filepath" : "Sources\/Commandant\/Option.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "T",
+                "key.offset" : 7843,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+                "key.parsed_scope.end" : 214,
+                "key.parsed_scope.start" : 214,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "_T0xmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOySayxGSg10Commandant0B5ErrorOyq_GGAE11CommandModeO_AE6OptionVyADGtcAE16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;|&lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.bodylength" : 272,
+            "key.bodyoffset" : 9404,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given boolean option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <|<ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Option.swift\" line=\"261\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ<\/USR><Declaration>public static func &lt;|&lt;ClientError&gt;(mode: CommandMode, option: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 261,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/Option.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;|<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 390,
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 57,
+            "key.nameoffset" : 9299,
+            "key.offset" : 9287,
+            "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 273,
+            "key.parsed_scope.start" : 261,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;|&lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;|&lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.filepath" : "Sources\/Commandant\/Option.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.name" : "ClientError",
+                "key.offset" : 9303,
+                "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+                "key.parsed_scope.end" : 261,
+                "key.parsed_scope.start" : 261,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "_T0xmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp"
+              }
+            ],
+            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.typeusr" : "_T06ResultAAOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6OptionVySbGtcluD",
+            "key.usr" : "s:10Commandant11CommandModeO2looi6ResultAEOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "_T010Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}, {
+  "Sources\/Commandant\/OrderedSet.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 921,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
+        "key.bodylength" : 343,
+        "key.bodyoffset" : 71,
+        "key.doc.column" : 17,
+        "key.doc.comment" : "A poor man's ordered set.",
+        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
+        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 376,
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 46,
+        "key.offset" : 39,
+        "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable>",
+        "key.parsed_scope.end" : 19,
+        "key.parsed_scope.start" : 2,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate var values: [T]<\/Declaration>",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>values<\/decl.name>: <decl.var.type>[T]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.name" : "values",
+            "key.namelength" : 6,
+            "key.nameoffset" : 89,
+            "key.offset" : 85,
+            "key.parsed_declaration" : "fileprivate var values: [T] = []",
+            "key.parsed_scope.end" : 3,
+            "key.parsed_scope.start" : 3,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.typename" : "[T]",
+            "key.typeusr" : "_T0SayxGD",
+            "key.usr" : "s:10Commandant10OrderedSetV6values33_E700A43BE27995F7283A44882E2B4A42LLSayxGv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>init&lt;S&gt;(_ sequence: <Type usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\">S<\/Type>) where T == S.Element, S : <Type usr=\"s:s8SequenceP\">Sequence<\/Type><\/Declaration>",
+            "key.bodylength" : 74,
+            "key.bodyoffset" : 163,
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\"><decl.generic_type_param.name>S<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>sequence<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T == S.Element<\/decl.generic_type_requirement>, <decl.generic_type_requirement>S : <ref.protocol usr=\"s:s8SequenceP\">Sequence<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 130,
+            "key.name" : "init(_:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 108,
+            "key.offset" : 108,
+            "key.parsed_declaration" : "init<S: Sequence>(_ sequence: S) where S.Element == T",
+            "key.parsed_scope.end" : 9,
+            "key.parsed_scope.start" : 5,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T, S where T : Hashable, T == S.Element, S : Sequence> (OrderedSet<T>.Type) -> (S) -> OrderedSet<T>",
+            "key.typeusr" : "_T010Commandant10OrderedSetVyxGqd__c7ElementQyd__Rszs8SequenceRd__luD",
+            "key.usr" : "s:10Commandant10OrderedSetVACyxGqd__c7ElementQyd__Rszs8SequenceRd__lufc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>@discardableResult mutating func remove(_ member: <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.mutating"
+              },
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult"
+              }
+            ],
+            "key.bodylength" : 110,
+            "key.bodyoffset" : 302,
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>remove<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>member<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 143,
+            "key.name" : "remove(_:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 275,
+            "key.offset" : 270,
+            "key.parsed_declaration" : "mutating func remove(_ member: T) -> T?",
+            "key.parsed_scope.end" : 18,
+            "key.parsed_scope.start" : 12,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (inout OrderedSet<T>) -> (T) -> T?",
+            "key.typeusr" : "_T0xSgxcD",
+            "key.usr" : "s:10Commandant10OrderedSetV6removexSgxF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
+        "key.bodylength" : 101,
+        "key.bodyoffset" : 450,
+        "key.doc.column" : 17,
+        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
+        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 439
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 135,
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 427,
+        "key.offset" : 417,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>static func ==(lhs: <Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>, rhs: <Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.bodylength" : 36,
+            "key.bodyoffset" : 513,
+            "key.doc.declaration" : "static func ==(lhs: Self, rhs: Self) -> Bool",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Equality is the inverse of inequality. For any values `a` and `b`, `a == b` implies that `a != b` is `false`."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Function><Name>==(_:_:)<\/Name><USR>s:s9EquatableP2eeoiSbx_xtFZ<\/USR><Declaration>static func ==(lhs: Self, rhs: Self) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are equal.<\/Para><\/Abstract><Parameters><Parameter><Name>lhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A value to compare.<\/Para><\/Discussion><\/Parameter><Parameter><Name>rhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>Another value to compare.<\/Para><\/Discussion><\/Parameter><\/Parameters><Discussion><Para>Equality is the inverse of inequality. For any values <codeVoice>a<\/codeVoice> and <codeVoice>b<\/codeVoice>, <codeVoice>a == b<\/codeVoice> implies that <codeVoice>a != b<\/codeVoice> is <codeVoice>false<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.name" : "==(_:_:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "A value to compare."
+                  }
+                ],
+                "name" : "lhs"
+              },
+              {
+                "discussion" : [
+                  {
+                    "Para" : "Another value to compare."
+                  }
+                ],
+                "name" : "rhs"
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>==<\/decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 98,
+            "key.name" : "==(_:_:)",
+            "key.namelength" : 39,
+            "key.nameoffset" : 464,
+            "key.offset" : 452,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s9EquatableP2eeoiSbx_xtFZ"
+              }
+            ],
+            "key.parsed_declaration" : "static func == (_ lhs: OrderedSet, rhs: OrderedSet) -> Bool",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 22,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation15AffineTransformV2eeoiSbAC_ACtFZ\">==(_: AffineTransform, _: AffineTransform) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8CalendarV2eeoiSbAC_ACtFZ\">==(_: Calendar, _: Calendar) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12CharacterSetV2eeoiSbAC_ACtFZ\">==(_: CharacterSet, _: CharacterSet) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DataV2eeoiSbAC_ACtFZ\">==(_: Data, _: Data) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DateV2eeoiSbAC_ACtFZ\">==(_: Date, _: Date) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation14DateComponentsV2eeoiSbAC_ACtFZ\">==(_: DateComponents, _: DateComponents) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12DateIntervalV2eeoiSbAC_ACtFZ\">==(_: DateInterval, _: DateInterval) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC7DecimalV10FoundationE2eeoiSbAB_ABtFZ\">==(_: Decimal, _: Decimal) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation9IndexPathV2eeoiSbAC_ACtFZ\">==(_: IndexPath, _: IndexPath) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV0B0V2eeoiSbAE_AEtFZ\">==(_: IndexSet.Index, _: IndexSet.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV9RangeViewV2eeoiSbAE_AEtFZ\">==(_: IndexSet.RangeView, _: IndexSet.RangeView) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV2eeoiSbAC_ACtFZ\">==(_: IndexSet, _: IndexSet) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation6LocaleV2eeoiSbAC_ACtFZ\">==(_: Locale, _: Locale) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation11MeasurementV2eeoiSbACyqd__G_ACyqd_0_GtSo4UnitCRbd__AHRbd_0_r0_lFZ\">==&lt;LeftHandSideType, RightHandSideType&gt;(_: Measurement&lt;LeftHandSideType&gt;, _: Measurement&lt;RightHandSideType&gt;) -&gt; Bool where LeftHandSideType : Unit, RightHandSideType : Unit<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12NotificationV2eeoiSbAC_ACtFZ\">==(_: Notification, _: Notification) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs13SignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs15UnsignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation21_BridgedStoredNSErrorPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC8_NSRangeV10FoundationE2eeoiSbAB_ABtFZ\">==(_: NSRange, _: NSRange) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS10FoundationE8EncodingV2eeoiSbAC_ACtFZ\">==(_: String.Encoding, _: String.Encoding) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation20PersonNameComponentsV2eeoiSbAC_ACtFZ\">==(_: PersonNameComponents, _: PersonNameComponents) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8TimeZoneV2eeoiSbAC_ACtFZ\">==(_: TimeZone, _: TimeZone) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation3URLV2eeoiSbAC_ACtFZ\">==(_: URL, _: URL) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation13URLComponentsV2eeoiSbAC_ACtFZ\">==(_: URLComponents, _: URLComponents) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12URLQueryItemV2eeoiSbAC_ACtFZ\">==(_: URLQueryItem, _: URLQueryItem) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation10URLRequestV2eeoiSbAC_ACtFZ\">==(_: URLRequest, _: URLRequest) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4UUIDV2eeoiSbAC_ACtFZ\">==(_: UUID, _: UUID) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:14CoreFoundation9_CFObjectPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Darwin2eeoiSbAA0A7BooleanV_ADtF\">==(_: DarwinBoolean, _: DarwinBoolean) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch2eeoiSbAA0A3QoSV_ADtF\">==(_: DispatchQoS, _: DispatchQoS) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A4TimeV2eeoiSbAC_ACtFZ\">==(_: DispatchTime, _: DispatchTime) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A8WallTimeV2eeoiSbAC_ACtFZ\">==(_: DispatchWallTime, _: DispatchWallTime) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A12TimeIntervalO2eeoiSbAC_ACtFZ\">==(_: DispatchTimeInterval, _: DispatchTimeInterval) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbAA8SelectorV_ADtF\">==(_: Selector, _: Selector) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbSo8NSObjectC_ADtF\">==(_: NSObject, _: NSObject) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC17CGAffineTransformV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGAffineTransform, _: CGAffineTransform) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC7CGPointV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGPoint, _: CGPoint) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGSizeV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGSize, _: CGSize) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC8CGVectorV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGVector, _: CGVector) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGRectV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGRect, _: CGRect) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs15ContiguousArrayVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ContiguousArray&lt;Element&gt;, _: ContiguousArray&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs10ArraySliceVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ArraySlice&lt;Element&gt;, _: ArraySlice&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbSayxG_ABts9EquatableRzlF\">==&lt;Element&gt;(_: Array&lt;Element&gt;, _: Array&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbypXpSg_ABtF\">==(_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_ABts9EquatableRzlF\">==&lt;T&gt;(_: T?, _: T?) -&gt; Bool where T : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_s26_OptionalNilComparisonTypeVtlF\">==&lt;T&gt;(_: T?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs26_OptionalNilComparisonTypeV_xSgtlF\">==&lt;T&gt;(_: _OptionalNilComparisonType, _: T?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbyt_yttF\">==(_: (), _: ()) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_t_x_q_tts9EquatableRzsABR_r0_lF\">==&lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_t_x_q_q0_tts9EquatableRzsABR_sABR0_r1_lF\">==&lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_t_x_q_q0_q1_tts9EquatableRzsABR_sABR0_sABR1_r2_lF\">==&lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_t_x_q_q0_q1_q2_tts9EquatableRzsABR_sABR0_sABR1_sABR2_r3_lF\">==&lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_tts9EquatableRzsABR_sABR0_sABR1_sABR2_sABR3_r4_lF\">==&lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiS2b_SbtFZ\">==(_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s33AutoreleasingUnsafeMutablePointerV2eeoiSbAByxG_ADtFZ\">==(_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV2eeoiSbAB_ABtFZ\">==(_: Character, _: Character) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV17UnicodeScalarViewV5IndexV2eeoiSbAF_AFtFZ\">==(_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiSbAB_ABtFZ\">==(_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s16ClosedRangeIndexV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRangeIndex&lt;Bound&gt;, _: ClosedRangeIndex&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiSbAB_ABtFZ\">==(_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s18LazyDropWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyDropWhileIndex&lt;Base&gt;, _: LazyDropWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiSbAByxG_ADtFZ\">==(_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s9EquatableP2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s22FlattenCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenCollectionIndex&lt;BaseElements&gt;, _: FlattenCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s35FlattenBidirectionalCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;, _: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13FloatingPointPsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV2eeoiSbAByxG_ADtFZ\">==(_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV4KeysV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryVss8HashableRzs9EquatableR_r0_lE2eeoiSbAByxq_G_AFtFZ\">==(_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiSbAB_ABtFZ\">==(_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13BinaryIntegerPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiSbAB_ABtFZ\">==(_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiSbAB_ABtFZ\">==(_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiSbAB_ABtFZ\">==(_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiSbAB_ABtFZ\">==(_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiSbAB_ABtFZ\">==(_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiSbAB_ABtFZ\">==(_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiSbAB_ABtFZ\">==(_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiSbAB_ABtFZ\">==(_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiSbSu_SutFZ\">==(_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiSbSi_SitFZ\">==(_: Int, _: Int) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiSbAB_ABtFZ\">==(_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiSbAByxq_G_ADtFZ\">==(_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiSbAD_ADtFZ\">==(_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s16ObjectIdentifierV2eeoiSbAB_ABtFZ\">==(_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s20LazyPrefixWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyPrefixWhileIndex&lt;Base&gt;, _: LazyPrefixWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5RangeV2eeoiSbAByxG_ADtFZ\">==(_: Range&lt;Bound&gt;, _: Range&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s14CountableRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableRange&lt;Bound&gt;, _: CountableRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11ClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s20CountableClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableClosedRange&lt;Bound&gt;, _: CountableClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13ReversedIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedIndex&lt;Base&gt;, _: ReversedIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s25ReversedRandomAccessIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedRandomAccessIndex&lt;Base&gt;, _: ReversedRandomAccessIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10StrideablePsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiSbSS_SStFZ\">==(_: String, _: String) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiSbAB_ABtFZ\">==(_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s14StringProtocolPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;R&gt;(_: Self, _: R) -&gt; Bool where R : StringProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiSbSpyxG_ABtFZ\">==(_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiSbSPyxG_ABtFZ\">==(_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiSbSv_SvtFZ\">==(_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiSbSV_SVtFZ\">==(_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiSbAB_ABtFZ\">==(_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SC30_SwiftNSOperatingSystemVersionVsE2eeoiSbAB_ABtFZ\">==(_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiSbAB_ABtFZ\">==(_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (OrderedSet<T>.Type) -> (OrderedSet<T>, OrderedSet<T>) -> Bool",
+            "key.typeusr" : "_T0Sb10Commandant10OrderedSetVyxG_ADtcD",
+            "key.usr" : "s:s9EquatableP2eeoiSbx_xtFZ"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; where T : <Type usr=\"s:s8HashableP\">Hashable<\/Type><\/Declaration>",
+        "key.bodylength" : 331,
+        "key.bodyoffset" : 588,
+        "key.doc.column" : 17,
+        "key.doc.declaration" : "internal struct OrderedSet<T> where T : Hashable",
+        "key.doc.file" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 10,
+            "key.offset" : 576
+          }
+        ],
+        "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:s8HashableP\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Collection"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 366,
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 564,
+        "key.offset" : 554,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var count: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 24,
+            "key.bodyoffset" : 669,
+            "key.doc.declaration" : "var count: Self.IndexDistance { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "To check whether a collection is empty, use its `isEmpty` property instead of comparing `count` to zero. Unless the collection guarantees random-access performance, calculating `count` can be an O() operation."
+              },
+              {
+                "Complexity" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>count<\/Name><USR>s:s10CollectionP5count13IndexDistanceQzv<\/USR><Declaration>var count: Self.IndexDistance { get }<\/Declaration><CommentParts><Abstract><Para>The number of elements in the collection.<\/Para><\/Abstract><Discussion><Para>To check whether a collection is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing <codeVoice>count<\/codeVoice> to zero. Unless the collection guarantees random-access performance, calculating <codeVoice>count<\/codeVoice> can be an O(<emphasis>n<\/emphasis>) operation.<\/Para><Complexity><Para>O(1) if the collection conforms to <codeVoice>RandomAccessCollection<\/codeVoice>; otherwise, O(<emphasis>n<\/emphasis>), where <emphasis>n<\/emphasis> is the length of the collection.<\/Para><\/Complexity><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "count",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>count<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 41,
+            "key.name" : "count",
+            "key.namelength" : 5,
+            "key.nameoffset" : 657,
+            "key.offset" : 653,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s10CollectionP5count13IndexDistanceQzv"
+              }
+            ],
+            "key.parsed_declaration" : "var count: Int",
+            "key.parsed_scope.end" : 34,
+            "key.parsed_scope.start" : 32,
+            "key.typename" : "Int",
+            "key.typeusr" : "_T0SiD",
+            "key.usr" : "s:s10CollectionP5count13IndexDistanceQzv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var isEmpty: <Type usr=\"s:Sb\">Bool<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 26,
+            "key.bodyoffset" : 716,
+            "key.doc.declaration" : "var isEmpty: Bool { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need to check whether your collection is empty, use the `isEmpty` property instead of checking that the `count` property is equal to zero. For collections that don’t conform to `RandomAccessCollection`, accessing the `count` property iterates through the elements of the collection."
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Complexity" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>isEmpty<\/Name><USR>s:s10CollectionP7isEmptySbv<\/USR><Declaration>var isEmpty: Bool { get }<\/Declaration><CommentParts><Abstract><Para>A Boolean value indicating whether the collection is empty.<\/Para><\/Abstract><Discussion><Para>When you need to check whether your collection is empty, use the <codeVoice>isEmpty<\/codeVoice> property instead of checking that the <codeVoice>count<\/codeVoice> property is equal to zero. For collections that don’t conform to <codeVoice>RandomAccessCollection<\/codeVoice>, accessing the <codeVoice>count<\/codeVoice> property iterates through the elements of the collection.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let horseName = \"Silver\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if horseName.isEmpty {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"I've been through the desert on a horse with no name.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Hi ho, \\(horseName)!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Hi ho, Silver!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Complexity><Para>O(1)<\/Para><\/Complexity><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "isEmpty",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>isEmpty<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
+            "key.name" : "isEmpty",
+            "key.namelength" : 7,
+            "key.nameoffset" : 701,
+            "key.offset" : 697,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s10CollectionP7isEmptySbv"
+              }
+            ],
+            "key.parsed_declaration" : "var isEmpty: Bool",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 36,
+            "key.typename" : "Bool",
+            "key.typeusr" : "_T0SbD",
+            "key.usr" : "s:s10CollectionP7isEmptySbv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var startIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 29,
+            "key.bodyoffset" : 767,
+            "key.doc.declaration" : "var startIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the collection is empty, `startIndex` is equal to `endIndex`."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>startIndex<\/Name><USR>s:s14_IndexableBaseP10startIndex0D0Qzv<\/USR><Declaration>var startIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The position of the first element in a nonempty collection.<\/Para><\/Abstract><Discussion><Para>If the collection is empty, <codeVoice>startIndex<\/codeVoice> is equal to <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "startIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>startIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 51,
+            "key.name" : "startIndex",
+            "key.namelength" : 10,
+            "key.nameoffset" : 750,
+            "key.offset" : 746,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s14_IndexableBaseP10startIndex0D0Qzv"
+              }
+            ],
+            "key.parsed_declaration" : "var startIndex: Int",
+            "key.parsed_scope.end" : 42,
+            "key.parsed_scope.start" : 40,
+            "key.typename" : "Int",
+            "key.typeusr" : "_T0SiD",
+            "key.usr" : "s:s14_IndexableBaseP10startIndex0D0Qzv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var endIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 819,
+            "key.doc.declaration" : "var endIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need a range that includes the last element of a collection, use the half-open range operator (`..<`) with `endIndex`. The `..<` operator creates a range that doesn’t include the upper bound, so it’s always safe to use with `endIndex`. For example:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "If the collection is empty, `endIndex` is equal to `startIndex`."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>endIndex<\/Name><USR>s:s14_IndexableBaseP8endIndex0D0Qzv<\/USR><Declaration>var endIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The collection’s “past the end” position—that is, the position one greater than the last valid subscript argument.<\/Para><\/Abstract><Discussion><Para>When you need a range that includes the last element of a collection, use the half-open range operator (<codeVoice>..&lt;<\/codeVoice>) with <codeVoice>endIndex<\/codeVoice>. The <codeVoice>..&lt;<\/codeVoice> operator creates a range that doesn’t include the upper bound, so it’s always safe to use with <codeVoice>endIndex<\/codeVoice>. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let numbers = [10, 20, 30, 40, 50]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if let index = numbers.index(of: 30) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(numbers[index ..< numbers.endIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[30, 40, 50]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If the collection is empty, <codeVoice>endIndex<\/codeVoice> is equal to <codeVoice>startIndex<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "endIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>endIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 47,
+            "key.name" : "endIndex",
+            "key.namelength" : 8,
+            "key.nameoffset" : 804,
+            "key.offset" : 800,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s14_IndexableBaseP8endIndex0D0Qzv"
+              }
+            ],
+            "key.parsed_declaration" : "var endIndex: Int",
+            "key.parsed_scope.end" : 46,
+            "key.parsed_scope.start" : 44,
+            "key.typename" : "Int",
+            "key.typeusr" : "_T0SiD",
+            "key.usr" : "s:s14_IndexableBaseP8endIndex0D0Qzv"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>func index(after i: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.bodylength" : 34,
+            "key.bodyoffset" : 883,
+            "key.doc.declaration" : "func index(after i: Self.Index) -> Self.Index",
+            "key.doc.discussion" : [
+              {
+                "Para" : "The successor of an index must be well defined. For an index `i` into a collection `c`, calling `c.index(after: i)` returns the same index every time."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Function><Name>index(after:)<\/Name><USR>s:s14_IndexableBaseP5index5IndexQzAE5after_tF<\/USR><Declaration>func index(after i: Self.Index) -&gt; Self.Index<\/Declaration><CommentParts><Abstract><Para>Returns the position immediately after the given index.<\/Para><\/Abstract><Parameters><Parameter><Name>i<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A valid index of the collection. <codeVoice>i<\/codeVoice> must be less than <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/Parameter><\/Parameters><ResultDiscussion><Para>The index value immediately after <codeVoice>i<\/codeVoice>.<\/Para><\/ResultDiscussion><Discussion><Para>The successor of an index must be well defined. For an index <codeVoice>i<\/codeVoice> into a collection <codeVoice>c<\/codeVoice>, calling <codeVoice>c.index(after: i)<\/codeVoice> returns the same index every time.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.name" : "index(after:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "A valid index of the collection. `i` must be less than `endIndex`."
+                  }
+                ],
+                "name" : "i"
+              }
+            ],
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The index value immediately after `i`."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "Sources\/Commandant\/OrderedSet.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>index<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>after<\/decl.var.parameter.argument_label> <decl.var.parameter.name>i<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 68,
+            "key.name" : "index(after:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 855,
+            "key.offset" : 850,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s14_IndexableBaseP5index5IndexQzAE5after_tF"
+              }
+            ],
+            "key.parsed_declaration" : "func index(after i: Int) -> Int",
+            "key.parsed_scope.end" : 50,
+            "key.parsed_scope.start" : 48,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (OrderedSet<T>) -> (Int) -> Int",
+            "key.typeusr" : "_T0S2i5after_tcD",
+            "key.usr" : "s:s14_IndexableBaseP5index5IndexQzAE5after_tF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "_T010Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      }
+    ]
+  }
+}, {
   "Sources\/Commandant\/Switch.swift" : {
     "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
     "key.length" : 2022,
@@ -4245,1658 +5897,6 @@
         "key.typename" : "CommandMode.Type",
         "key.typeusr" : "_T010Commandant11CommandModeOmD",
         "key.usr" : "s:10Commandant11CommandModeO"
-      }
-    ]
-  }
-}, {
-  "Sources\/Commandant\/Command.swift" : {
-    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
-    "key.length" : 7159,
-    "key.offset" : 0,
-    "key.substructure" : [
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public protocol CommandProtocol<\/Declaration>",
-        "key.bodylength" : 473,
-        "key.bodyoffset" : 294,
-        "key.doc.column" : 17,
-        "key.doc.comment" : "Represents a subcommand that can be executed with its own set of arguments.",
-        "key.doc.declaration" : "public protocol CommandProtocol",
-        "key.doc.file" : "Sources\/Commandant\/Command.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"13\" column=\"17\"><Name>CommandProtocol<\/Name><USR>s:10Commandant15CommandProtocolP<\/USR><Declaration>public protocol CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a subcommand that can be executed with its own set of arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 13,
-        "key.doc.name" : "CommandProtocol",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Command.swift",
-        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>CommandProtocol<\/decl.name><\/decl.protocol>",
-        "key.kind" : "source.lang.swift.decl.protocol",
-        "key.length" : 500,
-        "key.name" : "CommandProtocol",
-        "key.namelength" : 15,
-        "key.nameoffset" : 277,
-        "key.offset" : 268,
-        "key.parsed_declaration" : "public protocol CommandProtocol",
-        "key.parsed_scope.end" : 30,
-        "key.parsed_scope.start" : 13,
-        "key.runtime_name" : "_TtP8__main__15CommandProtocol_",
-        "key.substructure" : [
-          {
-            "key.annotated_decl" : "<Declaration>associatedtype Options : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type><\/Declaration>",
-            "key.doc.column" : 17,
-            "key.doc.comment" : "The command's options type.",
-            "key.doc.declaration" : "associatedtype Options : OptionsProtocol",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"16\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7Options<\/USR><Declaration>associatedtype Options : OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 16,
-            "key.doc.name" : "Options",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Options<\/decl.name> : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol><\/decl.associatedtype>",
-            "key.kind" : "source.lang.swift.decl.associatedtype",
-            "key.length" : 7,
-            "key.name" : "Options",
-            "key.offset" : 346,
-            "key.parsed_declaration" : "associatedtype Options: OptionsProtocol",
-            "key.parsed_scope.end" : 16,
-            "key.parsed_scope.start" : 16,
-            "key.typename" : "Self.Options.Type",
-            "key.typeusr" : "_T07Options10Commandant15CommandProtocolPQzmD",
-            "key.usr" : "s:10Commandant15CommandProtocolP7Options"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 5,
-            "key.bodyoffset" : 536,
-            "key.doc.column" : 6,
-            "key.doc.comment" : "The action that users should specify to use this subcommand (e.g.,\n`help`).",
-            "key.doc.declaration" : "var verb: String { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"22\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSv<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 22,
-            "key.doc.name" : "verb",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 24,
-            "key.name" : "verb",
-            "key.namelength" : 4,
-            "key.nameoffset" : 522,
-            "key.offset" : 518,
-            "key.parsed_declaration" : "var verb: String",
-            "key.parsed_scope.end" : 22,
-            "key.parsed_scope.start" : 22,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>var function: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 5,
-            "key.bodyoffset" : 652,
-            "key.doc.column" : 6,
-            "key.doc.comment" : "A human-readable, high-level description of what this command is used\nfor.",
-            "key.doc.declaration" : "var function: String { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"26\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSv<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 26,
-            "key.doc.name" : "function",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 28,
-            "key.name" : "function",
-            "key.namelength" : 8,
-            "key.nameoffset" : 634,
-            "key.offset" : 630,
-            "key.parsed_declaration" : "var function: String",
-            "key.parsed_scope.end" : 26,
-            "key.parsed_scope.start" : 26,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>func run(_ options: <Type usr=\"s:10Commandant15CommandProtocolP7Options\">Options<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant15CommandProtocolP11ClientError\">ClientError<\/Type>&gt;<\/Declaration>",
-            "key.doc.column" : 7,
-            "key.doc.comment" : "Runs this subcommand with the given options.",
-            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"29\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 29,
-            "key.doc.name" : "run(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7Options\">Options<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientError\">ClientError<\/ref.associatedtype>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 55,
-            "key.name" : "run(_:)",
-            "key.namelength" : 23,
-            "key.nameoffset" : 716,
-            "key.offset" : 711,
-            "key.parsed_declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
-            "key.parsed_scope.end" : 29,
-            "key.parsed_scope.start" : 29,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<Self where Self : CommandProtocol> (Self) -> (Self.Options) -> Result<(), Self.ClientError>",
-            "key.typeusr" : "_T06ResultAAOyyt11ClientErrorQzG7OptionsQzcD",
-            "key.usr" : "s:10Commandant15CommandProtocolP3run6ResultAEOyyt11ClientErrorQzG7OptionsQzF"
-          }
-        ],
-        "key.typename" : "CommandProtocol.Protocol",
-        "key.typeusr" : "_T010Commandant15CommandProtocol_pmD",
-        "key.usr" : "s:10Commandant15CommandProtocolP"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.bodylength" : 997,
-        "key.bodyoffset" : 847,
-        "key.doc.column" : 15,
-        "key.doc.comment" : "A type-erased command.",
-        "key.doc.declaration" : "public struct CommandWrapper<ClientError> where ClientError : Error",
-        "key.doc.file" : "Sources\/Commandant\/Command.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"33\" column=\"15\"><Name>CommandWrapper<\/Name><USR>s:10Commandant14CommandWrapperV<\/USR><Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A type-erased command.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 33,
-        "key.doc.name" : "CommandWrapper",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Command.swift",
-        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>CommandWrapper<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
-        "key.kind" : "source.lang.swift.decl.struct",
-        "key.length" : 1041,
-        "key.name" : "CommandWrapper",
-        "key.namelength" : 14,
-        "key.nameoffset" : 811,
-        "key.offset" : 804,
-        "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error>",
-        "key.parsed_scope.end" : 66,
-        "key.parsed_scope.start" : 33,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 16,
-            "key.name" : "verb",
-            "key.namelength" : 4,
-            "key.nameoffset" : 860,
-            "key.offset" : 856,
-            "key.parsed_declaration" : "public let verb: String",
-            "key.parsed_scope.end" : 34,
-            "key.parsed_scope.start" : 34,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant14CommandWrapperV4verbSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 20,
-            "key.name" : "function",
-            "key.namelength" : 8,
-            "key.nameoffset" : 885,
-            "key.offset" : 881,
-            "key.parsed_declaration" : "public let function: String",
-            "key.parsed_scope.end" : 35,
-            "key.parsed_scope.start" : 35,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:10Commandant14CommandWrapperV8functionSSv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let run: (<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>run<\/decl.name>: <decl.var.type>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 69,
-            "key.name" : "run",
-            "key.namelength" : 3,
-            "key.nameoffset" : 916,
-            "key.offset" : 912,
-            "key.parsed_declaration" : "public let run: (ArgumentParser) -> Result<(), CommandantError<ClientError>>",
-            "key.parsed_scope.end" : 37,
-            "key.parsed_scope.start" : 37,
-            "key.typename" : "(ArgumentParser) -> Result<(), CommandantError<ClientError>>",
-            "key.typeusr" : "_T06ResultAAOyyt10Commandant0B5ErrorOyxGGAC14ArgumentParserCcD",
-            "key.usr" : "s:10Commandant14CommandWrapperV3run6ResultAEOyytAA0A5ErrorOyxGGAA14ArgumentParserCcv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public let usage: () -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;?<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type>() -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 46,
-            "key.name" : "usage",
-            "key.namelength" : 5,
-            "key.nameoffset" : 996,
-            "key.offset" : 992,
-            "key.parsed_declaration" : "public let usage: () -> CommandantError<ClientError>?",
-            "key.parsed_scope.end" : 39,
-            "key.parsed_scope.start" : 39,
-            "key.typename" : "() -> CommandantError<ClientError>?",
-            "key.typeusr" : "_T010Commandant0A5ErrorOyxGSgycD",
-            "key.usr" : "s:10Commandant14CommandWrapperV5usageAA0A5ErrorOyxGSgycv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
-            "key.annotated_decl" : "<Declaration>fileprivate init&lt;C&gt;(_ command: <Type usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>) where ClientError == C.ClientError, C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type>, C.ClientError == C.Options.ClientError<\/Declaration>",
-            "key.bodylength" : 633,
-            "key.bodyoffset" : 1209,
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Creates a command that wraps another.",
-            "key.doc.declaration" : "fileprivate init<C>(_ command: C) where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"42\" column=\"14\"><Name>init(_:)<\/Name><USR>s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc<\/USR><Declaration>fileprivate init&lt;C&gt;(_ command: C) where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError<\/Declaration><CommentParts><Abstract><Para>Creates a command that wraps another.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 42,
-            "key.doc.name" : "init(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>command<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError == C.ClientError<\/decl.generic_type_requirement>, <decl.generic_type_requirement>C : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement>, <decl.generic_type_requirement>C.ClientError == C.Options.ClientError<\/decl.generic_type_requirement><\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 747,
-            "key.name" : "init(_:)",
-            "key.namelength" : 38,
-            "key.nameoffset" : 1096,
-            "key.offset" : 1096,
-            "key.parsed_declaration" : "fileprivate init<C: CommandProtocol>(_ command: C) where C.ClientError == ClientError, C.Options.ClientError == ClientError",
-            "key.parsed_scope.end" : 65,
-            "key.parsed_scope.start" : 42,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError> (CommandWrapper<ClientError>.Type) -> (C) -> CommandWrapper<ClientError>",
-            "key.typeusr" : "_T010Commandant14CommandWrapperVyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSluD",
-            "key.usr" : "s:10Commandant14CommandWrapperVACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AEQYd__AFRSlu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc"
-          }
-        ],
-        "key.typename" : "CommandWrapper<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant14CommandWrapperVyxGmD",
-        "key.usr" : "s:10Commandant14CommandWrapperV"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
-        "key.bodylength" : 216,
-        "key.bodyoffset" : 1928,
-        "key.doc.column" : 13,
-        "key.doc.comment" : "Describes the \"mode\" in which a command should run.",
-        "key.doc.declaration" : "public enum CommandMode",
-        "key.doc.file" : "Sources\/Commandant\/Command.swift",
-        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"69\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-        "key.doc.line" : 69,
-        "key.doc.name" : "CommandMode",
-        "key.doc.type" : "Other",
-        "key.filepath" : "Sources\/Commandant\/Command.swift",
-        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
-        "key.kind" : "source.lang.swift.decl.enum",
-        "key.length" : 235,
-        "key.name" : "CommandMode",
-        "key.namelength" : 11,
-        "key.nameoffset" : 1915,
-        "key.offset" : 1910,
-        "key.parsed_declaration" : "public enum CommandMode",
-        "key.parsed_scope.end" : 76,
-        "key.parsed_scope.start" : 69,
-        "key.substructure" : [
-          {
-            "key.kind" : "source.lang.swift.decl.enumcase",
-            "key.length" : 30,
-            "key.namelength" : 0,
-            "key.nameoffset" : 0,
-            "key.offset" : 1999,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.internal",
-                "key.annotated_decl" : "<Declaration>case arguments(<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>)<\/Declaration>",
-                "key.doc.column" : 7,
-                "key.doc.comment" : "Options should be parsed from the given command-line arguments.",
-                "key.doc.declaration" : "",
-                "key.doc.file" : "Sources\/Commandant\/Command.swift",
-                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"71\" column=\"7\"><Name>arguments<\/Name><USR>s:10Commandant11CommandModeO9argumentsAcA14ArgumentParserCcACmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Options should be parsed from the given command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-                "key.doc.line" : 71,
-                "key.doc.name" : "arguments",
-                "key.doc.type" : "Other",
-                "key.filepath" : "Sources\/Commandant\/Command.swift",
-                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>(<ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class>)<\/decl.enumelement>",
-                "key.kind" : "source.lang.swift.decl.enumelement",
-                "key.length" : 25,
-                "key.name" : "arguments",
-                "key.namelength" : 9,
-                "key.nameoffset" : 2004,
-                "key.offset" : 2004,
-                "key.parsed_declaration" : "case arguments(ArgumentParser)",
-                "key.parsed_scope.end" : 71,
-                "key.parsed_scope.start" : 71,
-                "key.typename" : "(CommandMode.Type) -> (ArgumentParser) -> CommandMode",
-                "key.typeusr" : "_T010Commandant11CommandModeOAA14ArgumentParserCcACmcD",
-                "key.usr" : "s:10Commandant11CommandModeO9argumentsAcA14ArgumentParserCcACmF"
-              }
-            ]
-          },
-          {
-            "key.kind" : "source.lang.swift.decl.enumcase",
-            "key.length" : 10,
-            "key.namelength" : 0,
-            "key.nameoffset" : 0,
-            "key.offset" : 2133,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.internal",
-                "key.annotated_decl" : "<Declaration>case usage<\/Declaration>",
-                "key.doc.column" : 7,
-                "key.doc.comment" : "Each option should record its usage information in an error, for\npresentation to the user.",
-                "key.doc.declaration" : "",
-                "key.doc.file" : "Sources\/Commandant\/Command.swift",
-                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"75\" column=\"7\"><Name>usage<\/Name><USR>s:10Commandant11CommandModeO5usageA2CmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Each option should record its usage information in an error, for presentation to the user.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-                "key.doc.line" : 75,
-                "key.doc.name" : "usage",
-                "key.doc.type" : "Other",
-                "key.filepath" : "Sources\/Commandant\/Command.swift",
-                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usage<\/decl.name><\/decl.enumelement>",
-                "key.kind" : "source.lang.swift.decl.enumelement",
-                "key.length" : 5,
-                "key.name" : "usage",
-                "key.namelength" : 5,
-                "key.nameoffset" : 2138,
-                "key.offset" : 2138,
-                "key.parsed_declaration" : "case usage",
-                "key.parsed_scope.end" : 75,
-                "key.parsed_scope.start" : 75,
-                "key.typename" : "(CommandMode.Type) -> CommandMode",
-                "key.typeusr" : "_T010Commandant11CommandModeOACmcD",
-                "key.usr" : "s:10Commandant11CommandModeO5usageA2CmF"
-              }
-            ]
-          }
-        ],
-        "key.typename" : "CommandMode.Type",
-        "key.typeusr" : "_T010Commandant11CommandModeOmD",
-        "key.usr" : "s:10Commandant11CommandModeO"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.attributes" : [
-          {
-            "key.attribute" : "source.decl.attribute.final"
-          }
-        ],
-        "key.bodylength" : 1242,
-        "key.bodyoffset" : 2256,
-        "key.doc.column" : 20,
-        "key.doc.comment" : "Maintains the list of commands available to run.",
-        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
-        "key.doc.file" : "Sources\/Commandant\/Command.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"79\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 79,
-        "key.doc.name" : "CommandRegistry",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Command.swift",
-        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
-        "key.kind" : "source.lang.swift.decl.class",
-        "key.length" : 1286,
-        "key.name" : "CommandRegistry",
-        "key.namelength" : 15,
-        "key.nameoffset" : 2219,
-        "key.offset" : 2213,
-        "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error>",
-        "key.parsed_scope.end" : 117,
-        "key.parsed_scope.start" : 79,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private var commandsByVerb: [<Type usr=\"s:SS\">String<\/Type> : <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;ClientError&gt;]<\/Declaration>",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commandsByVerb<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct> : <ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;ClientError&gt;]<\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 63,
-            "key.name" : "commandsByVerb",
-            "key.namelength" : 14,
-            "key.nameoffset" : 2270,
-            "key.offset" : 2266,
-            "key.parsed_declaration" : "private var commandsByVerb: [String: CommandWrapper<ClientError>] = [:]",
-            "key.parsed_scope.end" : 80,
-            "key.parsed_scope.start" : 80,
-            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
-            "key.typename" : "[String : CommandWrapper<ClientError>]",
-            "key.typeusr" : "_T0s10DictionaryVySS10Commandant14CommandWrapperVyxGGD",
-            "key.usr" : "s:10Commandant15CommandRegistryC14commandsByVerb33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs10DictionaryVySSAA0B7WrapperVyxGGv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public var commands: [<Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;] { get }<\/Declaration>",
-            "key.bodylength" : 69,
-            "key.bodyoffset" : 2413,
-            "key.doc.column" : 13,
-            "key.doc.comment" : "All available commands.",
-            "key.doc.declaration" : "public var commands: [CommandWrapper<ClientError>] { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"83\" column=\"13\"><Name>commands<\/Name><USR>s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGv<\/USR><Declaration>public var commands: [CommandWrapper&lt;ClientError&gt;] { get }<\/Declaration><CommentParts><Abstract><Para>All available commands.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 83,
-            "key.doc.name" : "commands",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commands<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 115,
-            "key.name" : "commands",
-            "key.namelength" : 8,
-            "key.nameoffset" : 2372,
-            "key.offset" : 2368,
-            "key.parsed_declaration" : "public var commands: [CommandWrapper<ClientError>]",
-            "key.parsed_scope.end" : 85,
-            "key.parsed_scope.start" : 83,
-            "key.typename" : "[CommandWrapper<ClientError>]",
-            "key.typeusr" : "_T0Say10Commandant14CommandWrapperVyxGGD",
-            "key.usr" : "s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
-            "key.bodylength" : 0,
-            "key.bodyoffset" : 2501,
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 9,
-            "key.name" : "init()",
-            "key.namelength" : 6,
-            "key.nameoffset" : 2493,
-            "key.offset" : 2493,
-            "key.parsed_declaration" : "public init()",
-            "key.parsed_scope.end" : 87,
-            "key.parsed_scope.start" : 87,
-            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>.Type) -> () -> CommandRegistry<ClientError>",
-            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGycD",
-            "key.usr" : "s:10Commandant15CommandRegistryCACyxGycfc"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>@discardableResult public func register&lt;C&gt;(_ commands: <Type usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\">C<\/Type>...) -&gt; <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type> where ClientError == C.ClientError, C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type>, C.ClientError == C.Options.ClientError<\/Declaration>",
-            "key.attributes" : [
-              {
-                "key.attribute" : "source.decl.attribute.discardableResult"
-              }
-            ],
-            "key.bodylength" : 106,
-            "key.bodyoffset" : 2857,
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Registers the given commands, making those available to run.\n\nIf another commands were already registered with the same `verb`s, those\nwill be overwritten.",
-            "key.doc.declaration" : "public func register<C>(_ commands: C...) -> CommandRegistry where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If another commands were already registered with the same `verb`s, those will be overwritten."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"94\" column=\"14\"><Name>register(_:)<\/Name><USR>s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF<\/USR><Declaration>public func register&lt;C&gt;(_ commands: C...) -&gt; CommandRegistry where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError<\/Declaration><CommentParts><Abstract><Para>Registers the given commands, making those available to run.<\/Para><\/Abstract><Discussion><Para>If another commands were already registered with the same <codeVoice>verb<\/codeVoice>s, those will be overwritten.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 94,
-            "key.doc.name" : "register(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>register<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>commands<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type>...<\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class><\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError == C.ClientError<\/decl.generic_type_requirement>, <decl.generic_type_requirement>C : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement>, <decl.generic_type_requirement>C.ClientError == C.Options.ClientError<\/decl.generic_type_requirement><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 257,
-            "key.name" : "register(_:)",
-            "key.namelength" : 46,
-            "key.nameoffset" : 2712,
-            "key.offset" : 2707,
-            "key.parsed_declaration" : "public func register<C: CommandProtocol>(_ commands: C...)\n\t-> CommandRegistry\n\twhere C.ClientError == ClientError, C.Options.ClientError == ClientError",
-            "key.parsed_scope.end" : 102,
-            "key.parsed_scope.start" : 94,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol, C.ClientError == C.Options.ClientError> (CommandRegistry<ClientError>) -> (C...) -> CommandRegistry<ClientError>",
-            "key.typeusr" : "_T010Commandant15CommandRegistryCyxGSayqd__Gd_tc11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AFQYd__AGRSluD",
-            "key.usr" : "s:10Commandant15CommandRegistryC8registerACyxGSayqd__Gd_t11ClientErrorQyd__RszAA0B8ProtocolRd__7Options_AGQYd__AHRSlF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public func run(command verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;?<\/Declaration>",
-            "key.bodylength" : 54,
-            "key.bodyoffset" : 3246,
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Runs the command corresponding to the given verb, passing it the given\narguments.\n\nReturns the results of the execution, or nil if no such command exists.",
-            "key.doc.declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Returns the results of the execution, or nil if no such command exists."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"108\" column=\"14\"><Name>run(command:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC3run6ResultAEOyytAA0A5ErrorOyxGGSgSS7command_SaySSG9argumentstF<\/USR><Declaration>public func run(command verb: String, arguments: [String]) -&gt; Result&lt;(), CommandantError&lt;ClientError&gt;&gt;?<\/Declaration><CommentParts><Abstract><Para>Runs the command corresponding to the given verb, passing it the given arguments.<\/Para><\/Abstract><Discussion><Para>Returns the results of the execution, or nil if no such command exists.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 108,
-            "key.doc.name" : "run(command:arguments:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>command<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;?<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 153,
-            "key.name" : "run(command:arguments:)",
-            "key.namelength" : 46,
-            "key.nameoffset" : 3153,
-            "key.offset" : 3148,
-            "key.parsed_declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
-            "key.parsed_scope.end" : 110,
-            "key.parsed_scope.start" : 108,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, [String]) -> Result<(), CommandantError<ClientError>>?",
-            "key.typeusr" : "_T06ResultAAOyyt10Commandant0B5ErrorOyxGGSgSS7command_SaySSG9argumentstcD",
-            "key.usr" : "s:10Commandant15CommandRegistryC3run6ResultAEOyytAA0A5ErrorOyxGGSgSS7command_SaySSG9argumentstF"
-          },
-          {
-            "key.annotated_decl" : "<Declaration>public subscript(verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;? { get }<\/Declaration>",
-            "key.doc.column" : 9,
-            "key.doc.comment" : "Returns the command matching the given verb, or nil if no such command\nis registered.",
-            "key.doc.declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>? { get }",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/Command.swift\" line=\"114\" column=\"9\"><Name>subscript(_:)<\/Name><USR>s:10Commandant15CommandRegistryC9subscriptAA0B7WrapperVyxGSgSSci<\/USR><Declaration>public subscript(verb: String) -&gt; CommandWrapper&lt;ClientError&gt;? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the command matching the given verb, or nil if no such command is registered.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 114,
-            "key.doc.name" : "subscript(_:)",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
-            "key.kind" : "source.lang.swift.decl.function.subscript",
-            "key.length" : 9,
-            "key.name" : "subscript(_:)",
-            "key.offset" : 3407,
-            "key.parsed_declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>?",
-            "key.parsed_scope.end" : 114,
-            "key.parsed_scope.start" : 114,
-            "key.typename" : "<ClientError where ClientError : Error> (String) -> CommandWrapper<ClientError>?",
-            "key.typeusr" : "_T010Commandant14CommandWrapperVyxGSgSScD",
-            "key.usr" : "s:10Commandant15CommandRegistryC9subscriptAA0B7WrapperVyxGSgSSci"
-          }
-        ],
-        "key.typename" : "CommandRegistry<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant15CommandRegistryCyxGmD",
-        "key.usr" : "s:10Commandant15CommandRegistryC"
-      },
-      {
-        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
-        "key.bodylength" : 3629,
-        "key.bodyoffset" : 3528,
-        "key.doc.column" : 20,
-        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
-        "key.doc.file" : "Sources\/Commandant\/Command.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/Command.swift\" line=\"79\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 79,
-        "key.doc.name" : "CommandRegistry",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/Command.swift",
-        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>ClientError : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 3657,
-        "key.name" : "CommandRegistry",
-        "key.namelength" : 15,
-        "key.nameoffset" : 3511,
-        "key.offset" : 3501,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public func main(defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; ()) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
-            "key.bodylength" : 97,
-            "key.bodyoffset" : 4412,
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing CommandLine.arguments\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
-            "key.doc.declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
-              },
-              {
-                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
-              },
-              {
-                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
-              },
-              {
-                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"137\" column=\"14\"><Name>main(defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF<\/USR><Declaration>public func main(defaultVerb: String, errorHandler: (ClientError) -&gt; ()) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing CommandLine.arguments and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 137,
-            "key.doc.name" : "main(defaultVerb:errorHandler:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><tuple>()<\/tuple><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 175,
-            "key.name" : "main(defaultVerb:errorHandler:)",
-            "key.namelength" : 60,
-            "key.nameoffset" : 4340,
-            "key.offset" : 4335,
-            "key.parsed_declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
-            "key.parsed_scope.end" : 139,
-            "key.parsed_scope.start" : 137,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF\">main(arguments:defaultVerb:errorHandler:)<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, (ClientError) -> ()) -> Never",
-            "key.typeusr" : "_T0s5NeverOSS11defaultVerb_yxc12errorHandlertcD",
-            "key.usr" : "s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public func main(arguments: [<Type usr=\"s:SS\">String<\/Type>], defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; ()) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
-            "key.bodylength" : 947,
-            "key.bodyoffset" : 5407,
-            "key.doc.column" : 14,
-            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing `arguments`\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
-            "key.doc.declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
-              },
-              {
-                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
-              },
-              {
-                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
-              },
-              {
-                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"158\" column=\"14\"><Name>main(arguments:defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF<\/USR><Declaration>public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -&gt; ()) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing <codeVoice>arguments<\/codeVoice> and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 158,
-            "key.doc.name" : "main(arguments:defaultVerb:errorHandler:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><tuple>()<\/tuple><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 1046,
-            "key.name" : "main(arguments:defaultVerb:errorHandler:)",
-            "key.namelength" : 81,
-            "key.nameoffset" : 5314,
-            "key.offset" : 5309,
-            "key.parsed_declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> ()) -> Never",
-            "key.parsed_scope.end" : 197,
-            "key.parsed_scope.start" : 158,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4mains5NeverOSS11defaultVerb_yxc12errorHandlertF\">main(defaultVerb:errorHandler:)<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> ([String], String, (ClientError) -> ()) -> Never",
-            "key.typeusr" : "_T0s5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertcD",
-            "key.usr" : "s:10Commandant15CommandRegistryC4mains5NeverOSaySSG9arguments_SS11defaultVerbyxc12errorHandlertF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private func executeSubcommandIfExists(_ executableName: <Type usr=\"s:SS\">String<\/Type>, verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type>?<\/Declaration>",
-            "key.bodylength" : 489,
-            "key.bodyoffset" : 6666,
-            "key.doc.column" : 15,
-            "key.doc.comment" : "Finds and executes a subcommand which exists in your $PATH. The executable\nname must be in the form of `executable-verb`.\n\n- Returns: The exit status of found subcommand or nil.",
-            "key.doc.declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
-            "key.doc.file" : "Sources\/Commandant\/Command.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/Command.swift\" line=\"203\" column=\"15\"><Name>executeSubcommandIfExists(_:verb:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF<\/USR><Declaration>private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -&gt; Int32?<\/Declaration><CommentParts><Abstract><Para>Finds and executes a subcommand which exists in your $PATH. The executable name must be in the form of <codeVoice>executable-verb<\/codeVoice>.<\/Para><\/Abstract><ResultDiscussion><Para>The exit status of found subcommand or nil.<\/Para><\/ResultDiscussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 203,
-            "key.doc.name" : "executeSubcommandIfExists(_:verb:arguments:)",
-            "key.doc.result_discussion" : [
-              {
-                "Para" : "The exit status of found subcommand or nil."
-              }
-            ],
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/Command.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>executeSubcommandIfExists<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>executableName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 593,
-            "key.name" : "executeSubcommandIfExists(_:verb:arguments:)",
-            "key.namelength" : 86,
-            "key.nameoffset" : 6568,
-            "key.offset" : 6563,
-            "key.parsed_declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
-            "key.parsed_scope.end" : 222,
-            "key.parsed_scope.start" : 203,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.private",
-                "key.annotated_decl" : "<Declaration>func launchTask(_ path: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type><\/Declaration>",
-                "key.bodylength" : 159,
-                "key.bodyoffset" : 6816,
-                "key.filepath" : "Sources\/Commandant\/Command.swift",
-                "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>launchTask<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>path<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct><\/decl.function.returntype><\/decl.function.free>",
-                "key.kind" : "source.lang.swift.decl.function.free",
-                "key.length" : 223,
-                "key.name" : "launchTask(_:arguments:)",
-                "key.namelength" : 47,
-                "key.nameoffset" : 6758,
-                "key.offset" : 6753,
-                "key.parsed_declaration" : "func launchTask(_ path: String, arguments: [String]) -> Int32",
-                "key.parsed_scope.end" : 215,
-                "key.parsed_scope.start" : 206,
-                "key.substructure" : [
-
-                ],
-                "key.typename" : "<ClientError where ClientError : Error> (String, arguments: [String]) -> Int32",
-                "key.typeusr" : "_T0s5Int32VSS_SaySSG9argumentstcs5ErrorRzluD",
-                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF10launchTaskL_AGSS_AjKts5ErrorRzlF"
-              }
-            ],
-            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, String, [String]) -> Int32?",
-            "key.typeusr" : "_T0s5Int32VSgSS_SS4verbSaySSG9argumentstcD",
-            "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELLs5Int32VSgSS_SS4verbSaySSG9argumentstF"
-          }
-        ],
-        "key.typename" : "CommandRegistry<ClientError>.Type",
-        "key.typeusr" : "_T010Commandant15CommandRegistryCyxGmD",
-        "key.usr" : "s:10Commandant15CommandRegistryC"
-      }
-    ]
-  }
-}, {
-  "Sources\/Commandant\/ArgumentParser.swift" : {
-    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
-    "key.length" : 4956,
-    "key.offset" : 0,
-    "key.substructure" : [
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.private",
-        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:s9EquatableP\">Equatable<\/Type><\/Declaration>",
-        "key.bodylength" : 296,
-        "key.bodyoffset" : 280,
-        "key.doc.column" : 14,
-        "key.doc.comment" : "Represents an argument passed on the command line.",
-        "key.doc.declaration" : "private enum RawArgument : Equatable",
-        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"13\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-        "key.doc.line" : 13,
-        "key.doc.name" : "RawArgument",
-        "key.doc.type" : "Other",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 9,
-            "key.offset" : 269
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:s9EquatableP\">Equatable<\/ref.protocol><\/decl.enum>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "Equatable"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.enum",
-        "key.length" : 326,
-        "key.name" : "RawArgument",
-        "key.namelength" : 11,
-        "key.nameoffset" : 256,
-        "key.offset" : 251,
-        "key.parsed_declaration" : "private enum RawArgument: Equatable",
-        "key.parsed_scope.end" : 23,
-        "key.parsed_scope.start" : 13,
-        "key.substructure" : [
-          {
-            "key.kind" : "source.lang.swift.decl.enumcase",
-            "key.length" : 16,
-            "key.namelength" : 0,
-            "key.nameoffset" : 0,
-            "key.offset" : 355,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.private",
-                "key.annotated_decl" : "<Declaration>case key(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
-                "key.doc.column" : 7,
-                "key.doc.comment" : "A key corresponding to an option (e.g., `verbose` for `--verbose`).",
-                "key.doc.declaration" : "",
-                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"15\" column=\"7\"><Name>key<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A key corresponding to an option (e.g., <codeVoice>verbose<\/codeVoice> for <codeVoice>--verbose<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
-                "key.doc.line" : 15,
-                "key.doc.name" : "key",
-                "key.doc.type" : "Other",
-                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>key<\/decl.name>(<ref.struct usr=\"s:SS\">String<\/ref.struct>)<\/decl.enumelement>",
-                "key.kind" : "source.lang.swift.decl.enumelement",
-                "key.length" : 11,
-                "key.name" : "key",
-                "key.namelength" : 3,
-                "key.nameoffset" : 360,
-                "key.offset" : 360,
-                "key.parsed_declaration" : "case key(String)",
-                "key.parsed_scope.end" : 15,
-                "key.parsed_scope.start" : 15,
-                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
-                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
-                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyADSScADmF"
-              }
-            ]
-          },
-          {
-            "key.kind" : "source.lang.swift.decl.enumcase",
-            "key.length" : 18,
-            "key.namelength" : 0,
-            "key.nameoffset" : 0,
-            "key.offset" : 462,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.private",
-                "key.annotated_decl" : "<Declaration>case value(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
-                "key.doc.column" : 7,
-                "key.doc.comment" : "A value, either associated with an option or passed as a positional\nargument.",
-                "key.doc.declaration" : "",
-                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"19\" column=\"7\"><Name>value<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A value, either associated with an option or passed as a positional argument.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-                "key.doc.line" : 19,
-                "key.doc.name" : "value",
-                "key.doc.type" : "Other",
-                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>value<\/decl.name>(<ref.struct usr=\"s:SS\">String<\/ref.struct>)<\/decl.enumelement>",
-                "key.kind" : "source.lang.swift.decl.enumelement",
-                "key.length" : 13,
-                "key.name" : "value",
-                "key.namelength" : 5,
-                "key.nameoffset" : 467,
-                "key.offset" : 467,
-                "key.parsed_declaration" : "case value(String)",
-                "key.parsed_scope.end" : 19,
-                "key.parsed_scope.start" : 19,
-                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
-                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
-                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueADSScADmF"
-              }
-            ]
-          },
-          {
-            "key.kind" : "source.lang.swift.decl.enumcase",
-            "key.length" : 32,
-            "key.namelength" : 0,
-            "key.nameoffset" : 0,
-            "key.offset" : 543,
-            "key.substructure" : [
-              {
-                "key.accessibility" : "source.lang.swift.accessibility.private",
-                "key.annotated_decl" : "<Declaration>case flag(<Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>&lt;<Type usr=\"s:s9CharacterV\">Character<\/Type>&gt;)<\/Declaration>",
-                "key.doc.column" : 7,
-                "key.doc.comment" : "One or more flag arguments (e.g 'r' and 'f' for `-rf`)",
-                "key.doc.declaration" : "",
-                "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"22\" column=\"7\"><Name>flag<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagAdA10OrderedSetVys9CharacterVGcADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>One or more flag arguments (e.g ‘r’ and ‘f’ for <codeVoice>-rf<\/codeVoice>)<\/Para><\/Abstract><\/CommentParts><\/Other>",
-                "key.doc.line" : 22,
-                "key.doc.name" : "flag",
-                "key.doc.type" : "Other",
-                "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>(<ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct>&lt;<ref.struct usr=\"s:s9CharacterV\">Character<\/ref.struct>&gt;)<\/decl.enumelement>",
-                "key.kind" : "source.lang.swift.decl.enumelement",
-                "key.length" : 27,
-                "key.name" : "flag",
-                "key.namelength" : 4,
-                "key.nameoffset" : 548,
-                "key.offset" : 548,
-                "key.parsed_declaration" : "case flag(OrderedSet<Character>)",
-                "key.parsed_scope.end" : 22,
-                "key.parsed_scope.start" : 22,
-                "key.typename" : "(RawArgument.Type) -> (OrderedSet<Character>) -> RawArgument",
-                "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOAA10OrderedSetVys9CharacterVGcADmcD",
-                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagAdA10OrderedSetVys9CharacterVGcADmF"
-              }
-            ]
-          }
-        ],
-        "key.typename" : "RawArgument.Type",
-        "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
-        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.private",
-        "key.annotated_decl" : "<Declaration>private func ==(lhs: <Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>, rhs: <Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
-        "key.bodylength" : 239,
-        "key.bodyoffset" : 640,
-        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>==<\/decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
-        "key.kind" : "source.lang.swift.decl.function.free",
-        "key.length" : 293,
-        "key.name" : "==(_:_:)",
-        "key.namelength" : 38,
-        "key.nameoffset" : 592,
-        "key.offset" : 587,
-        "key.parsed_declaration" : "private func ==(lhs: RawArgument, rhs: RawArgument) -> Bool",
-        "key.parsed_scope.end" : 39,
-        "key.parsed_scope.start" : 25,
-        "key.related_decls" : [
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant10OrderedSetV2eeoiSbACyxG_AEtFZ\">==(_: OrderedSet, _: OrderedSet) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation15AffineTransformV2eeoiSbAC_ACtFZ\">==(_: AffineTransform, _: AffineTransform) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8CalendarV2eeoiSbAC_ACtFZ\">==(_: Calendar, _: Calendar) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12CharacterSetV2eeoiSbAC_ACtFZ\">==(_: CharacterSet, _: CharacterSet) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DataV2eeoiSbAC_ACtFZ\">==(_: Data, _: Data) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4DateV2eeoiSbAC_ACtFZ\">==(_: Date, _: Date) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation14DateComponentsV2eeoiSbAC_ACtFZ\">==(_: DateComponents, _: DateComponents) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12DateIntervalV2eeoiSbAC_ACtFZ\">==(_: DateInterval, _: DateInterval) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC7DecimalV10FoundationE2eeoiSbAB_ABtFZ\">==(_: Decimal, _: Decimal) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation9IndexPathV2eeoiSbAC_ACtFZ\">==(_: IndexPath, _: IndexPath) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV0B0V2eeoiSbAE_AEtFZ\">==(_: IndexSet.Index, _: IndexSet.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV9RangeViewV2eeoiSbAE_AEtFZ\">==(_: IndexSet.RangeView, _: IndexSet.RangeView) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8IndexSetV2eeoiSbAC_ACtFZ\">==(_: IndexSet, _: IndexSet) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation6LocaleV2eeoiSbAC_ACtFZ\">==(_: Locale, _: Locale) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation11MeasurementV2eeoiSbACyqd__G_ACyqd_0_GtSo4UnitCRbd__AHRbd_0_r0_lFZ\">==&lt;LeftHandSideType, RightHandSideType&gt;(_: Measurement&lt;LeftHandSideType&gt;, _: Measurement&lt;RightHandSideType&gt;) -&gt; Bool where LeftHandSideType : Unit, RightHandSideType : Unit<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12NotificationV2eeoiSbAC_ACtFZ\">==(_: Notification, _: Notification) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs13SignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation16__BridgedNSErrorPA2aBRzs16RawRepresentableRzs15UnsignedInteger0D5ValuesADPRpzlE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation21_BridgedStoredNSErrorPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC8_NSRangeV10FoundationE2eeoiSbAB_ABtFZ\">==(_: NSRange, _: NSRange) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SS10FoundationE8EncodingV2eeoiSbAC_ACtFZ\">==(_: String.Encoding, _: String.Encoding) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation20PersonNameComponentsV2eeoiSbAC_ACtFZ\">==(_: PersonNameComponents, _: PersonNameComponents) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation8TimeZoneV2eeoiSbAC_ACtFZ\">==(_: TimeZone, _: TimeZone) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation3URLV2eeoiSbAC_ACtFZ\">==(_: URL, _: URL) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation13URLComponentsV2eeoiSbAC_ACtFZ\">==(_: URLComponents, _: URLComponents) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation12URLQueryItemV2eeoiSbAC_ACtFZ\">==(_: URLQueryItem, _: URLQueryItem) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation10URLRequestV2eeoiSbAC_ACtFZ\">==(_: URLRequest, _: URLRequest) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10Foundation4UUIDV2eeoiSbAC_ACtFZ\">==(_: UUID, _: UUID) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:14CoreFoundation9_CFObjectPAAE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:6Darwin2eeoiSbAA0A7BooleanV_ADtF\">==(_: DarwinBoolean, _: DarwinBoolean) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch2eeoiSbAA0A3QoSV_ADtF\">==(_: DispatchQoS, _: DispatchQoS) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A4TimeV2eeoiSbAC_ACtFZ\">==(_: DispatchTime, _: DispatchTime) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A8WallTimeV2eeoiSbAC_ACtFZ\">==(_: DispatchWallTime, _: DispatchWallTime) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:8Dispatch0A12TimeIntervalO2eeoiSbAC_ACtFZ\">==(_: DispatchTimeInterval, _: DispatchTimeInterval) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbAA8SelectorV_ADtF\">==(_: Selector, _: Selector) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:10ObjectiveC2eeoiSbSo8NSObjectC_ADtF\">==(_: NSObject, _: NSObject) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC17CGAffineTransformV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGAffineTransform, _: CGAffineTransform) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC7CGPointV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGPoint, _: CGPoint) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGSizeV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGSize, _: CGSize) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC8CGVectorV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGVector, _: CGVector) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC6CGRectV12CoreGraphicsE2eeoiSbAB_ABtFZ\">==(_: CGRect, _: CGRect) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs15ContiguousArrayVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ContiguousArray&lt;Element&gt;, _: ContiguousArray&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs10ArraySliceVyxG_ADts9EquatableRzlF\">==&lt;Element&gt;(_: ArraySlice&lt;Element&gt;, _: ArraySlice&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbSayxG_ABts9EquatableRzlF\">==&lt;Element&gt;(_: Array&lt;Element&gt;, _: Array&lt;Element&gt;) -&gt; Bool where Element : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbypXpSg_ABtF\">==(_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_ABts9EquatableRzlF\">==&lt;T&gt;(_: T?, _: T?) -&gt; Bool where T : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbxSg_s26_OptionalNilComparisonTypeVtlF\">==&lt;T&gt;(_: T?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbs26_OptionalNilComparisonTypeV_xSgtlF\">==&lt;T&gt;(_: _OptionalNilComparisonType, _: T?) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbyt_yttF\">==(_: (), _: ()) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_t_x_q_tts9EquatableRzsABR_r0_lF\">==&lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_t_x_q_q0_tts9EquatableRzsABR_sABR0_r1_lF\">==&lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_t_x_q_q0_q1_tts9EquatableRzsABR_sABR0_sABR1_r2_lF\">==&lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_t_x_q_q0_q1_q2_tts9EquatableRzsABR_sABR0_sABR1_sABR2_r3_lF\">==&lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiSbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_tts9EquatableRzsABR_sABR0_sABR1_sABR2_sABR3_r4_lF\">==&lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiS2b_SbtFZ\">==(_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s33AutoreleasingUnsafeMutablePointerV2eeoiSbAByxG_ADtFZ\">==(_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV2eeoiSbAB_ABtFZ\">==(_: Character, _: Character) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s9CharacterV17UnicodeScalarViewV5IndexV2eeoiSbAF_AFtFZ\">==(_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiSbAB_ABtFZ\">==(_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s16ClosedRangeIndexV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRangeIndex&lt;Bound&gt;, _: ClosedRangeIndex&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiSbAB_ABtFZ\">==(_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s18LazyDropWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyDropWhileIndex&lt;Base&gt;, _: LazyDropWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiSbAByxG_ADtFZ\">==(_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s9EquatableP2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s22FlattenCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenCollectionIndex&lt;BaseElements&gt;, _: FlattenCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s35FlattenBidirectionalCollectionIndexV2eeoiSbAByxG_ADtFZ\">==(_: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;, _: FlattenBidirectionalCollectionIndex&lt;BaseElements&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s13FloatingPointPsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV2eeoiSbAByxG_ADtFZ\">==(_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV4KeysV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryVss8HashableRzs9EquatableR_r0_lE2eeoiSbAByxq_G_AFtFZ\">==(_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s3SetV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s10DictionaryV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiSbAB_ABtFZ\">==(_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s13BinaryIntegerPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiSbAB_ABtFZ\">==(_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiSbAB_ABtFZ\">==(_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiSbAB_ABtFZ\">==(_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiSbAB_ABtFZ\">==(_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiSbAB_ABtFZ\">==(_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiSbAB_ABtFZ\">==(_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiSbAB_ABtFZ\">==(_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiSbAB_ABtFZ\">==(_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiSbSu_SutFZ\">==(_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiSbSi_SitFZ\">==(_: Int, _: Int) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiSbAB_ABtFZ\">==(_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiSbAByxq_G_ADtFZ\">==(_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiSbAD_ADtFZ\">==(_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s16ObjectIdentifierV2eeoiSbAB_ABtFZ\">==(_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s20LazyPrefixWhileIndexV2eeoiSbAByxG_ADtFZ\">==(_: LazyPrefixWhileIndex&lt;Base&gt;, _: LazyPrefixWhileIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s5RangeV2eeoiSbAByxG_ADtFZ\">==(_: Range&lt;Bound&gt;, _: Range&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s14CountableRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableRange&lt;Bound&gt;, _: CountableRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s11ClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s20CountableClosedRangeV2eeoiSbAByxG_ADtFZ\">==(_: CountableClosedRange&lt;Bound&gt;, _: CountableClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s13ReversedIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedIndex&lt;Base&gt;, _: ReversedIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s25ReversedRandomAccessIndexV2eeoiSbAByxG_ADtFZ\">==(_: ReversedRandomAccessIndex&lt;Base&gt;, _: ReversedRandomAccessIndex&lt;Base&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s10StrideablePsE2eeoiSbx_xtFZ\">==(_: Self, _: Self) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiSbSS_SStFZ\">==(_: String, _: String) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiSbAB_ABtFZ\">==(_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s14StringProtocolPsE2eeoiSbx_qd__tsAARd__lFZ\">==&lt;R&gt;(_: Self, _: R) -&gt; Bool where R : StringProtocol<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiSbADyxq__G_AFtFZ\">==(_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiSbSpyxG_ABtFZ\">==(_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiSbSPyxG_ABtFZ\">==(_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiSbSv_SvtFZ\">==(_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiSbSV_SVtFZ\">==(_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiSbAB_ABtFZ\">==(_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiSbADyx_G_AFtFZ\">==(_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:SC30_SwiftNSOperatingSystemVersionVsE2eeoiSbAB_ABtFZ\">==(_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiSbAB_ABtFZ\">==(_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:6Result2eeoiSbx_xtAA0A8ProtocolRzs9Equatable5ErrorRpzsAD5ValueRpzlF\">==&lt;T&gt;(_: T, _: T) -&gt; Bool where T : ResultProtocol, T.Error : Equatable, T.Value : Equatable<\/RelatedName>"
-          },
-          {
-            "key.annotated_decl" : "<RelatedName usr=\"s:6Result7NoErrorO2eeoiSbAC_ACtFZ\">==(_: NoError, _: NoError) -&gt; Bool<\/RelatedName>"
-          }
-        ],
-        "key.substructure" : [
-
-        ],
-        "key.typename" : "(RawArgument, RawArgument) -> Bool",
-        "key.typeusr" : "_T0Sb10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO_ADtcD",
-        "key.usr" : "s:10Commandant2eeoi33_BA859BFBBE9DF3838A11641CB273713ELLSbAA11RawArgumentACLLO_AEtF"
-      },
-      {
-        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:s9EquatableP\">Equatable<\/Type><\/Declaration>",
-        "key.bodylength" : 214,
-        "key.bodyoffset" : 930,
-        "key.doc.column" : 14,
-        "key.doc.declaration" : "private enum RawArgument : Equatable",
-        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"13\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-        "key.doc.line" : 13,
-        "key.doc.name" : "RawArgument",
-        "key.doc.type" : "Other",
-        "key.elements" : [
-          {
-            "key.kind" : "source.lang.swift.structure.elem.typeref",
-            "key.length" : 23,
-            "key.offset" : 905
-          }
-        ],
-        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:s9EquatableP\">Equatable<\/ref.protocol><\/decl.enum>",
-        "key.inheritedtypes" : [
-          {
-            "key.name" : "CustomStringConvertible"
-          }
-        ],
-        "key.kind" : "source.lang.swift.decl.extension",
-        "key.length" : 263,
-        "key.name" : "RawArgument",
-        "key.namelength" : 11,
-        "key.nameoffset" : 892,
-        "key.offset" : 882,
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
-            "key.annotated_decl" : "<Declaration>fileprivate var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
-            "key.bodylength" : 173,
-            "key.bodyoffset" : 969,
-            "key.doc.declaration" : "var description: String { get }",
-            "key.doc.discussion" : [
-              {
-                "Para" : "Instead of accessing this property directly, convert an instance of any type to a string by using the `String(describing:)` initializer. For example:"
-              },
-              {
-                "CodeListing" : ""
-              },
-              {
-                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
-              }
-            ],
-            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSv<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Instead of accessing this property directly, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
-            "key.doc.name" : "description",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 199,
-            "key.name" : "description",
-            "key.namelength" : 11,
-            "key.nameoffset" : 948,
-            "key.offset" : 944,
-            "key.overrides" : [
-              {
-                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
-              }
-            ],
-            "key.parsed_declaration" : "fileprivate var description: String",
-            "key.parsed_scope.end" : 53,
-            "key.parsed_scope.start" : 42,
-            "key.typename" : "String",
-            "key.typeusr" : "_T0SSD",
-            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSv"
-          }
-        ],
-        "key.typename" : "RawArgument.Type",
-        "key.typeusr" : "_T010Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
-        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
-      },
-      {
-        "key.accessibility" : "source.lang.swift.accessibility.public",
-        "key.annotated_decl" : "<Declaration>public final class ArgumentParser<\/Declaration>",
-        "key.attributes" : [
-          {
-            "key.attribute" : "source.decl.attribute.final"
-          }
-        ],
-        "key.bodylength" : 3713,
-        "key.bodyoffset" : 1241,
-        "key.doc.column" : 20,
-        "key.doc.comment" : "Destructively parses a list of command-line arguments.",
-        "key.doc.declaration" : "public final class ArgumentParser",
-        "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.doc.full_as_xml" : "<Class file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"57\" column=\"20\"><Name>ArgumentParser<\/Name><USR>s:10Commandant14ArgumentParserC<\/USR><Declaration>public final class ArgumentParser<\/Declaration><CommentParts><Abstract><Para>Destructively parses a list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
-        "key.doc.line" : 57,
-        "key.doc.name" : "ArgumentParser",
-        "key.doc.type" : "Class",
-        "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>ArgumentParser<\/decl.name><\/decl.class>",
-        "key.kind" : "source.lang.swift.decl.class",
-        "key.length" : 3736,
-        "key.name" : "ArgumentParser",
-        "key.namelength" : 14,
-        "key.nameoffset" : 1225,
-        "key.offset" : 1219,
-        "key.parsed_declaration" : "public final class ArgumentParser",
-        "key.parsed_scope.end" : 192,
-        "key.parsed_scope.start" : 57,
-        "key.runtime_name" : "_TtC8__main__14ArgumentParser",
-        "key.substructure" : [
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.private",
-            "key.annotated_decl" : "<Declaration>private var rawArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
-            "key.doc.column" : 14,
-            "key.doc.comment" : "The remaining arguments to be extracted, in their raw form.",
-            "key.doc.declaration" : "private var rawArguments: [Commandant.RawArgument]",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"59\" column=\"14\"><Name>rawArguments<\/Name><USR>s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGv<\/USR><Declaration>private var rawArguments: [Commandant.RawArgument]<\/Declaration><CommentParts><Abstract><Para>The remaining arguments to be extracted, in their raw form.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 59,
-            "key.doc.name" : "rawArguments",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>rawArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 36,
-            "key.name" : "rawArguments",
-            "key.namelength" : 12,
-            "key.nameoffset" : 1320,
-            "key.offset" : 1316,
-            "key.parsed_declaration" : "private var rawArguments: [RawArgument] = []",
-            "key.parsed_scope.end" : 59,
-            "key.parsed_scope.start" : 59,
-            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
-            "key.typename" : "[RawArgument]",
-            "key.typeusr" : "_T0Say10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
-            "key.usr" : "s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.public",
-            "key.annotated_decl" : "<Declaration>public init(_ arguments: [<Type usr=\"s:SS\">String<\/Type>])<\/Declaration>",
-            "key.bodylength" : 741,
-            "key.bodyoffset" : 1468,
-            "key.doc.column" : 9,
-            "key.doc.comment" : "Initializes the generator from a simple list of command-line arguments.",
-            "key.doc.declaration" : "public init(_ arguments: [String])",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"62\" column=\"9\"><Name>init(_:)<\/Name><USR>s:10Commandant14ArgumentParserCACSaySSGcfc<\/USR><Declaration>public init(_ arguments: [String])<\/Declaration><CommentParts><Abstract><Para>Initializes the generator from a simple list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 62,
-            "key.doc.name" : "init(_:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>arguments<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 771,
-            "key.name" : "init(_:)",
-            "key.namelength" : 27,
-            "key.nameoffset" : 1439,
-            "key.offset" : 1439,
-            "key.parsed_declaration" : "public init(_ arguments: [String])",
-            "key.parsed_scope.end" : 87,
-            "key.parsed_scope.start" : 62,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser.Type) -> ([String]) -> ArgumentParser",
-            "key.typeusr" : "_T010Commandant14ArgumentParserCSaySSGcD",
-            "key.usr" : "s:10Commandant14ArgumentParserCACSaySSGcfc"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal var remainingArguments: [<Type usr=\"s:SS\">String<\/Type>]? { get }<\/Declaration>",
-            "key.bodylength" : 76,
-            "key.bodyoffset" : 2295,
-            "key.doc.column" : 15,
-            "key.doc.comment" : "Returns the remaining arguments.",
-            "key.doc.declaration" : "internal var remainingArguments: [String]? { get }",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Other file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"90\" column=\"15\"><Name>remainingArguments<\/Name><USR>s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgv<\/USR><Declaration>internal var remainingArguments: [String]? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the remaining arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
-            "key.doc.line" : 90,
-            "key.doc.name" : "remainingArguments",
-            "key.doc.type" : "Other",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>remainingArguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
-            "key.kind" : "source.lang.swift.decl.var.instance",
-            "key.length" : 112,
-            "key.name" : "remainingArguments",
-            "key.namelength" : 18,
-            "key.nameoffset" : 2264,
-            "key.offset" : 2260,
-            "key.parsed_declaration" : "internal var remainingArguments: [String]?",
-            "key.parsed_scope.end" : 92,
-            "key.parsed_scope.start" : 90,
-            "key.typename" : "[String]?",
-            "key.typeusr" : "_T0SaySSGSgD",
-            "key.usr" : "s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgv"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
-            "key.bodylength" : 281,
-            "key.bodyoffset" : 2640,
-            "key.doc.column" : 16,
-            "key.doc.comment" : "Returns whether the given key was enabled or disabled, or nil if it\nwas not given at all.\n\nIf the key is found, it is then removed from the list of arguments\nremaining to be parsed.",
-            "key.doc.declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If the key is found, it is then removed from the list of arguments remaining to be parsed."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"99\" column=\"16\"><Name>consumeBoolean(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF<\/USR><Declaration>internal func consumeBoolean(forKey key: String) -&gt; Bool?<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was enabled or disabled, or nil if it was not given at all.<\/Para><\/Abstract><Discussion><Para>If the key is found, it is then removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 99,
-            "key.doc.name" : "consumeBoolean(forKey:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 332,
-            "key.name" : "consumeBoolean(forKey:)",
-            "key.namelength" : 34,
-            "key.nameoffset" : 2595,
-            "key.offset" : 2590,
-            "key.parsed_declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
-            "key.parsed_scope.end" : 115,
-            "key.parsed_scope.start" : 99,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF\">consumeBoolean(flag:)<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser) -> (String) -> Bool?",
-            "key.typeusr" : "_T0SbSgSS6forKey_tcD",
-            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal func consumeValue(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:6Result7NoErrorO\">NoError<\/Type>&gt;&gt;<\/Declaration>",
-            "key.bodylength" : 503,
-            "key.bodyoffset" : 3318,
-            "key.doc.column" : 16,
-            "key.doc.comment" : "Returns the value associated with the given flag, or nil if the flag was\nnot specified. If the key is presented, but no value was given, an error\nis returned.\n\nIf a value is found, the key and the value are both removed from the\nlist of arguments remaining to be parsed.",
-            "key.doc.declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<NoError>>",
-            "key.doc.discussion" : [
-              {
-                "Para" : "If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed."
-              }
-            ],
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"123\" column=\"16\"><Name>consumeValue(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC12consumeValue6ResultAEOySSSgAA0A5ErrorOyAE02NoG0OGGSS6forKey_tF<\/USR><Declaration>internal func consumeValue(forKey key: String) -&gt; Result&lt;String?, CommandantError&lt;NoError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the value associated with the given flag, or nil if the flag was not specified. If the key is presented, but no value was given, an error is returned.<\/Para><\/Abstract><Discussion><Para>If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
-            "key.doc.line" : 123,
-            "key.doc.name" : "consumeValue(forKey:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeValue<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.enum usr=\"s:6Result7NoErrorO\">NoError<\/ref.enum>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 588,
-            "key.name" : "consumeValue(forKey:)",
-            "key.namelength" : 32,
-            "key.nameoffset" : 3239,
-            "key.offset" : 3234,
-            "key.parsed_declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<NoError>>",
-            "key.parsed_scope.end" : 148,
-            "key.parsed_scope.start" : 123,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser) -> (String) -> Result<String?, CommandantError<NoError>>",
-            "key.typeusr" : "_T06ResultAAOySSSg10Commandant0B5ErrorOyAA02NoC0OGGSS6forKey_tcD",
-            "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6ResultAEOySSSgAA0A5ErrorOyAE02NoG0OGGSS6forKey_tF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal func consumePositionalArgument() -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
-            "key.bodylength" : 164,
-            "key.bodyoffset" : 4007,
-            "key.doc.column" : 16,
-            "key.doc.comment" : "Returns the next positional argument that hasn't yet been returned, or\nnil if there are no more positional arguments.",
-            "key.doc.declaration" : "internal func consumePositionalArgument() -> String?",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"152\" column=\"16\"><Name>consumePositionalArgument()<\/Name><USR>s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF<\/USR><Declaration>internal func consumePositionalArgument() -&gt; String?<\/Declaration><CommentParts><Abstract><Para>Returns the next positional argument that hasn’t yet been returned, or nil if there are no more positional arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 152,
-            "key.doc.name" : "consumePositionalArgument()",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumePositionalArgument<\/decl.name>() -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 210,
-            "key.name" : "consumePositionalArgument()",
-            "key.namelength" : 27,
-            "key.nameoffset" : 3967,
-            "key.offset" : 3962,
-            "key.parsed_declaration" : "internal func consumePositionalArgument() -> String?",
-            "key.parsed_scope.end" : 161,
-            "key.parsed_scope.start" : 152,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser) -> () -> String?",
-            "key.typeusr" : "_T0SSSgycD",
-            "key.usr" : "s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal func consume(key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
-            "key.bodylength" : 143,
-            "key.bodyoffset" : 4326,
-            "key.doc.column" : 16,
-            "key.doc.comment" : "Returns whether the given key was specified and removes it from the\nlist of arguments remaining.",
-            "key.doc.declaration" : "internal func consume(key: String) -> Bool",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"165\" column=\"16\"><Name>consume(key:)<\/Name><USR>s:10Commandant14ArgumentParserC7consumeSbSS3key_tF<\/USR><Declaration>internal func consume(key: String) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 165,
-            "key.doc.name" : "consume(key:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consume<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 179,
-            "key.name" : "consume(key:)",
-            "key.namelength" : 20,
-            "key.nameoffset" : 4296,
-            "key.offset" : 4291,
-            "key.parsed_declaration" : "internal func consume(key: String) -> Bool",
-            "key.parsed_scope.end" : 170,
-            "key.parsed_scope.start" : 165,
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser) -> (String) -> Bool",
-            "key.typeusr" : "_T0SbSS3key_tcD",
-            "key.usr" : "s:10Commandant14ArgumentParserC7consumeSbSS3key_tF"
-          },
-          {
-            "key.accessibility" : "source.lang.swift.accessibility.internal",
-            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(flag: <Type usr=\"s:s9CharacterV\">Character<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
-            "key.bodylength" : 316,
-            "key.bodyoffset" : 4636,
-            "key.doc.column" : 16,
-            "key.doc.comment" : "Returns whether the given flag was specified and removes it from the\nlist of arguments remaining.",
-            "key.doc.declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
-            "key.doc.file" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.doc.full_as_xml" : "<Function file=\"Sources\/Commandant\/ArgumentParser.swift\" line=\"174\" column=\"16\"><Name>consumeBoolean(flag:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF<\/USR><Declaration>internal func consumeBoolean(flag: Character) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given flag was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
-            "key.doc.line" : 174,
-            "key.doc.name" : "consumeBoolean(flag:)",
-            "key.doc.type" : "Function",
-            "key.filepath" : "Sources\/Commandant\/ArgumentParser.swift",
-            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s9CharacterV\">Character<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
-            "key.kind" : "source.lang.swift.decl.function.method.instance",
-            "key.length" : 363,
-            "key.name" : "consumeBoolean(flag:)",
-            "key.namelength" : 31,
-            "key.nameoffset" : 4595,
-            "key.offset" : 4590,
-            "key.parsed_declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
-            "key.parsed_scope.end" : 191,
-            "key.parsed_scope.start" : 174,
-            "key.related_decls" : [
-              {
-                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBooleanSbSgSS6forKey_tF\">consumeBoolean(forKey:)<\/RelatedName>"
-              }
-            ],
-            "key.substructure" : [
-
-            ],
-            "key.typename" : "(ArgumentParser) -> (Character) -> Bool",
-            "key.typeusr" : "_T0Sbs9CharacterV4flag_tcD",
-            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBooleanSbs9CharacterV4flag_tF"
-          }
-        ],
-        "key.typename" : "ArgumentParser.Type",
-        "key.typeusr" : "_T010Commandant14ArgumentParserCmD",
-        "key.usr" : "s:10Commandant14ArgumentParserC"
       }
     ]
   }


### PR DESCRIPTION
The order of `sourcefiles` are different between SPM and Xcode.
- Sorted alphabetically on SPM
- In the order described in Compile Sources build phase within Xcode project

These affect the differences in fixtures generated by `testCommandantDocs()` and `testCommandantDocsSPM()`.
This change minimizes that difference.