### PR TITLE
Loosen version requirement of Yams in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.13.0"),
         .package(url: "https://github.com/drmohundro/SWXMLHash.git", from: "4.5.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "0.6.0") ),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "0.6.0"),
         .package(url: "https://github.com/norio-nomura/Clang_C.git", from: "1.0.0"),
         .package(url: "https://github.com/norio-nomura/SourceKit.git", from: "1.0.0"),
     ],


### PR DESCRIPTION
Since 0.19.1 has `.upToNextMinor(from: "0.5.0")` as requirements, SwiftLint can't update Yams to 0.6.0 without updating SourceKitten.
This change will avoid such situation in future.