### PR TITLE
Fix misidentification of .swift-suffixed directory as a Swift file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* “.swift”-suffixed directory in xcodebuild arguments no longer detected as
+  Swift file.  
+  [Minh Nguyễn](https://github.com/1ec5)
+  [#574](https://github.com/jpsim/SourceKitten/issues/574)
 
 ## 0.22.0
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -466,7 +466,9 @@ extension NSString {
 
 extension String {
     internal var isFile: Bool {
-        return FileManager.default.fileExists(atPath: self)
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: self, isDirectory: &isDirectory)
+        return exists && !isDirectory.boolValue
     }
 
     internal func capitalizingFirstLetter() -> String {

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -465,10 +465,6 @@ extension NSString {
 }
 
 extension String {
-    internal var isFileOrDirectory: Bool {
-        return FileManager.default.fileExists(atPath: self)
-    }
-
     internal var isFile: Bool {
         var isDirectory: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: self, isDirectory: &isDirectory)

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -465,6 +465,10 @@ extension NSString {
 }
 
 extension String {
+    internal var isFileOrDirectory: Bool {
+        return FileManager.default.fileExists(atPath: self)
+    }
+
     internal var isFile: Bool {
         var isDirectory: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: self, isDirectory: &isDirectory)

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -42,7 +42,7 @@ let toolchainLoader = Loader(searchPaths: [
     userApplicationsDir?.xcodeDeveloperDir.toolchainDir,
     userApplicationsDir?.xcodeBetaDeveloperDir.toolchainDir
 ].compactMap { path in
-    if let fullPath = path?.usrLibDir, fullPath.isFile {
+    if let fullPath = path?.usrLibDir, FileManager.default.fileExists(atPath: fullPath) {
         return fullPath
     }
     return nil
@@ -53,7 +53,7 @@ struct Loader {
     let searchPaths: [String]
 
     func load(path: String) -> DynamicLinkLibrary {
-        let fullPaths = searchPaths.map { $0.appending(pathComponent: path) }.filter { $0.isFileOrDirectory }
+        let fullPaths = searchPaths.map { $0.appending(pathComponent: path) }.filter { $0.isFile }
 
         // try all fullPaths that contains target file,
         // then try loading with simple path that depends resolving to DYLD

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -53,7 +53,7 @@ struct Loader {
     let searchPaths: [String]
 
     func load(path: String) -> DynamicLinkLibrary {
-        let fullPaths = searchPaths.map { $0.appending(pathComponent: path) }.filter { $0.isFile }
+        let fullPaths = searchPaths.map { $0.appending(pathComponent: path) }.filter { $0.isFileOrDirectory }
 
         // try all fullPaths that contains target file,
         // then try loading with simple path that depends resolving to DYLD


### PR DESCRIPTION
A “.swift”-suffixed directory in `xcodebuild` arguments is no longer detected as a Swift file.

Fixes #574.