### PR TITLE
Silence errors due to which failing to find swiftenv

### DIFF
--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -79,6 +79,9 @@ private func runCommand(_ path: String, _ args: String...) -> String? {
 
     let pipe = Pipe()
     process.standardOutput = pipe
+    // FileHandle.nullDevice does not work here, as it consists of an invalid file descriptor,
+    // causing process.launch() to abort with an EBADF.
+    process.standardError = FileHandle(forWritingAtPath: "/dev/null")!
     process.launch()
 
     let data = pipe.fileHandleForReading.readDataToEndOfFile()


### PR DESCRIPTION
With 0.22.0, if I run sourcekitten, I'll get this printed:

```
/usr/bin/which: no swiftenv in (/home/ryan/bin:/var/lib/bluecap/exports/bin:/home/ryan/.local/share/flatpak/exports/bin:/var/lib/flatpak/exports/bin:/home/ryan/.cargopak/bin:/home/ryan/Android/Sdk/platform-tools:/home/ryan/.local/bin:/home/ryan/.cargo/bin:/home/ryan/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```

even if/when the command successfully finds the sourcekit library.