### PR TITLE
[SwiftDocKey] Make Substructure type description more explicit

### DIFF
--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -36,7 +36,7 @@ public enum SwiftDocKey: String {
     case nameOffset           = "key.nameoffset"
     /// Offset (Int64).
     case offset               = "key.offset"
-    /// Substructure ([SourceKitRepresentable]).
+    /// Substructure ([[String: SourceKitRepresentable]]).
     case substructure         = "key.substructure"
     /// Syntax map (NSData).
     case syntaxMap            = "key.syntaxmap"


### PR DESCRIPTION
https://github.com/apple/swift/blob/master/tools/SourceKit/docs/Protocol.md

> <key.substructure>:   (dictionary)  // Contains an array of dictionaries ...