### PR TITLE
Don't pass swiftc to sourcekit with new build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   longer prevent documentation generation.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* `swiftc` no longer passed as a compiler argument when using `doc` and
+  the new build system.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ## 0.22.0
 
 ##### Breaking

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -250,10 +250,10 @@ internal func checkNewBuildSystem(in projectTempRoot: String, moduleName: String
                     let index = args.index(of: "-module-name"),
                     moduleName != nil ? args[args.index(after: index)].string == moduleName : true {
                     let fullArgs = args.compactMap { $0.string }
-                    if let separatorIndex = fullArgs.index(of: "--") {
-                        return Array(fullArgs.suffix(from: fullArgs.index(after: separatorIndex)))
-                    }
-                    return fullArgs
+                    let swiftCIndex = fullArgs.index(of: "--").flatMap {
+                        fullArgs.index(after: $0)
+                    } ?? fullArgs.startIndex
+                    return Array(fullArgs.suffix(from: fullArgs.index(after: swiftCIndex)))
                 }
             }
             return nil

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -250,9 +250,7 @@ internal func checkNewBuildSystem(in projectTempRoot: String, moduleName: String
                     let index = args.index(of: "-module-name"),
                     moduleName != nil ? args[args.index(after: index)].string == moduleName : true {
                     let fullArgs = args.compactMap { $0.string }
-                    let swiftCIndex = fullArgs.index(of: "--").flatMap {
-                        fullArgs.index(after: $0)
-                    } ?? fullArgs.startIndex
+                    let swiftCIndex = fullArgs.index(of: "--").flatMap(fullArgs.index(after:)) ?? fullArgs.startIndex
                     return Array(fullArgs.suffix(from: fullArgs.index(after: swiftCIndex)))
                 }
             }


### PR DESCRIPTION
When the new build system `manifest.xcbuild` file is used to figure out compiler args, the path to `swiftc` itself gets included.

This is different to old build system / SPM, and although it is (apparently) ignored by `cursorinfo` it causes problems with other requests (`docinfo` happens to be the one I'm working with).

This PR aligns the new-build-system args finder with the other two kinds.