### PR TITLE
 Replaced linear line index search with binary search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Replaced linear index search with binary search in NSString extension.  
+  [Tamas Lustyik](https://github.com/lvsti)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -32,30 +32,30 @@ private let commentLinePrefixCharacterSet: CharacterSet = {
     return characterSet
 }()
 
-private func indexInSortedCollection<C>(_ collection: C, comparing: (C.Element) throws -> ComparisonResult) rethrows -> C.Index? where C: RandomAccessCollection {
+private func indexInSortedCollection<C>(_ collection: C,
+                                        comparing: (C.Element) throws -> ComparisonResult) rethrows -> C.Index? where C: RandomAccessCollection {
     guard !collection.isEmpty else {
         return nil
     }
-    
+
     var lowerBound = collection.startIndex
     var upperBound = collection.index(before: collection.endIndex)
     var midIndex: C.Index
-    
+
     while lowerBound <= upperBound {
         let distance = collection.distance(from: lowerBound, to: upperBound)
         midIndex = collection.index(lowerBound, offsetBy: distance / 2)
         let midElem = collection[midIndex]
-        
+
         switch try comparing(midElem) {
         case .orderedDescending: lowerBound = collection.index(midIndex, offsetBy: 1)
         case .orderedAscending: upperBound = collection.index(midIndex, offsetBy: -1)
         case .orderedSame: return midIndex
         }
     }
-    
+
     return nil
 }
-
 
 extension NSString {
     /**
@@ -141,8 +141,7 @@ extension NSString {
             let index = indexInSortedCollection(lines) { line in
                 if byteOffset < line.byteRange.location {
                     return .orderedAscending
-                }
-                else if byteOffset >= line.byteRange.location + line.byteRange.length {
+                } else if byteOffset >= line.byteRange.location + line.byteRange.length {
                     return .orderedDescending
                 }
                 return .orderedSame
@@ -178,8 +177,7 @@ extension NSString {
             let index = indexInSortedCollection(lines) { line in
                 if location < line.range.location {
                     return .orderedAscending
-                }
-                else if location >= line.range.location + line.range.length {
+                } else if location >= line.range.location + line.range.length {
                     return .orderedDescending
                 }
                 return .orderedSame
@@ -207,8 +205,7 @@ extension NSString {
             let index = indexInSortedCollection(lines) { line in
                 if offset < line.range.location {
                     return .orderedAscending
-                }
-                else if offset >= line.range.location + line.range.length {
+                } else if offset >= line.range.location + line.range.length {
                     return .orderedDescending
                 }
                 return .orderedSame


### PR DESCRIPTION
TL;DR: O(log n) is better than O(n)

Long story:
While profiling Sourcery, I noticed that when processing long files, the code spent a significant amount of time searching for the line index of a given byte/character offset. It turned out that the bottlenecks were these lines:

```swift
let index = lines.index(where: { NSLocationInRange(location, $0.range) })
```

The algorithm behind `index(where:)` is obviously a linear search. But since the `lines` array is already ordered according to the range locations, we can do a binary search instead which performs much better on larger collections.

With this change, processing this [flat.swift.zip](https://github.com/jpsim/SourceKitten/files/1734015/flat.swift.zip) with Sourcery took 37 seconds instead of the original 152. It would be interesting to see the effect on other benchmark projects.

Note: I just dumped the search implementation in a private function, let me know if you want to see it in a separate file/as an extension/whatever.