### PR TITLE
Only allow U+000A and U+000D as line break tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Only allow U+000A and U+000D as line break tokens.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [#475](https://github.com/jpsim/SourceKitten/issues/475)
 
 ## 0.19.1
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -32,6 +32,9 @@ private let commentLinePrefixCharacterSet: CharacterSet = {
     return characterSet
 }()
 
+// https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/swift/grammar/line-break
+private let newLinesCharacterSet = CharacterSet(charactersIn: "\u{000A}\u{000D}")
+
 extension NSString {
     /**
     CacheContainer caches:
@@ -63,12 +66,12 @@ extension NSString {
             var utf16CountSoFar = 0
             var bytesSoFar = 0
             var lines = [Line]()
-            let lineContents = string.components(separatedBy: .newlines)
+            let lineContents = string.components(separatedBy: newLinesCharacterSet)
             // Be compatible with `NSString.getLineStart(_:end:contentsEnd:forRange:)`
             let endsWithNewLineCharacter: Bool
             if let lastChar = string.utf16.last,
                 let lastCharScalar = UnicodeScalar(lastChar) {
-                endsWithNewLineCharacter = CharacterSet.newlines.contains(lastCharScalar)
+                endsWithNewLineCharacter = newLinesCharacterSet.contains(lastCharScalar)
             } else {
                 endsWithNewLineCharacter = false
             }
@@ -549,7 +552,7 @@ extension String {
     public func removingCommonLeadingWhitespaceFromLines() -> String {
         var minLeadingCharacters = Int.max
 
-        let lineComponents = components(separatedBy: .newlines)
+        let lineComponents = components(separatedBy: newLinesCharacterSet)
 
         for line in lineComponents {
             let lineLeadingWhitespace = line.countOfLeadingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/SourceKittenFrameworkTests/FileTests.swift
+++ b/Tests/SourceKittenFrameworkTests/FileTests.swift
@@ -20,13 +20,20 @@ class FileTests: XCTestCase {
         let formattedFile = try! file?.format(trimmingTrailingWhitespace: true, useTabs: false, indentWidth: 4)
         XCTAssertEqual(formattedFile!, try! String(contentsOfFile: fixturesDirectory + "Bicycle.swift", encoding: .utf8))
     }
+
+    func testLinesRangesWhenUsingLineSeparator() {
+        let file = File(contents: "// There're two U+2028 invisible characters after the colon:\u{2028}\u{2028}\nclass X {}")
+        XCTAssertEqual(file.lines.count, 2)
+        XCTAssertEqual(file.lines.last?.byteRange, NSRange(location: 67, length: 10))
+    }
 }
 
 extension FileTests {
     static var allTests: [(String, (FileTests) -> () throws -> Void)] {
         return [
             ("testUnreadablePath", testUnreadablePath),
-            ("testFormat", testFormat)
+            ("testFormat", testFormat),
+            ("testLinesRangesWhenUsingLineSeparator", testLinesRangesWhenUsingLineSeparator)
         ]
     }
 }


### PR DESCRIPTION
Fixes #475 

We'll probably need to change this again to fix https://github.com/realm/SwiftLint/issues/1786, but I thought we should do that later.