### PR TITLE
Make SourceKitd initialize public

### DIFF
--- a/Source/SourceKittenFramework/library_wrapper_sourcekitd.swift
+++ b/Source/SourceKittenFramework/library_wrapper_sourcekitd.swift
@@ -7,7 +7,7 @@ private let path = "libsourcekitdInProc.so"
 private let path = "sourcekitd.framework/Versions/A/sourcekitd"
 #endif
 private let library = toolchainLoader.load(path: path)
-internal let sourcekitd_initialize: @convention(c) () -> () = library.load(symbol: "sourcekitd_initialize")
+public let sourcekitd_initialize: @convention(c) () -> () = library.load(symbol: "sourcekitd_initialize")
 internal let sourcekitd_shutdown: @convention(c) () -> () = library.load(symbol: "sourcekitd_shutdown")
 internal let sourcekitd_set_interrupted_connection_handler: @convention(c) (@escaping sourcekitd_interrupted_connection_handler_t) -> () = library.load(symbol: "sourcekitd_set_interrupted_connection_handler")
 internal let sourcekitd_uid_get_from_cstr: @convention(c) (UnsafePointer<Int8>) -> (sourcekitd_uid_t?) = library.load(symbol: "sourcekitd_uid_get_from_cstr")


### PR DESCRIPTION
Sometimes SourceKit process actually hangs internally. In this case, the only recovery is to kill the SourceKitService process and restart it. However the current `sourcekitd_initialize` function is `internal`. External projects cannot re-initialize it. This change simply exposes that function.