### PR TITLE
Fix clean xcodebuild with Xcode 10.2 and new build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   [Minh Nguyễn](https://github.com/1ec5)
   [#574](https://github.com/jpsim/SourceKitten/issues/574)
 
+* Fix `xcodebuild clean` path for new build system and Xcode 10.2.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [realm/jazzy#1057](https://github.com/realm/jazzy/issues/1057)
+
 * Pathnames containing shell-escaped characters in xcodebuild arguments no
   longer prevent documentation generation.  
   [John Fairhurst](https://github.com/johnfairh)

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -19,7 +19,11 @@ internal enum XcodeBuild {
     - returns: `xcodebuild`'s STDERR+STDOUT output combined.
     */
     internal static func cleanBuild(arguments: [String], inPath path: String) -> String? {
-        let arguments = arguments + ["clean", "build", "CODE_SIGN_IDENTITY=", "CODE_SIGNING_REQUIRED=NO"]
+        let arguments = arguments + ["clean",
+                                     "build",
+                                     "CODE_SIGN_IDENTITY=",
+                                     "CODE_SIGNING_REQUIRED=NO",
+                                     "CODE_SIGNING_ALLOWED=NO"]
         fputs("Running xcodebuild\n", stderr)
         return run(arguments: arguments, inPath: path)
     }


### PR DESCRIPTION
Found via realm/jazzy#1057.

`xcodebuild` in 10.2 requires an additional signing-related flag to skip signing without failing when using the new build system.

The `XcodeBuild.cleanBuild()` path is unreachable on new build system if all is well but we get there if user has wrong settings (etc).

edit: tested this on matrix of Xcode 10.1/10.2, new/old build system, project needs/doesn't need signing.