### PR TITLE
Add `swift-4.1.2` to `versionedExpectedFilename(for:)`

### DIFF
--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -75,6 +75,8 @@ private func compareDocs(withFixtureNamed name: String, file: StaticString = #fi
 private func versionedExpectedFilename(for name: String) -> String {
     #if swift(>=4.2)
         let versions = ["swift-4.2", "swift-4.1.1", "swift-4.1", "swift-4.0.3", "swift-4.0.2", "swift-4.0"]
+    #elseif swift(>=4.1.2)
+        let versions = ["swift-4.1.2", "swift-4.1.1", "swift-4.1", "swift-4.0.3", "swift-4.0.2", "swift-4.0"]
     #elseif swift(>=4.1.1)
         let versions = ["swift-4.1.1", "swift-4.1", "swift-4.0.3", "swift-4.0.2", "swift-4.0"]
     #elseif swift(>=4.1)


### PR DESCRIPTION
Confirmed that updating fixtures is unnecessary on `swift-4.1-DEVELOPMENT-SNAPSHOT-2018-05-12-a`.