### PR TITLE
Enable test parallelization on Xcode 10

### DIFF
--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -15,32 +15,12 @@ let projectRoot = #file.bridge()
     .deletingLastPathComponent.bridge()
     .deletingLastPathComponent
 
-let sourcekittenXcodebuildArguments = [
-    "-workspace", "SourceKitten.xcworkspace",
-    "-scheme", "SourceKittenFramework",
-    "-derivedDataPath",
-    URL(fileURLWithPath: NSTemporaryDirectory())
-        .appendingPathComponent("testSourceKittenFrameworkDocsAreValidJSON").path
-]
-
 class ModuleTests: XCTestCase {
 
     func testModuleNilInPathWithNoXcodeProject() {
         let pathWithNoXcodeProject = (#file as NSString).deletingLastPathComponent
         let model = Module(xcodeBuildArguments: [], name: nil, inPath: pathWithNoXcodeProject)
         XCTAssert(model == nil, "model initialization without any Xcode project should fail")
-    }
-
-    func testSourceKittenFrameworkDocsAreValidJSON() {
-        let sourceKittenModule = Module(xcodeBuildArguments: sourcekittenXcodebuildArguments, name: nil, inPath: projectRoot)!
-        let docsJSON = sourceKittenModule.docs.description
-        XCTAssert(docsJSON.range(of: "error type") == nil)
-        do {
-            let jsonArray = try JSONSerialization.jsonObject(with: docsJSON.data(using: .utf8)!, options: []) as? NSArray
-            XCTAssertNotNil(jsonArray, "JSON should be propery parsed")
-        } catch {
-            XCTFail("JSON should be propery parsed")
-        }
     }
 
     func testCommandantDocs() {
@@ -100,7 +80,6 @@ extension ModuleTests {
         return [
             // Disabled on Linux because these tests require Xcode
             // ("testModuleNilInPathWithNoXcodeProject", testModuleNilInPathWithNoXcodeProject),
-            // ("testSourceKittenFrameworkDocsAreValidJSON", testSourceKittenFrameworkDocsAreValidJSON),
             // ("testCommandantDocs", testCommandantDocs),
             ("testCommandantDocsSPM", testCommandantDocsSPM)
         ]

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -59,6 +59,14 @@ private func sourcekitStrings(startingWith pattern: String) -> Set<String> {
     })
 }
 
+let sourcekittenXcodebuildArguments = [
+    "-workspace", "SourceKitten.xcworkspace",
+    "-scheme", "SourceKittenFramework",
+    "-derivedDataPath",
+    URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("testLibraryWrappersAreUpToDate").path
+]
+
 // swiftlint:disable:next type_body_length
 class SourceKitTests: XCTestCase {
 
@@ -266,6 +274,14 @@ class SourceKitTests: XCTestCase {
 
     func testLibraryWrappersAreUpToDate() throws {
         let sourceKittenFrameworkModule = Module(xcodeBuildArguments: sourcekittenXcodebuildArguments, name: nil, inPath: projectRoot)!
+        let docsJSON = sourceKittenFrameworkModule.docs.description
+        XCTAssert(docsJSON.range(of: "error type") == nil)
+        do {
+            let jsonArray = try JSONSerialization.jsonObject(with: docsJSON.data(using: .utf8)!, options: []) as? NSArray
+            XCTAssertNotNil(jsonArray, "JSON should be propery parsed")
+        } catch {
+            XCTFail("JSON should be propery parsed")
+        }
         let modules: [(module: String, path: String, linuxPath: String?, spmModule: String)] = [
             ("CXString", "libclang.dylib", nil, "Clang_C"),
             ("Documentation", "libclang.dylib", nil, "Clang_C"),

--- a/sourcekitten.xcodeproj/xcshareddata/xcschemes/sourcekitten.xcscheme
+++ b/sourcekitten.xcodeproj/xcshareddata/xcschemes/sourcekitten.xcscheme
@@ -29,7 +29,8 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D0D1217619E87B05005E4BAA"


### PR DESCRIPTION
- Enable test parallelization option of `SourceKittenFrameworkTests` in `sourcekitten` scheme on Xcode 10
- Merge `testSourceKittenFrameworkDocsAreValidJSON` into `testLibraryWrappersAreUpToDate`  
Since both of `ModuleTests.testSourceKittenFrameworkDocsAreValidJSON()` and `SourceKitTests.testLibraryWrappersAreUpToDate()` used same build configuration `sourcekittenXcodebuildArguments`, one of `xcodebuild` instances was failing with error when test parallelization is enabled.
This changes avoid that.