### PR TITLE
Avoid `clean` on running `xcodebuild` if New Build System is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* If New Build System is enabled on Xcode, the `doc` command does not need to
+  use the `clean` action on `xcodebuild`.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/ClangTranslationUnit.swift
+++ b/Source/SourceKittenFramework/ClangTranslationUnit.swift
@@ -78,7 +78,7 @@ public struct ClangTranslationUnit {
     - parameter path:                Path to run `xcodebuild` from. Uses current path by default.
     */
     public init?(headerFiles: [String], xcodeBuildArguments: [String], inPath path: String = FileManager.default.currentDirectoryPath) {
-        let xcodeBuildOutput = runXcodeBuild(arguments: xcodeBuildArguments + ["-dry-run"], inPath: path) ?? ""
+        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments + ["-dry-run"], inPath: path) ?? ""
         guard let clangArguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput as NSString, language: .objc, moduleName: nil) else {
             fputs("could not parse compiler arguments\n\(xcodeBuildOutput)\n", stderr)
             return nil

--- a/Source/SourceKittenFramework/ClangTranslationUnit.swift
+++ b/Source/SourceKittenFramework/ClangTranslationUnit.swift
@@ -79,7 +79,7 @@ public struct ClangTranslationUnit {
     */
     public init?(headerFiles: [String], xcodeBuildArguments: [String], inPath path: String = FileManager.default.currentDirectoryPath) {
         let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments + ["-dry-run"], inPath: path) ?? ""
-        guard let clangArguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput as NSString, language: .objc, moduleName: nil) else {
+        guard let clangArguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput, language: .objc, moduleName: nil) else {
             fputs("could not parse compiler arguments\n\(xcodeBuildOutput)\n", stderr)
             return nil
         }

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -73,7 +73,7 @@ public struct Module {
     */
     public init?(xcodeBuildArguments: [String], name: String? = nil, inPath path: String = FileManager.default.currentDirectoryPath) {
         let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments, inPath: path) ?? ""
-        guard let arguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput.bridge(), language: .swift,
+        guard let arguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput, language: .swift,
                                                      moduleName: name ?? moduleName(fromArguments: xcodeBuildArguments)) else {
             fputs("Could not parse compiler arguments from `xcodebuild` output.\n", stderr)
             fputs("Please confirm that `xcodebuild` is building a Swift module.\n", stderr)

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -72,7 +72,7 @@ public struct Module {
     - parameter path:                Path to run `xcodebuild` from. Uses current path by default.
     */
     public init?(xcodeBuildArguments: [String], name: String? = nil, inPath path: String = FileManager.default.currentDirectoryPath) {
-        let xcodeBuildOutput = runXcodeBuild(arguments: xcodeBuildArguments, inPath: path) ?? ""
+        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments, inPath: path) ?? ""
         guard let arguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput.bridge(), language: .swift,
                                                      moduleName: name ?? moduleName(fromArguments: xcodeBuildArguments)) else {
             fputs("Could not parse compiler arguments from `xcodebuild` output.\n", stderr)

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -8,32 +8,47 @@
 
 import Foundation
 
-/**
-Run `xcodebuild clean build` along with any passed in build arguments.
+internal enum XcodeBuild {
+    /**
+    Run `xcodebuild clean build` along with any passed in build arguments.
 
-- parameter arguments: Arguments to pass to `xcodebuild`.
-- parameter path:      Path to run `xcodebuild` from.
+    - parameter arguments: Arguments to pass to `xcodebuild`.
+    - parameter path:      Path to run `xcodebuild` from.
 
-- returns: `xcodebuild`'s STDERR+STDOUT output combined.
-*/
-internal func runXcodeBuild(arguments: [String], inPath path: String) -> String? {
-    fputs("Running xcodebuild\n", stderr)
+    - returns: `xcodebuild`'s STDERR+STDOUT output combined.
+    */
+    internal static func cleanBuild(arguments: [String], inPath path: String) -> String? {
+        let arguments = arguments + ["clean", "build", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"]
+        return run(arguments: arguments, inPath: path)
+    }
 
-    let task = Process()
-    task.launchPath = "/usr/bin/xcodebuild"
-    task.currentDirectoryPath = path
-    task.arguments = arguments + ["clean", "build", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"]
+    /**
+    Run `xcodebuild` along with any passed in build arguments.
 
-    let pipe = Pipe()
-    task.standardOutput = pipe
-    task.standardError = pipe
+    - parameter arguments: Arguments to pass to `xcodebuild`.
+    - parameter path:      Path to run `xcodebuild` from.
 
-    task.launch()
+    - returns: `xcodebuild`'s STDERR+STDOUT output combined.
+    */
+    internal static func run(arguments: [String], inPath path: String) -> String? {
+        fputs("Running xcodebuild\n", stderr)
 
-    let file = pipe.fileHandleForReading
-    defer { file.closeFile() }
+        let task = Process()
+        task.launchPath = "/usr/bin/xcodebuild"
+        task.currentDirectoryPath = path
+        task.arguments = arguments
 
-    return String(data: file.readDataToEndOfFile(), encoding: .utf8)
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = pipe
+
+        task.launch()
+
+        let file = pipe.fileHandleForReading
+        defer { file.closeFile() }
+
+        return String(data: file.readDataToEndOfFile(), encoding: .utf8)
+    }
 }
 
 /**

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -228,7 +228,7 @@ ${PROJECT_TEMP_ROOT}
 
 - returns: Compiler arguments, filtered for suitable use by SourceKit.
 */
-internal func checkNewBuildSystem(in projectTempRoot: String, moduleName: String) -> [String]? {
+internal func checkNewBuildSystem(in projectTempRoot: String, moduleName: String? = nil) -> [String]? {
     let xcbuildDataURL = URL(fileURLWithPath: projectTempRoot).appendingPathComponent("XCBuildData")
 
     do {
@@ -247,7 +247,7 @@ internal func checkNewBuildSystem(in projectTempRoot: String, moduleName: String
             for command in commands where command["description"]?.string?.hasSuffix("com.apple.xcode.tools.swift.compiler") ?? false {
                 if let args = command["args"]?.sequence,
                     let index = args.index(of: "-module-name"),
-                    args[args.index(after: index)].string == moduleName {
+                    moduleName != nil ? args[args.index(after: index)].string == moduleName : true {
                     let fullArgs = args.compactMap { $0.string }
                     if let separatorIndex = fullArgs.index(of: "--") {
                         return Array(fullArgs.suffix(from: fullArgs.index(after: separatorIndex)))

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -61,11 +61,13 @@ private func sourcekitStrings(startingWith pattern: String) -> Set<String> {
 
 let sourcekittenXcodebuildArguments = [
     "-workspace", "SourceKitten.xcworkspace",
-    "-scheme", "SourceKittenFramework",
-    "-derivedDataPath",
-    URL(fileURLWithPath: NSTemporaryDirectory())
-        .appendingPathComponent("testLibraryWrappersAreUpToDate").path
-]
+    "-scheme", "sourcekitten"
+] + { () -> [String] in
+    return ProcessInfo.processInfo.environment["XCODE_VERSION_MINOR"].map { $0 >= "1000" } ?? false ? [] : [
+        "-derivedDataPath",
+        URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("testLibraryWrappersAreUpToDate").path
+    ]
+}()
 
 // swiftlint:disable:next type_body_length
 class SourceKitTests: XCTestCase {
@@ -307,7 +309,7 @@ class SourceKitTests: XCTestCase {
     }
 
     func testLibraryWrappersAreUpToDate() throws {
-        let sourceKittenFrameworkModule = Module(xcodeBuildArguments: sourcekittenXcodebuildArguments, name: nil, inPath: projectRoot)!
+        let sourceKittenFrameworkModule = Module(xcodeBuildArguments: sourcekittenXcodebuildArguments, name: "SourceKittenFramework", inPath: projectRoot)!
         let docsJSON = sourceKittenFrameworkModule.docs.description
         XCTAssert(docsJSON.range(of: "error type") == nil)
         do {

--- a/sourcekitten.xcodeproj/xcshareddata/xcschemes/sourcekitten.xcscheme
+++ b/sourcekitten.xcodeproj/xcshareddata/xcschemes/sourcekitten.xcscheme
@@ -85,6 +85,11 @@
             value = "${TOOLCHAINS}"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "XCODE_VERSION_MINOR"
+            value = "${XCODE_VERSION_MINOR}"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>


### PR DESCRIPTION
Since Xcode’s New Build System uses `llbuild`, compiler arguments for `Module` can be retrieved from manifest of `llbuild` instead of parsing `xcodebuild`’s output. Until this changes, the `clean` action was used for `xcodebuild` to ensure compiler arguments, but it is not necessary when using the New Build System.