### PR TITLE
'flatMap' is deprecated: renamed to 'compactMap(_:)'

### DIFF
--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -27,7 +27,7 @@ let toolchainLoader = Loader(searchPaths: [
     linuxFindSwiftenvActiveLibPath,
     linuxFindSwiftInstallationLibPath,
     linuxDefaultLibPath
-].flatMap({ $0 }))
+].compactMap({ $0 }))
 #else
 let toolchainLoader = Loader(searchPaths: [
     xcodeDefaultToolchainOverride,

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -33,7 +33,7 @@ private let sourcekitStrings: [String] = {
         linuxFindSwiftenvActiveLibPath,
         linuxFindSwiftInstallationLibPath,
         linuxDefaultLibPath
-    ].flatMap({ $0 })
+    ].compactMap({ $0 })
     let sourceKitPath: String = {
         for path in searchPaths {
             let sopath = "\(path)/libsourcekitdInProc.so"


### PR DESCRIPTION
Should we use `-warnings-as-errors` on Linux CI?