### PR TITLE
Undo shell escapes from xcodebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [Minh Nguyễn](https://github.com/1ec5)
   [#574](https://github.com/jpsim/SourceKitten/issues/574)
 
+* Pathnames containing shell-escaped characters in xcodebuild arguments no
+  longer prevent documentation generation.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.22.0
 
 ##### Breaking

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -657,4 +657,18 @@ extension String {
         }
         return Int64(utf8.distance(from: utf8.startIndex, to: utf8pos))
     }
+
+    /// A version of the string with backslash escapes removed.
+    public var unescaped: String {
+        struct UnescapingSequence: Sequence, IteratorProtocol {
+            var iterator: IndexingIterator<String>
+
+            mutating func next() -> Character? {
+                guard let char = iterator.next() else { return nil }
+                guard char == "\\" else { return char }
+                return iterator.next()
+            }
+        }
+        return String(UnescapingSequence(iterator: makeIterator()))
+    }
 }

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -147,6 +147,7 @@ internal func parseCompilerArguments(xcodebuildOutput: String, language: Languag
     let escapedSpacePlaceholder = "\u{0}"
     let args = filter(arguments: String(xcodebuildOutput[matchRange])
         .replacingOccurrences(of: "\\ ", with: escapedSpacePlaceholder)
+        .unescaped
         .components(separatedBy: " "))
 
     // Remove first argument (swiftc/clang) and re-add spaces in arguments

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -215,6 +215,19 @@ class StringTests: XCTestCase {
         XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 4), (4, 5))
         XCTAssertEqual(string.bridge().lineAndCharacter(forCharacterOffset: 35, expandingTabsToWidth: 8), (4, 9))
     }
+
+    func testUnescaping() {
+        XCTAssertEqual("aaa".unescaped, "aaa")
+        XCTAssertEqual("a\\bc".unescaped, "abc")
+        XCTAssertEqual("\\abc".unescaped, "abc")
+        XCTAssertEqual("ab\\c".unescaped, "abc")
+        XCTAssertEqual("\\a".unescaped, "a")
+        XCTAssertEqual("\\\\".unescaped, "\\")
+        XCTAssertEqual("a\\\\\\b".unescaped, "a\\b")
+
+        // no crash on bad input
+        XCTAssertEqual("ab\\".unescaped, "ab")
+    }
 }
 
 typealias LineRangeType = (start: Int, end: Int)
@@ -251,7 +264,8 @@ extension StringTests {
             ("testLineRangeWithByteRange", testLineRangeWithByteRange),
             ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset),
             ("testByteRangeToNSRange", testByteRangeToNSRange),
-            ("testLineAndCharacterForCharacterOffset", testLineAndCharacterForCharacterOffset)
+            ("testLineAndCharacterForCharacterOffset", testLineAndCharacterForCharacterOffset),
+            ("testUnescaping", testUnescaping)
         ]
     }
 }


### PR DESCRIPTION
realm/jazzy#1049 shows that if the source paths include characters (other than space) that the shell needs escaping like quotes, then xcodebuild does that escaping in its output but sourcekitten fails because the .swift pathnames still contain the escaping backslashes.

This PR undoes the backslash escaping as part of parsing the Xcode arguments.

(I couldn't find a library function for this or a regex solution that wasn't extremely opaque, improvements v welcome...  the approach here goes wrong if there were arguments that are themselves quoted strings containing backslashes but we'd be broken there already on spaces so I guess they don't exist...)
