### PR TITLE
Fix crash in NSString.location(fromByteOffset:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix crash in `NSString.location(fromByteOffset:)` when using unicode
+  characters.  
+  [JP Simard](https://github.com/jpsim)
+  [realm/SwiftLint#2276](https://github.com/realm/SwiftLint/issues/2276)
 
 ## 0.21.3
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -167,9 +167,8 @@ extension NSString {
                 return NSMaxRange(line.range)
             }
             let utf8View = line.content.utf8
-            let endUTF16index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex)!
-                .samePosition(in: line.content.utf16)!
-            let utf16Diff = line.content.utf16.distance(from: line.content.utf16.startIndex, to: endUTF16index)
+            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex)!
+            let utf16Diff = line.content.utf16.distance(from: line.content.utf16.startIndex, to: endUTF8Index)
             return line.range.location + utf16Diff
         }
 

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -174,6 +174,26 @@ class StringTests: XCTestCase {
         XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: 17), (1, 18))
     }
 
+    func testByteRangeToNSRange() {
+        let string = """
+            enum Foo {
+                case one
+                case two
+            }
+
+            func bar(foo: Foo) -> String {
+                let some = "ru_RU"
+                switch foo {
+                case .one:
+                    return "\\(some) один"
+                default:
+                    return "\\(some) два"
+                }
+            }
+            """
+        XCTAssertEqual(string.bridge().byteRangeToNSRange(start: 115, length: 42), NSRange(location: 115, length: 38))
+    }
+
     func testLineAndCharacterForCharacterOffset() {
         let string = "" +
         "func foo() {\n" + //     12+1 characters, start=0
@@ -230,6 +250,7 @@ extension StringTests {
             ("testSubstringLinesWithByteRange", testSubstringLinesWithByteRange),
             ("testLineRangeWithByteRange", testLineRangeWithByteRange),
             ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset),
+            ("testByteRangeToNSRange", testByteRangeToNSRange),
             ("testLineAndCharacterForCharacterOffset", testLineAndCharacterForCharacterOffset)
         ]
     }


### PR DESCRIPTION
when using unicode characters. Reported in realm/SwiftLint#2276