### PR TITLE
[CircleCI] Avoid auto updating Homebrew on installing `swiftlint`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
     - checkout
     - run: git submodule update --init --recursive
     - run: swift test
-    - run: brew install https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb && swiftlint lint --strict
+    - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb && swiftlint lint --strict
 
   - &steps-for-linux
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
     - checkout
     - run: git submodule update --init --recursive
     - run: swift test
-    - run: brew install swiftlint && swiftlint lint --strict
+    - run: brew install https://raw.github.com/Homebrew/homebrew-core/master/Formula/swiftlint.rb && swiftlint lint --strict
 
   - &steps-for-linux
     - checkout


### PR DESCRIPTION
This reduces the `swiftlint lint` step from 35-120 seconds to few seconds.