### PR TITLE
Add support for C-language annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Add support for annotations.  
+  [Jeff Verkoeyen](https://github.com/jverkoey)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ##### Enhancements
 
-* Add support for annotations.  
+* Add support for C-language annotations (e.g. `__attribute__((annotate("This is an annotation")))`).  
   [Jeff Verkoeyen](https://github.com/jverkoey)
 
 ##### Bug Fixes

--- a/Source/SourceKittenFramework/JSONOutput.swift
+++ b/Source/SourceKittenFramework/JSONOutput.swift
@@ -108,6 +108,7 @@ private func toOutputDictionary(_ decl: SourceDeclaration) -> [String: Any] {
     set(.alwaysUnavailable, decl.availability?.alwaysUnavailable)
     set(.deprecationMessage, decl.availability?.deprecationMessage)
     set(.unavailableMessage, decl.availability?.unavailableMessage)
+    set(.annotations, decl.annotations)
 
     setA(.docResultDiscussion, decl.documentation?.returnDiscussion.map(toOutputDictionary))
     setA(.docParameters, decl.documentation?.parameters.map(toOutputDictionary))

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -41,6 +41,7 @@ public struct SourceDeclaration {
     public let documentation: Documentation?
     public let commentBody: String?
     public var children: [SourceDeclaration]
+    public let annotations: [String]
     public let swiftDeclaration: String?
     public let swiftName: String?
     public let availability: ClangAvailability?
@@ -139,6 +140,13 @@ extension SourceDeclaration {
         }).rejectPropertyMethods()
         (swiftDeclaration, swiftName) = cursor.swiftDeclarationAndName(compilerArguments: compilerArguments)
         availability = cursor.platformAvailability()
+
+        annotations = cursor.compactMap({
+            if $0.kind == CXCursor_AnnotateAttr {
+                return clang_getCursorSpelling($0).str()!
+            }
+            return nil
+        })
     }
 }
 

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -143,15 +143,11 @@ extension SourceDeclaration {
 
         let annotations: [String] = cursor.compactMap({
             if $0.kind == CXCursor_AnnotateAttr {
-                return clang_getCursorSpelling($0).str()!
+                return clang_getCursorSpelling($0).str()
             }
             return nil
         })
-        if annotations.count > 0 {
-            self.annotations = annotations
-        } else {
-            self.annotations = nil
-        }
+        self.annotations = annotations.isEmpty ? nil : annotations
     }
 }
 

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -41,7 +41,7 @@ public struct SourceDeclaration {
     public let documentation: Documentation?
     public let commentBody: String?
     public var children: [SourceDeclaration]
-    public let annotations: [String]
+    public let annotations: [String]?
     public let swiftDeclaration: String?
     public let swiftName: String?
     public let availability: ClangAvailability?
@@ -141,12 +141,17 @@ extension SourceDeclaration {
         (swiftDeclaration, swiftName) = cursor.swiftDeclarationAndName(compilerArguments: compilerArguments)
         availability = cursor.platformAvailability()
 
-        annotations = cursor.compactMap({
+        let annotations: [String] = cursor.compactMap({
             if $0.kind == CXCursor_AnnotateAttr {
                 return clang_getCursorSpelling($0).str()!
             }
             return nil
         })
+        if annotations.count > 0 {
+            self.annotations = annotations
+        } else {
+            self.annotations = nil
+        }
     }
 }
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -506,7 +506,7 @@ extension String {
                 column: 1, offset: UInt32(markByteRange.location))
             return SourceDeclaration(type: .mark, location: location, extent: (location, location), name: markString,
                                      usr: nil, declaration: nil, documentation: nil, commentBody: nil, children: [],
-                                     swiftDeclaration: nil, swiftName: nil, availability: nil)
+                                     annotations: [], swiftDeclaration: nil, swiftName: nil, availability: nil)
         }
     }
 #endif

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -506,7 +506,7 @@ extension String {
                 column: 1, offset: UInt32(markByteRange.location))
             return SourceDeclaration(type: .mark, location: location, extent: (location, location), name: markString,
                                      usr: nil, declaration: nil, documentation: nil, commentBody: nil, children: [],
-                                     annotations: [], swiftDeclaration: nil, swiftName: nil, availability: nil)
+                                     annotations: nil, swiftDeclaration: nil, swiftName: nil, availability: nil)
         }
     }
 #endif

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -89,6 +89,8 @@ public enum SwiftDocKey: String {
     case deprecationMessage   = "key.deprecation_message"
     /// Always unavailable (String).
     case unavailableMessage   = "key.unavailable_message"
+    /// Annotations ([String]).
+    case annotations          = "key.annotations"
 
     // MARK: Typed SwiftDocKey Getters
 

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Musician.h
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Musician.h
@@ -19,7 +19,13 @@
 /**
  The name of the musician. i.e. "John Coltrane"
  */
-@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) NSString *name
+    __attribute__((annotate("This API will eventually be deprecated in favor of fullName.")));
+
+/**
+ The full name of the musician. i.e. "John Coltrane"
+ */
+@property (nonatomic, readonly) NSString *fullName;
 
 /**
  The year the musician was born. i.e. 1926

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Musician.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Musician.json
@@ -16,7 +16,7 @@
           "key.kind" : "sourcekitten.source.lang.objc.decl.class",
           "key.name" : "JAZMusician",
           "key.parsed_declaration" : "@interface JAZMusician : NSObject",
-          "key.parsed_scope.end" : 45,
+          "key.parsed_scope.end" : 51,
           "key.parsed_scope.start" : 12,
           "key.substructure" : [
             {
@@ -52,6 +52,9 @@
             {
               "key.always_deprecated" : false,
               "key.always_unavailable" : false,
+              "key.annotations" : [
+                "This API will eventually be deprecated in favor of fullName."
+              ],
               "key.deprecation_message" : "",
               "key.doc.column" : 43,
               "key.doc.comment" : "The name of the musician. i.e. \"John Coltrane\"",
@@ -73,17 +76,37 @@
               "key.always_deprecated" : false,
               "key.always_unavailable" : false,
               "key.deprecation_message" : "",
+              "key.doc.column" : 43,
+              "key.doc.comment" : "The full name of the musician. i.e. \"John Coltrane\"",
+              "key.doc.file" : "Musician.h",
+              "key.doc.full_as_xml" : "",
+              "key.doc.line" : 28,
+              "key.filepath" : "Musician.h",
+              "key.kind" : "sourcekitten.source.lang.objc.decl.property",
+              "key.name" : "fullName",
+              "key.parsed_declaration" : "@property (readonly, nonatomic) NSString *fullName;",
+              "key.parsed_scope.end" : 28,
+              "key.parsed_scope.start" : 28,
+              "key.swift_declaration" : "var fullName: String! { get }",
+              "key.swift_name" : "fullName",
+              "key.unavailable_message" : "",
+              "key.usr" : "c:objc(cs)JAZMusician(py)fullName"
+            },
+            {
+              "key.always_deprecated" : false,
+              "key.always_unavailable" : false,
+              "key.deprecation_message" : "",
               "key.doc.column" : 44,
               "key.doc.comment" : "The year the musician was born. i.e. 1926",
               "key.doc.file" : "Musician.h",
               "key.doc.full_as_xml" : "",
-              "key.doc.line" : 27,
+              "key.doc.line" : 33,
               "key.filepath" : "Musician.h",
               "key.kind" : "sourcekitten.source.lang.objc.decl.property",
               "key.name" : "birthyear",
               "key.parsed_declaration" : "@property (readonly, nonatomic) NSUInteger birthyear;",
-              "key.parsed_scope.end" : 27,
-              "key.parsed_scope.start" : 27,
+              "key.parsed_scope.end" : 33,
+              "key.parsed_scope.start" : 33,
               "key.swift_declaration" : "var year: UInt { get }",
               "key.swift_name" : "year",
               "key.unavailable_message" : "",
@@ -92,12 +115,12 @@
             {
               "key.doc.column" : 1,
               "key.doc.file" : "Musician.h",
-              "key.doc.line" : 29,
+              "key.doc.line" : 35,
               "key.filepath" : "Musician.h",
               "key.kind" : "sourcekitten.source.lang.objc.mark",
               "key.name" : "Initializers-hyphenated",
-              "key.parsed_scope.end" : 29,
-              "key.parsed_scope.start" : 29
+              "key.parsed_scope.end" : 35,
+              "key.parsed_scope.start" : 35
             },
             {
               "key.always_deprecated" : false,
@@ -107,7 +130,7 @@
               "key.doc.comment" : "Initialize a JAZMusician.\nDon't forget to have a name and a birthyear.\n\n- warning: Jazz can be addicting.\nPlease be careful out there.\n\n- parameter: name      The name of the musician.\n- parameter: birthyear The year the musician was born.\n\n- returns:          An initialized JAZMusician instance.",
               "key.doc.file" : "Musician.h",
               "key.doc.full_as_xml" : "",
-              "key.doc.line" : 43,
+              "key.doc.line" : 49,
               "key.doc.parameters" : [
                 {
                   "discussion" : [
@@ -138,8 +161,8 @@
               "key.kind" : "sourcekitten.source.lang.objc.decl.method.instance",
               "key.name" : "-initWithName:birthyear:",
               "key.parsed_declaration" : "- (instancetype)initWithName:(NSString *)name birthyear:(NSUInteger)birthyear;",
-              "key.parsed_scope.end" : 43,
-              "key.parsed_scope.start" : 43,
+              "key.parsed_scope.end" : 49,
+              "key.parsed_scope.start" : 49,
               "key.swift_declaration" : "init!(name: String!, year birthyear: UInt)",
               "key.swift_name" : "init(name:year:)",
               "key.unavailable_message" : "",


### PR DESCRIPTION
Example annotation:

```
- (void)someMethod __attribute__((annotate("This is a custom annotation.")));
```

Will appear in the output as part of a new `annotations` field as `["This is a custom annotation."]`.