### PR TITLE
Improve Module Name Inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ##### Enhancements
 
-* None.
+* Introduce `XcodeBuildSetting` for interacting with project build settings.
+  [Chris Zielinski](https://github.com/chriszielinski)
+
+* Improve module name inference for `Module`.
+  [Chris Zielinski](https://github.com/chriszielinski)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ##### Enhancements
 
-* Introduce `XcodeBuildSetting` for interacting with project build settings.
+* Introduce `XcodeBuildSetting` for interacting with project build settings.  
   [Chris Zielinski](https://github.com/chriszielinski)
 
-* Improve module name inference for `Module`.
+* Improve module name inference for `Module`.  
   [Chris Zielinski](https://github.com/chriszielinski)
 
 ##### Bug Fixes

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -137,3 +137,20 @@ extension Module: CustomStringConvertible {
         return "Module(name: \(name), compilerArguments: \(compilerArguments), sourceFiles: \(sourceFiles))"
     }
 }
+
+// MARK: XcodeBuildSetting Conveniences
+
+private extension Collection where Element == XcodeBuildSetting {
+    /// Iterates through the `XcodeBuildSetting`s and returns the first value returned by the getter closure.
+    ///
+    /// For example, if we want the value of the first `XcodeBuildSetting` with a `"PROJECT_TEMP_ROOT"` value:
+    ///
+    ///     let buildSettings: [XcodeBuildSetting] = ...
+    ///     let projectTempRoot = buildSettings.firstBuildSettingValue { $0.projectTempRoot }
+    ///
+    /// - Parameter getterClosure: A closure that returns a dynamic member.
+    /// - Returns: The first value returned by the getter closure.
+    func firstBuildSettingValue(for getterClosure: (XcodeBuildSetting) -> String?) -> String? {
+        return lazy.compactMap(getterClosure).first
+    }
+}

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -31,8 +31,8 @@ internal enum XcodeBuild {
     /**
     Run `xcodebuild` along with any passed in build arguments.
 
-    - parameter arguments:           Arguments to pass to `xcodebuild`.
-    - parameter path:                Path to run `xcodebuild` from.
+    - parameter arguments: Arguments to pass to `xcodebuild`.
+    - parameter path:      Path to run `xcodebuild` from.
 
     - returns: `xcodebuild`'s STDERR+STDOUT output combined.
     */
@@ -85,11 +85,11 @@ internal enum XcodeBuild {
 
         let decoder = JSONDecoder()
 
-        #if os(Linux) && !swift(>=4.2.1)
+#if os(Linux) && !swift(>=4.2.1)
         // Handled in `XcodeBuildSetting`.
-        #else
+#else
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        #endif
+#endif
         return try? decoder.decode([XcodeBuildSetting].self, from: outputData)
     }
 }

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -74,7 +74,12 @@ internal enum XcodeBuild {
             else { return nil }
 
         let decoder = JSONDecoder()
+
+        #if os(Linux) && !swift(>=4.2.1)
+        // Handled in `XcodeBuildSetting`.
+        #else
         decoder.keyDecodingStrategy = .convertFromSnakeCase
+        #endif
         return try? decoder.decode([XcodeBuildSetting].self, from: data)
     }
 }

--- a/Source/SourceKittenFramework/XcodeBuildSetting.swift
+++ b/Source/SourceKittenFramework/XcodeBuildSetting.swift
@@ -22,9 +22,79 @@ struct XcodeBuildSetting: Codable {
     /// The target name.
     let target: String
 
+    #if os(Linux) && !swift(>=4.2.1)
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        action = try container.decode(String.self, forKey: .action)
+
+        var decodedKeybuildSettings: [String: String] = [:]
+        try container.decode([String: String].self, forKey: .buildSettings).forEach({ (key, value) in
+            decodedKeybuildSettings[XcodeBuildSetting._convertFromSnakeCase(key)] = value
+        })
+        buildSettings = decodedKeybuildSettings
+
+        target = try container.decode(String.self, forKey: .target)
+    }
+    #endif
+
     subscript(dynamicMember member: String) -> String? {
         return buildSettings[member]
     }
+
+    #if os(Linux) && !swift(>=4.2.1)
+    /// This method is part of the Swift.org open source project
+    /// https://github.com/apple/swift-corelibs-foundation/blob/489984ce5c03890a5d9d51e10298bb7582c26178/Foundation/JSONEncoder.swift#L1014
+    ///
+    /// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+    /// Licensed under Apache License v2.0 with Runtime Library Exception
+    ///
+    /// See https://swift.org/LICENSE.txt for license information
+    /// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+    fileprivate static func _convertFromSnakeCase(_ stringKey: String) -> String {
+        guard !stringKey.isEmpty else { return stringKey }
+
+        // Find the first non-underscore character
+        guard let firstNonUnderscore = stringKey.firstIndex(where: { $0 != "_" }) else {
+            // Reached the end without finding an _
+            return stringKey
+        }
+
+        // Find the last non-underscore character
+        var lastNonUnderscore = stringKey.index(before: stringKey.endIndex)
+        while lastNonUnderscore > firstNonUnderscore && stringKey[lastNonUnderscore] == "_" {
+            stringKey.formIndex(before: &lastNonUnderscore)
+        }
+
+        let keyRange = firstNonUnderscore...lastNonUnderscore
+        let leadingUnderscoreRange = stringKey.startIndex..<firstNonUnderscore
+        let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore)..<stringKey.endIndex
+
+        var components = stringKey[keyRange].split(separator: "_")
+        let joinedString : String
+        if components.count == 1 {
+            // No underscores in key, leave the word as is - maybe already camel cased
+            joinedString = String(stringKey[keyRange])
+        } else {
+            joinedString = ([components[0].lowercased()] + components[1...].map { $0.capitalized }).joined()
+        }
+
+        // Do a cheap isEmpty check before creating and appending potentially empty strings
+        let result : String
+        if (leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty) {
+            result = joinedString
+        } else if (!leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty) {
+            // Both leading and trailing underscores
+            result = String(stringKey[leadingUnderscoreRange]) + joinedString + String(stringKey[trailingUnderscoreRange])
+        } else if (!leadingUnderscoreRange.isEmpty) {
+            // Just leading
+            result = String(stringKey[leadingUnderscoreRange]) + joinedString
+        } else {
+            // Just trailing
+            result = joinedString + String(stringKey[trailingUnderscoreRange])
+        }
+        return result
+    }
+    #endif
 
 }
 

--- a/Source/SourceKittenFramework/XcodeBuildSetting.swift
+++ b/Source/SourceKittenFramework/XcodeBuildSetting.swift
@@ -1,0 +1,52 @@
+//
+//  XcodeBuildSetting.swift
+//  SourceKittenFramework
+//
+//  Created by Chris Zielinski on 2/23/19.
+//  Copyright © 2019 SourceKitten. All rights reserved.
+//
+
+@dynamicMemberLookup
+struct XcodeBuildSetting: Codable {
+
+    /// The build action.
+    let action: String
+    /// The build settings.
+    ///
+    /// - Important: The keys are camel cased (e.g. the build setting key `"PRODUCT_MODULE_NAME"`
+    ///              is `"productModuleName"`).
+    ///
+    /// - Note: You can access the values using _dot_ syntax (e.g. `XcodeBuildSetting.platformName`
+    ///         will return the value for the key `"PLATFORM_NAME"`).
+    let buildSettings: [String: String]
+    /// The target name.
+    let target: String
+
+    subscript(dynamicMember member: String) -> String? {
+        return buildSettings[member]
+    }
+
+}
+
+extension Array where Element == XcodeBuildSetting {
+
+    /// Iterates through the `XcodeBuildSetting`s and returns the first value returned by the getter closure.
+    ///
+    /// For example, if we want the value of the first `XcodeBuildSetting` with a `"PROJECT_TEMP_ROOT"` value:
+    ///
+    ///     let buildSettings: [XcodeBuildSetting] = ...
+    ///     let projectTempRoot = buildSettings.firstBuildSettingValue { $0.projectTempRoot }
+    ///
+    /// - Parameter getterClosure: A closure that returns a dynamic member.
+    /// - Returns: The first value returned by the getter closure.
+    func firstBuildSettingValue(for getterClosure: (XcodeBuildSetting) -> String?) -> String? {
+        for buildSetting in self {
+            if let value = getterClosure(buildSetting) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
+}

--- a/Source/SourceKittenFramework/XcodeBuildSetting.swift
+++ b/Source/SourceKittenFramework/XcodeBuildSetting.swift
@@ -22,7 +22,11 @@ struct XcodeBuildSetting: Codable {
     /// The target name.
     let target: String
 
-    #if os(Linux) && !swift(>=4.2.1)
+    subscript(dynamicMember member: String) -> String? {
+        return buildSettings[member]
+    }
+
+#if os(Linux) && !swift(>=4.2.1)
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         action = try container.decode(String.self, forKey: .action)
@@ -35,13 +39,7 @@ struct XcodeBuildSetting: Codable {
 
         target = try container.decode(String.self, forKey: .target)
     }
-    #endif
 
-    subscript(dynamicMember member: String) -> String? {
-        return buildSettings[member]
-    }
-
-    #if os(Linux) && !swift(>=4.2.1)
     /// This method is part of the Swift.org open source project
     /// https://github.com/apple/swift-corelibs-foundation/blob/489984ce5c03890a5d9d51e10298bb7582c26178/Foundation/JSONEncoder.swift#L1014
     ///
@@ -94,29 +92,6 @@ struct XcodeBuildSetting: Codable {
         }
         return result
     }
-    #endif
-
-}
-
-extension Array where Element == XcodeBuildSetting {
-
-    /// Iterates through the `XcodeBuildSetting`s and returns the first value returned by the getter closure.
-    ///
-    /// For example, if we want the value of the first `XcodeBuildSetting` with a `"PROJECT_TEMP_ROOT"` value:
-    ///
-    ///     let buildSettings: [XcodeBuildSetting] = ...
-    ///     let projectTempRoot = buildSettings.firstBuildSettingValue { $0.projectTempRoot }
-    ///
-    /// - Parameter getterClosure: A closure that returns a dynamic member.
-    /// - Returns: The first value returned by the getter closure.
-    func firstBuildSettingValue(for getterClosure: (XcodeBuildSetting) -> String?) -> String? {
-        for buildSetting in self {
-            if let value = getterClosure(buildSetting) {
-                return value
-            }
-        }
-
-        return nil
-    }
+#endif
 
 }

--- a/Source/SourceKittenFramework/XcodeBuildSetting.swift
+++ b/Source/SourceKittenFramework/XcodeBuildSetting.swift
@@ -28,9 +28,9 @@ struct XcodeBuildSetting: Codable {
         action = try container.decode(String.self, forKey: .action)
 
         var decodedKeybuildSettings: [String: String] = [:]
-        try container.decode([String: String].self, forKey: .buildSettings).forEach({ (key, value) in
+        try container.decode([String: String].self, forKey: .buildSettings).forEach { key, value in
             decodedKeybuildSettings[XcodeBuildSetting._convertFromSnakeCase(key)] = value
-        })
+        }
         buildSettings = decodedKeybuildSettings
 
         target = try container.decode(String.self, forKey: .target)
@@ -70,7 +70,7 @@ struct XcodeBuildSetting: Codable {
         let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore)..<stringKey.endIndex
 
         var components = stringKey[keyRange].split(separator: "_")
-        let joinedString : String
+        let joinedString: String
         if components.count == 1 {
             // No underscores in key, leave the word as is - maybe already camel cased
             joinedString = String(stringKey[keyRange])
@@ -79,13 +79,13 @@ struct XcodeBuildSetting: Codable {
         }
 
         // Do a cheap isEmpty check before creating and appending potentially empty strings
-        let result : String
-        if (leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty) {
+        let result: String
+        if leadingUnderscoreRange.isEmpty && trailingUnderscoreRange.isEmpty {
             result = joinedString
-        } else if (!leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty) {
+        } else if !leadingUnderscoreRange.isEmpty && !trailingUnderscoreRange.isEmpty {
             // Both leading and trailing underscores
             result = String(stringKey[leadingUnderscoreRange]) + joinedString + String(stringKey[trailingUnderscoreRange])
-        } else if (!leadingUnderscoreRange.isEmpty) {
+        } else if !leadingUnderscoreRange.isEmpty {
             // Just leading
             result = String(stringKey[leadingUnderscoreRange]) + joinedString
         } else {

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-4.2.json
@@ -1,0 +1,3806 @@
+[{
+  "Carthage\/Checkouts\/Result\/Result\/AnyError.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 1017,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct AnyError : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 132
+          }
+        ],
+        "key.bodylength" : 197,
+        "key.bodyoffset" : 169,
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A type-erased error which wraps an arbitrary error instance. This should be\nuseful for generic contexts.",
+        "key.doc.declaration" : "public struct AnyError : Swift.Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/AnyError.swift\" line=\"5\" column=\"15\"><Name>AnyError<\/Name><USR>s:6Result8AnyErrorV<\/USR><Declaration>public struct AnyError : Swift.Error<\/Declaration><CommentParts><Abstract><Para>A type-erased error which wraps an arbitrary error instance. This should be useful for generic contexts.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 5,
+        "key.doc.name" : "AnyError",
+        "key.doc.type" : "Class",
+        "key.doclength" : 113,
+        "key.docoffset" : 19,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 11,
+            "key.offset" : 156
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>AnyError<\/decl.name> : Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Swift.Error"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 228,
+        "key.name" : "AnyError",
+        "key.namelength" : 8,
+        "key.nameoffset" : 146,
+        "key.offset" : 139,
+        "key.parsed_declaration" : "public struct AnyError: Swift.Error",
+        "key.parsed_scope.end" : 16,
+        "key.parsed_scope.start" : 5,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let error: Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 198
+              }
+            ],
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The underlying error.",
+            "key.doc.declaration" : "public let error: Swift.Error",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/AnyError.swift\" line=\"7\" column=\"13\"><Name>error<\/Name><USR>s:6Result8AnyErrorV5errors0C0_pvp<\/USR><Declaration>public let error: Swift.Error<\/Declaration><CommentParts><Abstract><Para>The underlying error.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 7,
+            "key.doc.name" : "error",
+            "key.doc.type" : "Other",
+            "key.doclength" : 26,
+            "key.docoffset" : 171,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>error<\/decl.name>: <decl.var.type>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 22,
+            "key.name" : "error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 209,
+            "key.offset" : 205,
+            "key.parsed_declaration" : "public let error: Swift.Error",
+            "key.parsed_scope.end" : 7,
+            "key.parsed_scope.start" : 7,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Result8AnyErrorV5error4fromACs0C0_p_tFZ\">error(from:)<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "Error",
+            "key.typeusr" : "$Ss5Error_pD",
+            "key.usr" : "s:6Result8AnyErrorV5errors0C0_pvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ error: Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 230
+              }
+            ],
+            "key.bodylength" : 99,
+            "key.bodyoffset" : 265,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>error<\/decl.var.parameter.name>: <decl.var.parameter.type>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 128,
+            "key.name" : "init(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 237,
+            "key.offset" : 237,
+            "key.parsed_declaration" : "public init(_ error: Swift.Error)",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 9,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(AnyError.Type) -> (Error) -> AnyError",
+            "key.typeusr" : "$Sy6Result8AnyErrorVs0C0_pcD",
+            "key.usr" : "s:6Result8AnyErrorVyACs0C0_pcfc"
+          }
+        ],
+        "key.typename" : "AnyError.Type",
+        "key.typeusr" : "$S6Result8AnyErrorVmD",
+        "key.usr" : "s:6Result8AnyErrorV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct AnyError : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 88,
+        "key.bodyoffset" : 407,
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct AnyError : Swift.Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/AnyError.swift\" line=\"5\" column=\"15\"><Name>AnyError<\/Name><USR>s:6Result8AnyErrorV<\/USR><Declaration>public struct AnyError : Swift.Error<\/Declaration><CommentParts><Abstract><Para>A type-erased error which wraps an arbitrary error instance. This should be useful for generic contexts.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 5,
+        "key.doc.name" : "AnyError",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 389
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>AnyError<\/decl.name> : Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ErrorConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 127,
+        "key.name" : "AnyError",
+        "key.namelength" : 8,
+        "key.nameoffset" : 379,
+        "key.offset" : 369,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func error(from error: <Type usr=\"s:s5ErrorP\">Error<\/Type>) -&gt; <Type usr=\"s:6Result8AnyErrorV\">AnyError<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 409
+              }
+            ],
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 466,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>error<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>from<\/decl.var.parameter.argument_label> <decl.var.parameter.name>error<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:6Result8AnyErrorV\">AnyError<\/ref.struct><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 78,
+            "key.name" : "error(from:)",
+            "key.namelength" : 24,
+            "key.nameoffset" : 428,
+            "key.offset" : 416,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:6Result16ErrorConvertibleP5error4fromxs0B0_p_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func error(from error: Error) -> AnyError",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 19,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Result8AnyErrorV5errors0C0_pvp\">error<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(AnyError.Type) -> (Error) -> AnyError",
+            "key.typeusr" : "$S4from6Result8AnyErrorVs0D0_p_tcD",
+            "key.usr" : "s:6Result8AnyErrorV5error4fromACs0C0_p_tFZ"
+          }
+        ],
+        "key.typename" : "AnyError.Type",
+        "key.typeusr" : "$S6Result8AnyErrorVmD",
+        "key.usr" : "s:6Result8AnyErrorV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct AnyError : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 73,
+        "key.bodyoffset" : 543,
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct AnyError : Swift.Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/AnyError.swift\" line=\"5\" column=\"15\"><Name>AnyError<\/Name><USR>s:6Result8AnyErrorV<\/USR><Declaration>public struct AnyError : Swift.Error<\/Declaration><CommentParts><Abstract><Para>A type-erased error which wraps an arbitrary error instance. This should be useful for generic contexts.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 5,
+        "key.doc.name" : "AnyError",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 518
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>AnyError<\/decl.name> : Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 119,
+        "key.name" : "AnyError",
+        "key.namelength" : 8,
+        "key.nameoffset" : 508,
+        "key.offset" : 498,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 545
+              }
+            ],
+            "key.bodylength" : 37,
+            "key.bodyoffset" : 577,
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 63,
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 556,
+            "key.offset" : 552,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "AnyError.Type",
+        "key.typeusr" : "$S6Result8AnyErrorVmD",
+        "key.usr" : "s:6Result8AnyErrorV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct AnyError : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 360,
+        "key.bodyoffset" : 655,
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct AnyError : Swift.Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/AnyError.swift\" line=\"5\" column=\"15\"><Name>AnyError<\/Name><USR>s:6Result8AnyErrorV<\/USR><Declaration>public struct AnyError : Swift.Error<\/Declaration><CommentParts><Abstract><Para>A type-erased error which wraps an arbitrary error instance. This should be useful for generic contexts.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 5,
+        "key.doc.name" : "AnyError",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 14,
+            "key.offset" : 639
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>AnyError<\/decl.name> : Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "LocalizedError"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 397,
+        "key.name" : "AnyError",
+        "key.namelength" : 8,
+        "key.nameoffset" : 629,
+        "key.offset" : 619,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var errorDescription: <Type usr=\"s:SS\">String<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 657
+              }
+            ],
+            "key.bodylength" : 38,
+            "key.bodyoffset" : 695,
+            "key.doc.declaration" : "var errorDescription: String? { get }",
+            "key.doc.full_as_xml" : "<Other><Name>errorDescription<\/Name><USR>s:10Foundation14LocalizedErrorP16errorDescriptionSSSgvp<\/USR><Declaration>var errorDescription: String? { get }<\/Declaration><CommentParts><Abstract><Para>A localized message describing what error occurred.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.name" : "errorDescription",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>errorDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 70,
+            "key.name" : "errorDescription",
+            "key.namelength" : 16,
+            "key.nameoffset" : 668,
+            "key.offset" : 664,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Foundation14LocalizedErrorP16errorDescriptionSSSgvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var errorDescription: String?",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 31,
+            "key.typename" : "String?",
+            "key.typeusr" : "$SSSSgD",
+            "key.usr" : "s:10Foundation14LocalizedErrorP16errorDescriptionSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var failureReason: <Type usr=\"s:SS\">String<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 737
+              }
+            ],
+            "key.bodylength" : 53,
+            "key.bodyoffset" : 772,
+            "key.doc.declaration" : "var failureReason: String? { get }",
+            "key.doc.full_as_xml" : "<Other><Name>failureReason<\/Name><USR>s:10Foundation14LocalizedErrorP13failureReasonSSSgvp<\/USR><Declaration>var failureReason: String? { get }<\/Declaration><CommentParts><Abstract><Para>A localized message describing the reason for the failure.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.name" : "failureReason",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>failureReason<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 82,
+            "key.name" : "failureReason",
+            "key.namelength" : 13,
+            "key.nameoffset" : 748,
+            "key.offset" : 744,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Foundation14LocalizedErrorP13failureReasonSSSgvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var failureReason: String?",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 35,
+            "key.typename" : "String?",
+            "key.typeusr" : "$SSSSgD",
+            "key.usr" : "s:10Foundation14LocalizedErrorP13failureReasonSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var helpAnchor: <Type usr=\"s:SS\">String<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 829
+              }
+            ],
+            "key.bodylength" : 50,
+            "key.bodyoffset" : 861,
+            "key.doc.declaration" : "var helpAnchor: String? { get }",
+            "key.doc.full_as_xml" : "<Other><Name>helpAnchor<\/Name><USR>s:10Foundation14LocalizedErrorP10helpAnchorSSSgvp<\/USR><Declaration>var helpAnchor: String? { get }<\/Declaration><CommentParts><Abstract><Para>A localized message providing “help” text if the user requests help.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.name" : "helpAnchor",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>helpAnchor<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 76,
+            "key.name" : "helpAnchor",
+            "key.namelength" : 10,
+            "key.nameoffset" : 840,
+            "key.offset" : 836,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Foundation14LocalizedErrorP10helpAnchorSSSgvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var helpAnchor: String?",
+            "key.parsed_scope.end" : 41,
+            "key.parsed_scope.start" : 39,
+            "key.typename" : "String?",
+            "key.typeusr" : "$SSSSgD",
+            "key.usr" : "s:10Foundation14LocalizedErrorP10helpAnchorSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var recoverySuggestion: <Type usr=\"s:SS\">String<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 915
+              }
+            ],
+            "key.bodylength" : 58,
+            "key.bodyoffset" : 955,
+            "key.doc.declaration" : "var recoverySuggestion: String? { get }",
+            "key.doc.full_as_xml" : "<Other><Name>recoverySuggestion<\/Name><USR>s:10Foundation14LocalizedErrorP18recoverySuggestionSSSgvp<\/USR><Declaration>var recoverySuggestion: String? { get }<\/Declaration><CommentParts><Abstract><Para>A localized message describing how one might recover from the failure.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.name" : "recoverySuggestion",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/AnyError.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>recoverySuggestion<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 92,
+            "key.name" : "recoverySuggestion",
+            "key.namelength" : 18,
+            "key.nameoffset" : 926,
+            "key.offset" : 922,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Foundation14LocalizedErrorP18recoverySuggestionSSSgvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var recoverySuggestion: String?",
+            "key.parsed_scope.end" : 45,
+            "key.parsed_scope.start" : 43,
+            "key.typename" : "String?",
+            "key.typeusr" : "$SSSSgD",
+            "key.usr" : "s:10Foundation14LocalizedErrorP18recoverySuggestionSSSgvp"
+          }
+        ],
+        "key.typename" : "AnyError.Type",
+        "key.typeusr" : "$S6Result8AnyErrorVmD",
+        "key.usr" : "s:6Result8AnyErrorV"
+      }
+    ]
+  }
+}, {
+  "Carthage\/Checkouts\/Result\/Result\/NoError.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 398,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum NoError : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type>, <Type usr=\"s:SQ\">Equatable<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 272
+          }
+        ],
+        "key.bodylength" : 79,
+        "key.bodyoffset" : 317,
+        "key.doc.column" : 13,
+        "key.doc.comment" : "An “error” that is impossible to construct.\n\nThis can be used to describe `Result`s where failures will never\nbe generated. For example, `Result<Int, NoError>` describes a result that\ncontains an `Int`eger and is guaranteed never to be a `failure`.",
+        "key.doc.declaration" : "public enum NoError : Swift.Error, Equatable",
+        "key.doc.discussion" : [
+          {
+            "Para" : "This can be used to describe `Result`s where failures will never be generated. For example, `Result<Int, NoError>` describes a result that contains an `Int`eger and is guaranteed never to be a `failure`."
+          }
+        ],
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/NoError.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/NoError.swift\" line=\"6\" column=\"13\"><Name>NoError<\/Name><USR>s:6Result7NoErrorO<\/USR><Declaration>public enum NoError : Swift.Error, Equatable<\/Declaration><CommentParts><Abstract><Para>An “error” that is impossible to construct.<\/Para><\/Abstract><Discussion><Para>This can be used to describe <codeVoice>Result<\/codeVoice>s where failures will never be generated. For example, <codeVoice>Result&lt;Int, NoError&gt;<\/codeVoice> describes a result that contains an <codeVoice>Int<\/codeVoice>eger and is guaranteed never to be a <codeVoice>failure<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+        "key.doc.line" : 6,
+        "key.doc.name" : "NoError",
+        "key.doc.type" : "Other",
+        "key.doclength" : 272,
+        "key.docoffset" : 0,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 11,
+            "key.offset" : 293
+          },
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 306
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/NoError.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>NoError<\/decl.name> : Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol>, <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Swift.Error"
+          },
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 118,
+        "key.name" : "NoError",
+        "key.namelength" : 7,
+        "key.nameoffset" : 284,
+        "key.offset" : 279,
+        "key.parsed_declaration" : "public enum NoError: Swift.Error, Equatable",
+        "key.parsed_scope.end" : 10,
+        "key.parsed_scope.start" : 6,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func == (lhs: <Type usr=\"s:6Result7NoErrorO\">NoError<\/Type>, rhs: <Type usr=\"s:6Result7NoErrorO\">NoError<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 319
+              }
+            ],
+            "key.bodylength" : 16,
+            "key.bodyoffset" : 378,
+            "key.doc.declaration" : "static func == (lhs: Self, rhs: Self) -> Bool",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Equality is the inverse of inequality. For any values `a` and `b`, `a == b` implies that `a != b` is `false`."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Function><Name>==(_:_:)<\/Name><USR>s:SQ2eeoiySbx_xtFZ<\/USR><Declaration>static func == (lhs: Self, rhs: Self) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are equal.<\/Para><\/Abstract><Parameters><Parameter><Name>lhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A value to compare.<\/Para><\/Discussion><\/Parameter><Parameter><Name>rhs<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>Another value to compare.<\/Para><\/Discussion><\/Parameter><\/Parameters><Discussion><Para>Equality is the inverse of inequality. For any values <codeVoice>a<\/codeVoice> and <codeVoice>b<\/codeVoice>, <codeVoice>a == b<\/codeVoice> implies that <codeVoice>a != b<\/codeVoice> is <codeVoice>false<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.name" : "==(_:_:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "A value to compare."
+                  }
+                ],
+                "name" : "lhs"
+              },
+              {
+                "discussion" : [
+                  {
+                    "Para" : "Another value to compare."
+                  }
+                ],
+                "name" : "rhs"
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/NoError.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>== <\/decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6Result7NoErrorO\">NoError<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6Result7NoErrorO\">NoError<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 69,
+            "key.name" : "==(_:_:)",
+            "key.namelength" : 30,
+            "key.nameoffset" : 338,
+            "key.offset" : 326,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:SQ2eeoiySbx_xtFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func ==(lhs: NoError, rhs: NoError) -> Bool",
+            "key.parsed_scope.end" : 9,
+            "key.parsed_scope.start" : 7,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOAASQRzSQR_rlE2eeoiySbAByxq_G_ADtFZ\">== (_: Result&lt;Value, Error&gt;, _: Result&lt;Value, Error&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbypXpSg_ABtF\">== (_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_xtSYRzSQ8RawValueRpzlF\">== &lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbyt_yttF\">== (_: (), _: ()) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_t_x_q_ttSQRzSQR_r0_lF\">== &lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_t_x_q_q0_ttSQRzSQR_SQR0_r1_lF\">== &lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_t_x_q_q0_q1_ttSQRzSQR_SQR0_SQR1_r2_lF\">== &lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_q2_t_x_q_q0_q1_q2_ttSQRzSQR_SQR0_SQR1_SQR2_r3_lF\">== &lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_ttSQRzSQR_SQR0_SQR1_SQR2_SQR3_r4_lF\">== &lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s15ContiguousArrayVsSQRzlE2eeoiySbAByxG_ADtFZ\">== (_: ContiguousArray&lt;ContiguousArray&lt;Element&gt;.Element&gt;, _: ContiguousArray&lt;ContiguousArray&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10ArraySliceVsSQRzlE2eeoiySbAByxG_ADtFZ\">== (_: ArraySlice&lt;ArraySlice&lt;Element&gt;.Element&gt;, _: ArraySlice&lt;ArraySlice&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SasSQRzlE2eeoiySbSayxG_ABtFZ\">== (_: Array&lt;Array&lt;Element&gt;.Element&gt;, _: Array&lt;Array&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiyS2b_SbtFZ\">== (_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SA2eeoiySbSAyxG_ABtFZ\">== (_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SJ2eeoiySbSJ_SJtFZ\">== (_: Character, _: Character) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SJ17UnicodeScalarViewV5IndexV2eeoiySbAD_ADtFZ\">== (_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiySbAB_ABtFZ\">== (_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SNsSxRzSZ6StrideRpzrlE5IndexO2eeoiySbADyx_G_AFtFZ\">== (_: ClosedRange&lt;Bound&gt;.Index, _: ClosedRange&lt;Bound&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SN2eeoiySbSNyxG_ABtFZ\">== (_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiySbAB_ABtFZ\">== (_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SD4KeysV2eeoiySbAByxq__G_ADtFZ\">== (_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SDsSQR_rlE2eeoiySbSDyxq_G_ABtFZ\">== (_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SD5IndexV2eeoiySbAByxq__G_ADtFZ\">== (_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s23LazyDropWhileCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: LazyDropWhileCollection&lt;Base&gt;.Index, _: LazyDropWhileCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiySbAByxG_ADtFZ\">== (_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SQ2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17FlattenCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: FlattenCollection&lt;Base&gt;.Index, _: FlattenCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17FloatingPointSignO2eeoiySbAB_ABtFZ\">== (_: FloatingPointSign, _: FloatingPointSign) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SFsE2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiySbAB_ABtFZ\">== (_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SzsE2eeoiySbx_qd__tSzRd__lFZ\">== &lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiySbAB_ABtFZ\">== (_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiySbAB_ABtFZ\">== (_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiySbAB_ABtFZ\">== (_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiySbAB_ABtFZ\">== (_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiySbAB_ABtFZ\">== (_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiySbAB_ABtFZ\">== (_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiySbAB_ABtFZ\">== (_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiySbAB_ABtFZ\">== (_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiySbSu_SutFZ\">== (_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiySbSi_SitFZ\">== (_: Int, _: Int) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiySbAB_ABtFZ\">== (_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiySbAByxq_G_ADtFZ\">== (_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiySbAD_ADtFZ\">== (_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SO2eeoiySbSO_SOtFZ\">== (_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SqsSQRzlE2eeoiySbxSg_ABtFZ\">== (_: Wrapped?, _: Wrapped?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sq2eeoiySbxSg_s26_OptionalNilComparisonTypeVtFZ\">== (_: Wrapped?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sq2eeoiySbs26_OptionalNilComparisonTypeV_xSgtFZ\">== (_: _OptionalNilComparisonType, _: Wrapped?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s25LazyPrefixWhileCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: LazyPrefixWhileCollection&lt;Base&gt;.Index, _: LazyPrefixWhileCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sn2eeoiySbSnyxG_ABtFZ\">== (_: Range&lt;Range&lt;Bound&gt;.Bound&gt;, _: Range&lt;Range&lt;Bound&gt;.Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s18ReversedCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: ReversedCollection&lt;Base&gt;.Index, _: ReversedCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sh2eeoiySbShyxG_ABtFZ\">== (_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sh5IndexV2eeoiySbAByx_G_ADtFZ\">== (_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SxsE2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SysE2eeoiySbx_qd__tSyRd__lFZ\">== &lt;S&gt;(_: Self, _: S) -&gt; Bool where S : StringProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiySbSS_SStFZ\">== (_: String, _: String) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiySbAB_ABtFZ\">== (_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiySbADyxq__G_AFtFZ\">== (_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiySbSpyxG_ABtFZ\">== (_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiySbSPyxG_ABtFZ\">== (_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiySbSv_SvtFZ\">== (_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiySbSV_SVtFZ\">== (_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiySbAB_ABtFZ\">== (_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:So30_SwiftNSOperatingSystemVersionasE2eeoiySbAB_ABtFZ\">== (_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiySbAB_ABtFZ\">== (_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(NoError.Type) -> (NoError, NoError) -> Bool",
+            "key.typeusr" : "$SySb6Result7NoErrorO_ACtcD",
+            "key.usr" : "s:SQ2eeoiySbx_xtFZ"
+          }
+        ],
+        "key.typename" : "NoError.Type",
+        "key.typeusr" : "$S6Result7NoErrorOmD",
+        "key.usr" : "s:6Result7NoErrorO"
+      }
+    ]
+  }
+}, {
+  "Carthage\/Checkouts\/Result\/Result\/Result.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 6115,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 157
+          }
+        ],
+        "key.bodylength" : 3014,
+        "key.bodyoffset" : 275,
+        "key.doc.column" : 13,
+        "key.doc.comment" : "An enum representing either a failure with an explanatory error, or a success with a result value.",
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.doclength" : 103,
+        "key.docoffset" : 54,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 14,
+            "key.offset" : 204
+          },
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 220
+          },
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 28,
+            "key.offset" : 245
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ResultProtocol"
+          },
+          {
+            "key.name" : "CustomStringConvertible"
+          },
+          {
+            "key.name" : "CustomDebugStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 3126,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 169,
+        "key.offset" : 164,
+        "key.parsed_declaration" : "public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible",
+        "key.parsed_scope.end" : 116,
+        "key.parsed_scope.start" : 4,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>Value<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 5,
+            "key.name" : "Value",
+            "key.namelength" : 5,
+            "key.nameoffset" : 176,
+            "key.offset" : 176,
+            "key.parsed_declaration" : "public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible",
+            "key.parsed_scope.end" : 4,
+            "key.parsed_scope.start" : 4,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5Valuea\">Value<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "Value.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6ResultAAO5Valuexmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>Error : Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 11,
+                "key.offset" : 190
+              }
+            ],
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Error<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Swift.Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.name" : "Error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 183,
+            "key.offset" : 183,
+            "key.parsed_declaration" : "public enum Result<Value, Error: Swift.Error>: ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible",
+            "key.parsed_scope.end" : 4,
+            "key.parsed_scope.start" : 4,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5Errora\">Error<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "Error.Type",
+            "key.typeusr" : "$Sq_mD",
+            "key.usr" : "s:6ResultAAO5Errorq_mfp"
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 19,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 277,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case success(<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>success<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 14,
+                "key.name" : "success(_:)",
+                "key.namelength" : 14,
+                "key.nameoffset" : 282,
+                "key.offset" : 282,
+                "key.parsed_declaration" : "case success(Value)",
+                "key.parsed_scope.end" : 5,
+                "key.parsed_scope.start" : 5,
+                "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Value) -> Result<Value, Error>",
+                "key.typeusr" : "$Sy6ResultAAOyxq_GxcACmcs5ErrorR_r0_luD",
+                "key.usr" : "s:6ResultAAO7successyAByxq_GxcADms5ErrorR_r0_lF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 19,
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 298,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case failure(<Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>)<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>failure<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 14,
+                "key.name" : "failure(_:)",
+                "key.namelength" : 14,
+                "key.nameoffset" : 303,
+                "key.offset" : 303,
+                "key.parsed_declaration" : "case failure(Error)",
+                "key.parsed_scope.end" : 6,
+                "key.parsed_scope.start" : 6,
+                "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Error) -> Result<Value, Error>",
+                "key.typeusr" : "$Sy6ResultAAOyxq_Gq_cACmcs5ErrorR_r0_luD",
+                "key.usr" : "s:6ResultAAO7failureyAByxq_Gq_cADms5ErrorR_r0_lF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 18,
+            "key.name" : "MARK: Constructors",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 323
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(value: <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 390
+              }
+            ],
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 417,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a success wrapping a `value`.",
+            "key.doc.declaration" : "public init(value: Value)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"11\" column=\"9\"><Name>init(value:)<\/Name><USR>s:6ResultAAO5valueAByxq_Gx_tcfc<\/USR><Declaration>public init(value: Value)<\/Declaration><CommentParts><Abstract><Para>Constructs a success wrapping a <codeVoice>value<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 11,
+            "key.doc.name" : "init(value:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 45,
+            "key.docoffset" : 344,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>value<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 48,
+            "key.name" : "init(value:)",
+            "key.namelength" : 18,
+            "key.nameoffset" : 397,
+            "key.offset" : 397,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:6Result0A8ProtocolP5valuex5ValueQz_tcfc"
+              }
+            ],
+            "key.parsed_declaration" : "public init(value: Value)",
+            "key.parsed_scope.end" : 13,
+            "key.parsed_scope.start" : 11,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Value) -> Result<Value, Error>",
+            "key.typeusr" : "$S5value6ResultABOyxq_Gx_tcD",
+            "key.usr" : "s:6ResultAAO5valueAByxq_Gx_tcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(error: <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 495
+              }
+            ],
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 522,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a failure wrapping an `error`.",
+            "key.doc.declaration" : "public init(error: Error)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"16\" column=\"9\"><Name>init(error:)<\/Name><USR>s:6ResultAAO5errorAByxq_Gq__tcfc<\/USR><Declaration>public init(error: Error)<\/Declaration><CommentParts><Abstract><Para>Constructs a failure wrapping an <codeVoice>error<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 16,
+            "key.doc.name" : "init(error:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 46,
+            "key.docoffset" : 448,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>error<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 48,
+            "key.name" : "init(error:)",
+            "key.namelength" : 18,
+            "key.nameoffset" : 502,
+            "key.offset" : 502,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:6Result0A8ProtocolP5errorx5ErrorQz_tcfc"
+              }
+            ],
+            "key.parsed_declaration" : "public init(error: Error)",
+            "key.parsed_scope.end" : 18,
+            "key.parsed_scope.start" : 16,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Error) -> Result<Value, Error>",
+            "key.typeusr" : "$S5error6ResultABOyxq_Gq__tcD",
+            "key.usr" : "s:6ResultAAO5errorAByxq_Gq__tcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ value: <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>?, failWith: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 629
+              }
+            ],
+            "key.bodylength" : 61,
+            "key.bodyoffset" : 695,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a result from an `Optional`, failing with `Error` if `nil`.",
+            "key.doc.declaration" : "public init(_ value: Value?, failWith: @autoclosure () -> Error)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"21\" column=\"9\"><Name>init(_:failWith:)<\/Name><USR>s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc<\/USR><Declaration>public init(_ value: Value?, failWith: @autoclosure () -&gt; Error)<\/Declaration><CommentParts><Abstract><Para>Constructs a result from an <codeVoice>Optional<\/codeVoice>, failing with <codeVoice>Error<\/codeVoice> if <codeVoice>nil<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 21,
+            "key.doc.name" : "init(_:failWith:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 75,
+            "key.docoffset" : 553,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>?<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>failWith<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 121,
+            "key.name" : "init(_:failWith:)",
+            "key.namelength" : 57,
+            "key.nameoffset" : 636,
+            "key.offset" : 636,
+            "key.parsed_declaration" : "public init(_ value: Value?, failWith: @autoclosure () -> Error)",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 21,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Value?, @autoclosure () -> Error) -> Result<Value, Error>",
+            "key.typeusr" : "$S_8failWith6ResultABOyxq_GxSg_q_yXKtcD",
+            "key.usr" : "s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ f: @autoclosure () throws -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 852
+              }
+            ],
+            "key.bodylength" : 26,
+            "key.bodyoffset" : 903,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a result from a function that uses `throw`, failing with `Error` if throws.",
+            "key.doc.declaration" : "public init(_ f: @autoclosure () throws -> Value)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"26\" column=\"9\"><Name>init(_:)<\/Name><USR>s:6ResultAAOyAByxq_GxyKXKcfc<\/USR><Declaration>public init(_ f: @autoclosure () throws -&gt; Value)<\/Declaration><CommentParts><Abstract><Para>Constructs a result from a function that uses <codeVoice>throw<\/codeVoice>, failing with <codeVoice>Error<\/codeVoice> if throws.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 26,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 91,
+            "key.docoffset" : 760,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 71,
+            "key.name" : "init(_:)",
+            "key.namelength" : 42,
+            "key.nameoffset" : 859,
+            "key.offset" : 859,
+            "key.parsed_declaration" : "public init(_ f: @autoclosure () throws -> Value)",
+            "key.parsed_scope.end" : 28,
+            "key.parsed_scope.start" : 26,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (@autoclosure () throws -> Value) -> Result<Value, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyxq_GxyKXKcD",
+            "key.usr" : "s:6ResultAAOyAByxq_GxyKXKcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(attempt f: () throws -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1025
+              }
+            ],
+            "key.bodylength" : 168,
+            "key.bodyoffset" : 1069,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a result from a function that uses `throw`, failing with `Error` if throws.",
+            "key.doc.declaration" : "public init(attempt f: () throws -> Value)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"31\" column=\"9\"><Name>init(attempt:)<\/Name><USR>s:6ResultAAO7attemptAByxq_GxyKXE_tcfc<\/USR><Declaration>public init(attempt f: () throws -&gt; Value)<\/Declaration><CommentParts><Abstract><Para>Constructs a result from a function that uses <codeVoice>throw<\/codeVoice>, failing with <codeVoice>Error<\/codeVoice> if throws.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 31,
+            "key.doc.name" : "init(attempt:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 91,
+            "key.docoffset" : 933,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>attempt<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>() <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 206,
+            "key.name" : "init(attempt:)",
+            "key.namelength" : 35,
+            "key.nameoffset" : 1032,
+            "key.offset" : 1032,
+            "key.parsed_declaration" : "public init(attempt f: () throws -> Value)",
+            "key.parsed_scope.end" : 40,
+            "key.parsed_scope.start" : 31,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>var error: <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>error<\/decl.name>: <decl.var.type><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 5,
+                "key.name" : "error",
+                "key.namelength" : 5,
+                "key.nameoffset" : 1119,
+                "key.offset" : 1119,
+                "key.parsed_declaration" : "} catch var error",
+                "key.parsed_scope.end" : 34,
+                "key.parsed_scope.start" : 34,
+                "key.related_decls" : [
+                  {
+                    "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5error_8function4file4lineSo7NSErrorCSSSg_S2SSitFZ\">error(_:function:file:line:)<\/RelatedName>"
+                  },
+                  {
+                    "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorq_Sgvp\">error<\/RelatedName>"
+                  }
+                ],
+                "key.typename" : "Error",
+                "key.typeusr" : "$Ss5Error_pD",
+                "key.usr" : "s:6ResultAAO7attemptAByxq_GxyKXE_tcfc5errorL_s5Error_pvp"
+              }
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (() throws -> Value) -> Result<Value, Error>",
+            "key.typeusr" : "$S7attempt6ResultABOyxq_GxyKXE_tcD",
+            "key.usr" : "s:6ResultAAO7attemptAByxq_GxyKXE_tcfc"
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 20,
+            "key.name" : "MARK: Deconstruction",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 1244
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func dematerialize() throws -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1336
+              }
+            ],
+            "key.bodylength" : 109,
+            "key.bodyoffset" : 1381,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns the value from `success` Results or `throw`s the error.",
+            "key.doc.declaration" : "public func dematerialize() throws -> Value",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"45\" column=\"14\"><Name>dematerialize()<\/Name><USR>s:6ResultAAO13dematerializexyKF<\/USR><Declaration>public func dematerialize() throws -&gt; Value<\/Declaration><CommentParts><Abstract><Para>Returns the value from <codeVoice>success<\/codeVoice> Results or <codeVoice>throw<\/codeVoice>s the error.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 45,
+            "key.doc.name" : "dematerialize()",
+            "key.doc.type" : "Function",
+            "key.doclength" : 68,
+            "key.docoffset" : 1267,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>dematerialize<\/decl.name>() <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 148,
+            "key.name" : "dematerialize()",
+            "key.namelength" : 15,
+            "key.nameoffset" : 1348,
+            "key.offset" : 1343,
+            "key.parsed_declaration" : "public func dematerialize() throws -> Value",
+            "key.parsed_scope.end" : 52,
+            "key.parsed_scope.start" : 45,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>) -> () throws -> Value",
+            "key.typeusr" : "$SxyKcD",
+            "key.usr" : "s:6ResultAAO13dematerializexyKF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func analysis&lt;Result&gt;(ifSuccess: (<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/Type>, ifFailure: (<Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>) -&gt; <Type usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/Type>) -&gt; <Type usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1645
+              }
+            ],
+            "key.bodylength" : 132,
+            "key.bodyoffset" : 1745,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Case analysis for Result.\n\nReturns the value produced by applying `ifFailure` to `failure` Results, or `ifSuccess` to `success` Results.",
+            "key.doc.declaration" : "public func analysis<Result>(ifSuccess: (Value) -> Result, ifFailure: (Error) -> Result) -> Result",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the value produced by applying `ifFailure` to `failure` Results, or `ifSuccess` to `success` Results."
+              }
+            ],
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"57\" column=\"14\"><Name>analysis(ifSuccess:ifFailure:)<\/Name><USR>s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlF<\/USR><Declaration>public func analysis&lt;Result&gt;(ifSuccess: (Value) -&gt; Result, ifFailure: (Error) -&gt; Result) -&gt; Result<\/Declaration><CommentParts><Abstract><Para>Case analysis for Result.<\/Para><\/Abstract><Discussion><Para>Returns the value produced by applying <codeVoice>ifFailure<\/codeVoice> to <codeVoice>failure<\/codeVoice> Results, or <codeVoice>ifSuccess<\/codeVoice> to <codeVoice>success<\/codeVoice> Results.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 57,
+            "key.doc.name" : "analysis(ifSuccess:ifFailure:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 150,
+            "key.docoffset" : 1494,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>analysis<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\"><decl.generic_type_param.name>Result<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>ifSuccess<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>ifFailure<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp\">Result<\/ref.generic_type_param><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 226,
+            "key.name" : "analysis(ifSuccess:ifFailure:)",
+            "key.namelength" : 76,
+            "key.nameoffset" : 1657,
+            "key.offset" : 1652,
+            "key.parsed_declaration" : "public func analysis<Result>(ifSuccess: (Value) -> Result, ifFailure: (Error) -> Result) -> Result",
+            "key.parsed_scope.end" : 64,
+            "key.parsed_scope.start" : 57,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>Result<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Result<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 6,
+                "key.name" : "Result",
+                "key.namelength" : 6,
+                "key.nameoffset" : 1666,
+                "key.offset" : 1666,
+                "key.parsed_declaration" : "public func analysis<Result>(ifSuccess: (Value) -> Result, ifFailure: (Error) -> Result) -> Result",
+                "key.parsed_scope.end" : 57,
+                "key.parsed_scope.start" : 57,
+                "key.typename" : "Result.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlFAAL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, Result where Error : Error> (Result<Value, Error>) -> ((Value) -> Result, (Error) -> Result) -> Result",
+            "key.typeusr" : "$S9ifSuccess0A7Failureqd__qd__xXE_qd__q_XEtcluD",
+            "key.usr" : "s:6ResultAAO8analysis9ifSuccess0C7Failureqd__qd__xXE_qd__q_XEtlF"
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 12,
+            "key.name" : "MARK: Errors",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 1884
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static var errorDomain: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1949
+              }
+            ],
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 1988,
+            "key.doc.column" : 20,
+            "key.doc.comment" : "The domain for errors constructed by Result.",
+            "key.doc.declaration" : "public static var errorDomain: String { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"69\" column=\"20\"><Name>errorDomain<\/Name><USR>s:6ResultAAO11errorDomainSSvpZ<\/USR><Declaration>public static var errorDomain: String { get }<\/Declaration><CommentParts><Abstract><Para>The domain for errors constructed by Result.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 69,
+            "key.doc.name" : "errorDomain",
+            "key.doc.type" : "Other",
+            "key.doclength" : 49,
+            "key.docoffset" : 1899,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>errorDomain<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 66,
+            "key.name" : "errorDomain",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1967,
+            "key.offset" : 1956,
+            "key.parsed_declaration" : "public static var errorDomain: String",
+            "key.parsed_scope.end" : 69,
+            "key.parsed_scope.start" : 69,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:6ResultAAO11errorDomainSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static var functionKey: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2101
+              }
+            ],
+            "key.bodylength" : 34,
+            "key.bodyoffset" : 2140,
+            "key.doc.column" : 20,
+            "key.doc.comment" : "The userInfo key for source functions in errors constructed by Result.",
+            "key.doc.declaration" : "public static var functionKey: String { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"72\" column=\"20\"><Name>functionKey<\/Name><USR>s:6ResultAAO11functionKeySSvpZ<\/USR><Declaration>public static var functionKey: String { get }<\/Declaration><CommentParts><Abstract><Para>The userInfo key for source functions in errors constructed by Result.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 72,
+            "key.doc.name" : "functionKey",
+            "key.doc.type" : "Other",
+            "key.doclength" : 75,
+            "key.docoffset" : 2025,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>functionKey<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 67,
+            "key.name" : "functionKey",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2119,
+            "key.offset" : 2108,
+            "key.parsed_declaration" : "public static var functionKey: String",
+            "key.parsed_scope.end" : 72,
+            "key.parsed_scope.start" : 72,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:6ResultAAO11functionKeySSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static var fileKey: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2255
+              }
+            ],
+            "key.bodylength" : 30,
+            "key.bodyoffset" : 2290,
+            "key.doc.column" : 20,
+            "key.doc.comment" : "The userInfo key for source file paths in errors constructed by Result.",
+            "key.doc.declaration" : "public static var fileKey: String { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"75\" column=\"20\"><Name>fileKey<\/Name><USR>s:6ResultAAO7fileKeySSvpZ<\/USR><Declaration>public static var fileKey: String { get }<\/Declaration><CommentParts><Abstract><Para>The userInfo key for source file paths in errors constructed by Result.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 75,
+            "key.doc.name" : "fileKey",
+            "key.doc.type" : "Other",
+            "key.doclength" : 76,
+            "key.docoffset" : 2178,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>fileKey<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 59,
+            "key.name" : "fileKey",
+            "key.namelength" : 7,
+            "key.nameoffset" : 2273,
+            "key.offset" : 2262,
+            "key.parsed_declaration" : "public static var fileKey: String",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 75,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:6ResultAAO7fileKeySSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static var lineKey: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2408
+              }
+            ],
+            "key.bodylength" : 30,
+            "key.bodyoffset" : 2443,
+            "key.doc.column" : 20,
+            "key.doc.comment" : "The userInfo key for source file line numbers in errors constructed by Result.",
+            "key.doc.declaration" : "public static var lineKey: String { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"78\" column=\"20\"><Name>lineKey<\/Name><USR>s:6ResultAAO7lineKeySSvpZ<\/USR><Declaration>public static var lineKey: String { get }<\/Declaration><CommentParts><Abstract><Para>The userInfo key for source file line numbers in errors constructed by Result.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 78,
+            "key.doc.name" : "lineKey",
+            "key.doc.type" : "Other",
+            "key.doclength" : 83,
+            "key.docoffset" : 2324,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>lineKey<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 59,
+            "key.name" : "lineKey",
+            "key.namelength" : 7,
+            "key.nameoffset" : 2426,
+            "key.offset" : 2415,
+            "key.parsed_declaration" : "public static var lineKey: String",
+            "key.parsed_scope.end" : 78,
+            "key.parsed_scope.start" : 78,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:6ResultAAO7lineKeySSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func error(_ message: <Type usr=\"s:SS\">String<\/Type>? = default, function: <Type usr=\"s:SS\">String<\/Type> = #function, file: <Type usr=\"s:SS\">String<\/Type> = #file, line: <Type usr=\"s:Si\">Int<\/Type> = #line) -&gt; <Type usr=\"c:objc(cs)NSError\">NSError<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2503
+              }
+            ],
+            "key.bodylength" : 253,
+            "key.bodyoffset" : 2637,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Constructs an error.",
+            "key.doc.declaration" : "public static func error(_ message: String? = default, function: String = #function, file: String = #file, line: Int = #line) -> NSError",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"81\" column=\"21\"><Name>error(_:function:file:line:)<\/Name><USR>s:6ResultAAO5error_8function4file4lineSo7NSErrorCSSSg_S2SSitFZ<\/USR><Declaration>public static func error(_ message: String? = default, function: String = #function, file: String = #file, line: Int = #line) -&gt; NSError<\/Declaration><CommentParts><Abstract><Para>Constructs an error.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 81,
+            "key.doc.name" : "error(_:function:file:line:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 25,
+            "key.docoffset" : 2477,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>error<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>message<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type> = <syntaxtype.keyword>default<\/syntaxtype.keyword><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>function<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type> = <syntaxtype.keyword>#function<\/syntaxtype.keyword><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>file<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type> = <syntaxtype.keyword>#file<\/syntaxtype.keyword><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>line<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type> = <syntaxtype.keyword>#line<\/syntaxtype.keyword><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)NSError\">NSError<\/ref.class><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 381,
+            "key.name" : "error(_:function:file:line:)",
+            "key.namelength" : 102,
+            "key.nameoffset" : 2522,
+            "key.offset" : 2510,
+            "key.parsed_declaration" : "public static func error(_ message: String? = nil, function: String = #function, file: String = #file, line: Int = #line) -> NSError",
+            "key.parsed_scope.end" : 93,
+            "key.parsed_scope.start" : 81,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorq_Sgvp\">error<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>var userInfo: [<Type usr=\"s:SS\">String<\/Type> : Any]<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>userInfo<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct> : Any]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 97,
+                "key.name" : "userInfo",
+                "key.namelength" : 8,
+                "key.nameoffset" : 2644,
+                "key.offset" : 2640,
+                "key.parsed_declaration" : "var userInfo: [String: Any] = [",
+                "key.parsed_scope.end" : 82,
+                "key.parsed_scope.start" : 82,
+                "key.typename" : "[String : Any]",
+                "key.typeusr" : "$SSDySSypGD",
+                "key.usr" : "s:6ResultAAO5error_8function4file4lineSo7NSErrorCSSSg_S2SSitFZ8userInfoL_SDySSypGvp"
+              }
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (String?, String, String, Int) -> NSError",
+            "key.typeusr" : "$S_8function4file4lineSo7NSErrorCSSSg_S2SSitcD",
+            "key.usr" : "s:6ResultAAO5error_8function4file4lineSo7NSErrorCSSSg_S2SSitFZ"
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 29,
+            "key.name" : "MARK: CustomStringConvertible",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 2898
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2930
+              }
+            ],
+            "key.bodylength" : 134,
+            "key.bodyoffset" : 2962,
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 160,
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2941,
+            "key.offset" : 2937,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 103,
+            "key.parsed_scope.start" : 98,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 34,
+            "key.name" : "MARK: CustomDebugStringConvertible",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 3104
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var debugDescription: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3141
+              }
+            ],
+            "key.bodylength" : 23,
+            "key.bodyoffset" : 3178,
+            "key.doc.declaration" : "var debugDescription: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(reflecting:)` initializer. This initializer works with any type, and uses the custom `debugDescription` property for types that conform to `CustomDebugStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `debugDescription` property."
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>debugDescription<\/Name><USR>s:s28CustomDebugStringConvertibleP16debugDescriptionSSvp<\/USR><Declaration>var debugDescription: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance, suitable for debugging.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(reflecting:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>debugDescription<\/codeVoice> property for types that conform to <codeVoice>CustomDebugStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomDebugStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var debugDescription: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(reflecting: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>debugDescription<\/codeVoice> property.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "debugDescription",
+            "key.doc.type" : "Other",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>debugDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 54,
+            "key.name" : "debugDescription",
+            "key.namelength" : 16,
+            "key.nameoffset" : 3152,
+            "key.offset" : 3148,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s28CustomDebugStringConvertibleP16debugDescriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var debugDescription: String",
+            "key.parsed_scope.end" : 110,
+            "key.parsed_scope.start" : 108,
+            "key.typename" : "String",
+            "key.typeusr" : "$SSSD",
+            "key.usr" : "s:s28CustomDebugStringConvertibleP16debugDescriptionSSvp"
+          },
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 20,
+            "key.name" : "MARK: ResultProtocol",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 3208
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var result: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt; { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3230
+              }
+            ],
+            "key.bodylength" : 16,
+            "key.bodyoffset" : 3271,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>result<\/decl.name>: <decl.var.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 51,
+            "key.name" : "result",
+            "key.namelength" : 6,
+            "key.nameoffset" : 3241,
+            "key.offset" : 3237,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:6Result0A8ProtocolP6resultA2AOy5ValueQz5ErrorQzGvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var result: Result<Value, Error>",
+            "key.parsed_scope.end" : 115,
+            "key.parsed_scope.start" : 113,
+            "key.typename" : "Result<Value, Error>",
+            "key.typeusr" : "$S6ResultAAOyxq_GD",
+            "key.usr" : "s:6ResultAAO6resultAByxq_Gvp"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 410,
+        "key.bodyoffset" : 3334,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 453,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 3302,
+        "key.offset" : 3292,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ f: @autoclosure () throws -&gt; <Type usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3434
+              }
+            ],
+            "key.bodylength" : 26,
+            "key.bodyoffset" : 3485,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a result from an expression that uses `throw`, failing with `AnyError` if throws.",
+            "key.doc.declaration" : "public init(_ f: @autoclosure () throws -> Value)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"120\" column=\"9\"><Name>init(_:)<\/Name><USR>s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc<\/USR><Declaration>public init(_ f: @autoclosure () throws -&gt; Value)<\/Declaration><CommentParts><Abstract><Para>Constructs a result from an expression that uses <codeVoice>throw<\/codeVoice>, failing with <codeVoice>AnyError<\/codeVoice> if throws.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 120,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 97,
+            "key.docoffset" : 3336,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 71,
+            "key.name" : "init(_:)",
+            "key.namelength" : 42,
+            "key.nameoffset" : 3441,
+            "key.offset" : 3441,
+            "key.parsed_declaration" : "public init(_ f: @autoclosure () throws -> Value)",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 120,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error == AnyError> (Result<Value, Error>.Type) -> (@autoclosure () throws -> Value) -> Result<Value, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyxAA8AnyErrorVGxyKXKcD",
+            "key.usr" : "s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(attempt f: () throws -&gt; <Type usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE5Valuexmfp\">Value<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3609
+              }
+            ],
+            "key.bodylength" : 89,
+            "key.bodyoffset" : 3653,
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Constructs a result from a closure that uses `throw`, failing with `AnyError` if throws.",
+            "key.doc.declaration" : "public init(attempt f: () throws -> Value)",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"125\" column=\"9\"><Name>init(attempt:)<\/Name><USR>s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc<\/USR><Declaration>public init(attempt f: () throws -&gt; Value)<\/Declaration><CommentParts><Abstract><Para>Constructs a result from a closure that uses <codeVoice>throw<\/codeVoice>, failing with <codeVoice>AnyError<\/codeVoice> if throws.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 125,
+            "key.doc.name" : "init(attempt:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 93,
+            "key.docoffset" : 3515,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>attempt<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>() <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlE5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 127,
+            "key.name" : "init(attempt:)",
+            "key.namelength" : 35,
+            "key.nameoffset" : 3616,
+            "key.offset" : 3616,
+            "key.parsed_declaration" : "public init(attempt f: () throws -> Value)",
+            "key.parsed_scope.end" : 131,
+            "key.parsed_scope.start" : 125,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5valueAByxq_Gx_tcfc\">init(value:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5errorAByxq_Gq__tcfc\">init(error:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO_8failWithAByxq_GxSg_q_yXKtcfc\">init(_:failWith:)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOyAByxq_GxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7attemptAByxq_GxyKXE_tcfc\">init(attempt: () throws -&gt; Value)<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAOA2A8AnyErrorVRs_rlEyAByxADGxyKXKcfc\">init(_: @autoclosure () throws -&gt; Value)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error == AnyError> (Result<Value, Error>.Type) -> (() throws -> Value) -> Result<Value, Error>",
+            "key.typeusr" : "$S7attempt6ResultABOyxAB8AnyErrorVGxyKXE_tcD",
+            "key.usr" : "s:6ResultAAOA2A8AnyErrorVRs_rlE7attemptAByxADGxyKXE_tcfc"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 43,
+        "key.name" : "MARK: - Derive result from failable closure",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 3750
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func materialize&lt;T&gt;(_ f: () throws -&gt; <Type usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp\">T<\/Type>, <Type usr=\"s:6Result8AnyErrorV\">AnyError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 3855
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 59,
+            "key.offset" : 3795
+          }
+        ],
+        "key.bodylength" : 28,
+        "key.bodyoffset" : 3927,
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>materialize<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>() <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.struct usr=\"s:6Result8AnyErrorV\">AnyError<\/ref.struct>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 94,
+        "key.name" : "materialize(_:)",
+        "key.namelength" : 35,
+        "key.nameoffset" : 3867,
+        "key.offset" : 3862,
+        "key.parsed_declaration" : "public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError>",
+        "key.parsed_scope.end" : 139,
+        "key.parsed_scope.start" : 137,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF\">materialize&lt;T&gt;(_: @autoclosure () throws -&gt; T) -&gt; Result&lt;T, AnyError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 3879,
+            "key.offset" : 3879,
+            "key.parsed_declaration" : "public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError>",
+            "key.parsed_scope.end" : 137,
+            "key.parsed_scope.start" : 137,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "<T> (() throws -> T) -> Result<T, AnyError>",
+        "key.typeusr" : "$Sy6ResultAAOyxAA8AnyErrorVGxyKXEcluD",
+        "key.usr" : "s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func materialize&lt;T&gt;(_ f: @autoclosure () throws -&gt; <Type usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp\">T<\/Type>, <Type usr=\"s:6Result8AnyErrorV\">AnyError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4012
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 53,
+            "key.offset" : 3958
+          }
+        ],
+        "key.bodylength" : 19,
+        "key.bodyoffset" : 4097,
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>materialize<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.struct usr=\"s:6Result8AnyErrorV\">AnyError<\/ref.struct>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 98,
+        "key.name" : "materialize(_:)",
+        "key.namelength" : 48,
+        "key.nameoffset" : 4024,
+        "key.offset" : 4019,
+        "key.parsed_declaration" : "public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError>",
+        "key.parsed_scope.end" : 144,
+        "key.parsed_scope.start" : 142,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXElF\">materialize&lt;T&gt;(_: () throws -&gt; T) -&gt; Result&lt;T, AnyError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4036,
+            "key.offset" : 4036,
+            "key.parsed_declaration" : "public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError>",
+            "key.parsed_scope.end" : 142,
+            "key.parsed_scope.start" : 142,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "<T> (@autoclosure () throws -> T) -> Result<T, AnyError>",
+        "key.typeusr" : "$Sy6ResultAAOyxAA8AnyErrorVGxyKXKcluD",
+        "key.usr" : "s:6Result11materializeyA2AOyxAA8AnyErrorVGxyKXKlF"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 36,
+        "key.name" : "MARK: - ErrorConvertible conformance",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 4122
+      },
+      {
+        "key.annotated_decl" : "<Declaration>class NSError : <Type usr=\"c:objc(cs)NSObject\">NSObject<\/Type>, <Type usr=\"c:objc(pl)NSCopying\">NSCopying<\/Type>, <Type usr=\"c:objc(pl)NSSecureCoding\">NSSecureCoding<\/Type><\/Declaration>",
+        "key.bodylength" : 166,
+        "key.bodyoffset" : 4198,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 4180
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>NSError<\/decl.name> : <ref.class usr=\"c:objc(cs)NSObject\">NSObject<\/ref.class>, <ref.protocol usr=\"c:objc(pl)NSCopying\">NSCopying<\/ref.protocol>, <ref.protocol usr=\"c:objc(pl)NSSecureCoding\">NSSecureCoding<\/ref.protocol><\/decl.class>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ErrorConvertible"
+          }
+        ],
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 204,
+        "key.modulename" : "Foundation.NSError",
+        "key.name" : "NSError",
+        "key.namelength" : 7,
+        "key.nameoffset" : 4171,
+        "key.offset" : 4161,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func error(from error: Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type>) -&gt; <Type usr=\"c:objc(cs)NSError\">Self<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 4200
+              }
+            ],
+            "key.bodylength" : 103,
+            "key.bodyoffset" : 4259,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>error<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>from<\/decl.var.parameter.argument_label> <decl.var.parameter.name>error<\/decl.var.parameter.name>: <decl.var.parameter.type>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)NSError\">Self<\/ref.class><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 156,
+            "key.name" : "error(from:)",
+            "key.namelength" : 30,
+            "key.nameoffset" : 4219,
+            "key.offset" : 4207,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:6Result16ErrorConvertibleP5error4fromxs0B0_p_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func error(from error: Swift.Error) -> Self",
+            "key.parsed_scope.end" : 155,
+            "key.parsed_scope.start" : 149,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>func cast&lt;T&gt;(_ error: Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type>) -&gt; <Type usr=\"s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ4castL_yxsAF_pABRbzlF1TL_xmfp\">T<\/Type> where T : <Type usr=\"c:objc(cs)NSError\">NSError<\/Type><\/Declaration>",
+                "key.bodylength" : 25,
+                "key.bodyoffset" : 4312,
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>cast<\/decl.name>&lt;<decl.generic_type_param usr=\"s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ4castL_yxsAF_pABRbzlF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>error<\/decl.var.parameter.name>: <decl.var.parameter.type>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ4castL_yxsAF_pABRbzlF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.class usr=\"c:objc(cs)NSError\">NSError<\/ref.class><\/decl.generic_type_requirement><\/decl.function.free>",
+                "key.kind" : "source.lang.swift.decl.function.free",
+                "key.length" : 76,
+                "key.name" : "cast(_:)",
+                "key.namelength" : 38,
+                "key.nameoffset" : 4267,
+                "key.offset" : 4262,
+                "key.parsed_declaration" : "func cast<T: NSError>(_ error: Swift.Error) -> T",
+                "key.parsed_scope.end" : 152,
+                "key.parsed_scope.start" : 150,
+                "key.substructure" : [
+                  {
+                    "key.annotated_decl" : "<Declaration>T : <Type usr=\"c:objc(cs)NSError\">NSError<\/Type><\/Declaration>",
+                    "key.elements" : [
+                      {
+                        "key.kind" : "source.lang.swift.structure.elem.typeref",
+                        "key.length" : 7,
+                        "key.offset" : 4275
+                      }
+                    ],
+                    "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+                    "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.class usr=\"c:objc(cs)NSError\">NSError<\/ref.class><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                    "key.inheritedtypes" : [
+                      {
+                        "key.name" : "NSError"
+                      }
+                    ],
+                    "key.kind" : "source.lang.swift.decl.generic_type_param",
+                    "key.length" : 10,
+                    "key.name" : "T",
+                    "key.namelength" : 1,
+                    "key.nameoffset" : 4272,
+                    "key.offset" : 4272,
+                    "key.parsed_declaration" : "func cast<T: NSError>(_ error: Swift.Error) -> T",
+                    "key.parsed_scope.end" : 150,
+                    "key.parsed_scope.start" : 150,
+                    "key.typename" : "T.Type",
+                    "key.typeusr" : "$SxmD",
+                    "key.usr" : "s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ4castL_yxsAF_pABRbzlF1TL_xmfp"
+                  }
+                ],
+                "key.typename" : "<T where T : NSError> (Error) -> T",
+                "key.typeusr" : "$Syxs5Error_pcSo7NSErrorCRbzluD",
+                "key.usr" : "s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ4castL_yxsAF_pABRbzlF"
+              }
+            ],
+            "key.typename" : "(NSError.Type) -> (Error) -> Self",
+            "key.typeusr" : "$S4fromSo7NSErrorCXDs5Error_p_tcD",
+            "key.usr" : "s:So7NSErrorC6ResultE5error4fromABXDs5Error_p_tFZ"
+          }
+        ],
+        "key.typename" : "NSError.Type",
+        "key.typeusr" : "$SSo7NSErrorCmD",
+        "key.usr" : "c:objc(cs)NSError"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 25,
+        "key.name" : "MARK: - migration support",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 4370
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4497
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 99,
+            "key.offset" : 4397
+          }
+        ],
+        "key.bodylength" : 15,
+        "key.bodyoffset" : 4568,
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 80,
+        "key.name" : "materialize(_:)",
+        "key.namelength" : 35,
+        "key.nameoffset" : 4509,
+        "key.offset" : 4504,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4521,
+            "key.offset" : 4521,
+            "key.parsed_declaration" : "public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError>",
+            "key.parsed_scope.end" : 161,
+            "key.parsed_scope.start" : 161,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6Result11materializeyA2AOyxSo7NSErrorCAEs5Error10Foundationg_GxyKXElF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "Result<T, NSError>"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4686
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 99,
+            "key.offset" : 4586
+          }
+        ],
+        "key.bodylength" : 15,
+        "key.bodyoffset" : 4770,
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 93,
+        "key.name" : "materialize(_:)",
+        "key.namelength" : 48,
+        "key.nameoffset" : 4698,
+        "key.offset" : 4693,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4710,
+            "key.offset" : 4710,
+            "key.parsed_declaration" : "public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSError>",
+            "key.parsed_scope.end" : 166,
+            "key.parsed_scope.start" : 166,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6Result11materializeyA2AOyxSo7NSErrorCAEs5Error10Foundationg_GxyKXKlF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "Result<T, NSError>"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 5300
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 167,
+            "key.offset" : 5132
+          }
+        ],
+        "key.bodylength" : 15,
+        "key.bodyoffset" : 5448,
+        "key.doc.comment" : "Constructs a `Result` with the result of calling `try` with an error pointer.\n\nThis is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:\n\n    Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }",
+        "key.doclength" : 291,
+        "key.docoffset" : 4841,
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 157,
+        "key.name" : "try(_:file:line:try:)",
+        "key.namelength" : 112,
+        "key.nameoffset" : 5312,
+        "key.offset" : 5307,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 5318,
+            "key.offset" : 5318,
+            "key.parsed_declaration" : "public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, `try`: (NSErrorPointer) -> T?) -> Result<T, NSError>",
+            "key.parsed_scope.end" : 178,
+            "key.parsed_scope.start" : 178,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$SxmD",
+            "key.usr" : "s:6Result3try_4file4lineAb2AOyxSo7NSErrorCAGs5Error10Foundationg_GSS_SSSixSgSAyAGSgGSgXEtlF1TL_xmfp"
+          }
+        ],
+        "key.typename" : "Result<T, NSError>"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 5911
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 167,
+            "key.offset" : 5743
+          }
+        ],
+        "key.bodylength" : 15,
+        "key.bodyoffset" : 6059,
+        "key.doc.comment" : "Constructs a `Result` with the result of calling `try` with an error pointer.\n\nThis is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:\n\n    Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }",
+        "key.doclength" : 277,
+        "key.docoffset" : 5466,
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 157,
+        "key.name" : "try(_:file:line:try:)",
+        "key.namelength" : 111,
+        "key.nameoffset" : 5923,
+        "key.offset" : 5918,
+        "key.substructure" : [
+
+        ],
+        "key.typename" : "Result<(), NSError>"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 7,
+        "key.name" : "MARK: -",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 6088
+      }
+    ]
+  }
+}, {
+  "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 5440,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol ResultProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 129
+          }
+        ],
+        "key.bodylength" : 143,
+        "key.bodyoffset" : 161,
+        "key.doc.column" : 17,
+        "key.doc.comment" : "A protocol that can be used to constrain associated types as `Result`.",
+        "key.doc.declaration" : "public protocol ResultProtocol",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"4\" column=\"17\"><Name>ResultProtocol<\/Name><USR>s:6Result0A8ProtocolP<\/USR><Declaration>public protocol ResultProtocol<\/Declaration><CommentParts><Abstract><Para>A protocol that can be used to constrain associated types as <codeVoice>Result<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "ResultProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 75,
+        "key.docoffset" : 54,
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>ResultProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 169,
+        "key.name" : "ResultProtocol",
+        "key.namelength" : 14,
+        "key.nameoffset" : 145,
+        "key.offset" : 136,
+        "key.parsed_declaration" : "public protocol ResultProtocol",
+        "key.parsed_scope.end" : 12,
+        "key.parsed_scope.start" : 4,
+        "key.runtime_name" : "_TtP4main14ResultProtocol_",
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype Value<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Value<\/decl.name><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 20,
+            "key.name" : "Value",
+            "key.namelength" : 5,
+            "key.nameoffset" : 178,
+            "key.offset" : 163,
+            "key.parsed_declaration" : "associatedtype Value",
+            "key.parsed_scope.end" : 5,
+            "key.parsed_scope.start" : 5,
+            "key.typename" : "Self.Value.Type",
+            "key.typeusr" : "$S5Value6Result0B8ProtocolPQzmD",
+            "key.usr" : "s:6Result0A8ProtocolP5ValueQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Error<\/decl.name> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 33,
+            "key.name" : "Error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 200,
+            "key.offset" : 185,
+            "key.parsed_declaration" : "associatedtype Error: Swift.Error",
+            "key.parsed_scope.end" : 6,
+            "key.parsed_scope.start" : 6,
+            "key.typename" : "Self.Error.Type",
+            "key.typeusr" : "$S5Error6Result0B8ProtocolPQzmD",
+            "key.usr" : "s:6Result0A8ProtocolP5ErrorQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>init(value: <Type usr=\"s:6Result0A8ProtocolP5ValueQa\">Value<\/Type>)<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>value<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.associatedtype usr=\"s:6Result0A8ProtocolP5ValueQa\">Value<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 18,
+            "key.name" : "init(value:)",
+            "key.namelength" : 18,
+            "key.nameoffset" : 221,
+            "key.offset" : 221,
+            "key.parsed_declaration" : "init(value: Value)",
+            "key.parsed_scope.end" : 8,
+            "key.parsed_scope.start" : 8,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Result0A8ProtocolP5errorx5ErrorQz_tcfc\">init(error:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ResultProtocol> (Self.Type) -> (Self.Value) -> Self",
+            "key.typeusr" : "$S5valuex5ValueQz_tcD",
+            "key.usr" : "s:6Result0A8ProtocolP5valuex5ValueQz_tcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>init(error: <Type usr=\"s:6Result0A8ProtocolP5ErrorQa\">Error<\/Type>)<\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>error<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.associatedtype usr=\"s:6Result0A8ProtocolP5ErrorQa\">Error<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 18,
+            "key.name" : "init(error:)",
+            "key.namelength" : 18,
+            "key.nameoffset" : 241,
+            "key.offset" : 241,
+            "key.parsed_declaration" : "init(error: Error)",
+            "key.parsed_scope.end" : 9,
+            "key.parsed_scope.start" : 9,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Result0A8ProtocolP5valuex5ValueQz_tcfc\">init(value:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ResultProtocol> (Self.Type) -> (Self.Error) -> Self",
+            "key.typeusr" : "$S5errorx5ErrorQz_tcD",
+            "key.usr" : "s:6Result0A8ProtocolP5errorx5ErrorQz_tcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>var result: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6Result0A8ProtocolP5ValueQa\">Value<\/Type>, <Type usr=\"s:6Result0A8ProtocolP5ErrorQa\">Error<\/Type>&gt; { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 297,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>result<\/decl.name>: <decl.var.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.associatedtype usr=\"s:6Result0A8ProtocolP5ValueQa\">Value<\/ref.associatedtype>, <ref.associatedtype usr=\"s:6Result0A8ProtocolP5ErrorQa\">Error<\/ref.associatedtype>&gt;<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 40,
+            "key.name" : "result",
+            "key.namelength" : 6,
+            "key.nameoffset" : 267,
+            "key.offset" : 263,
+            "key.parsed_declaration" : "var result: Result<Value, Error>",
+            "key.parsed_scope.end" : 11,
+            "key.parsed_scope.start" : 11,
+            "key.typename" : "Result<Self.Value, Self.Error>",
+            "key.typeusr" : "$S6ResultAAOy5ValueAA0A8ProtocolPQz5ErrorAEQzGD",
+            "key.usr" : "s:6Result0A8ProtocolP6resultA2AOy5ValueQz5ErrorQzGvp"
+          }
+        ],
+        "key.typename" : "ResultProtocol.Protocol",
+        "key.typeusr" : "$S6Result0A8Protocol_pmD",
+        "key.usr" : "s:6Result0A8ProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 307
+          }
+        ],
+        "key.bodylength" : 2247,
+        "key.bodyoffset" : 332,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 2266,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 324,
+        "key.offset" : 314,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var value: <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 404
+              }
+            ],
+            "key.bodylength" : 91,
+            "key.bodyoffset" : 430,
+            "key.doc.column" : 13,
+            "key.doc.comment" : "Returns the value if self represents a success, `nil` otherwise.",
+            "key.doc.declaration" : "public var value: Value? { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"16\" column=\"13\"><Name>value<\/Name><USR>s:6ResultAAO5valuexSgvp<\/USR><Declaration>public var value: Value? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the value if self represents a success, <codeVoice>nil<\/codeVoice> otherwise.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 16,
+            "key.doc.name" : "value",
+            "key.doc.type" : "Other",
+            "key.doclength" : 69,
+            "key.docoffset" : 334,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>value<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 111,
+            "key.name" : "value",
+            "key.namelength" : 5,
+            "key.nameoffset" : 415,
+            "key.offset" : 411,
+            "key.parsed_declaration" : "public var value: Value?",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 16,
+            "key.typename" : "Value?",
+            "key.typeusr" : "$SxSgD",
+            "key.usr" : "s:6ResultAAO5valuexSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var error: <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 596
+              }
+            ],
+            "key.bodylength" : 91,
+            "key.bodyoffset" : 622,
+            "key.doc.column" : 13,
+            "key.doc.comment" : "Returns the error if self represents a failure, `nil` otherwise.",
+            "key.doc.declaration" : "public var error: Error? { get }",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"24\" column=\"13\"><Name>error<\/Name><USR>s:6ResultAAO5errorq_Sgvp<\/USR><Declaration>public var error: Error? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the error if self represents a failure, <codeVoice>nil<\/codeVoice> otherwise.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 24,
+            "key.doc.name" : "error",
+            "key.doc.type" : "Other",
+            "key.doclength" : 69,
+            "key.docoffset" : 526,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>error<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 111,
+            "key.name" : "error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 607,
+            "key.offset" : 603,
+            "key.parsed_declaration" : "public var error: Error?",
+            "key.parsed_scope.end" : 29,
+            "key.parsed_scope.start" : 24,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO5error_8function4file4lineSo7NSErrorCSSSg_S2SSitFZ\">error(_:function:file:line:)<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "Error?",
+            "key.typeusr" : "$Sq_SgD",
+            "key.usr" : "s:6ResultAAO5errorq_Sgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func map&lt;U&gt;(_ transform: (<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp\">U<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 832
+              }
+            ],
+            "key.bodylength" : 47,
+            "key.bodyoffset" : 899,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns a new Result by mapping `Success`es’ values using `transform`, or re-wrapping `Failure`s’ errors.",
+            "key.doc.declaration" : "public func map<U>(_ transform: (Value) -> U) -> Result<U, Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"32\" column=\"14\"><Name>map(_:)<\/Name><USR>s:6ResultAAO3mapyAByqd__q_Gqd__xXElF<\/USR><Declaration>public func map&lt;U&gt;(_ transform: (Value) -&gt; U) -&gt; Result&lt;U, Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns a new Result by mapping <codeVoice>Success<\/codeVoice>es’ values using <codeVoice>transform<\/codeVoice>, or re-wrapping <codeVoice>Failure<\/codeVoice>s’ errors.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 32,
+            "key.doc.name" : "map(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 114,
+            "key.docoffset" : 717,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>map<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>transform<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 108,
+            "key.name" : "map(_:)",
+            "key.namelength" : 33,
+            "key.nameoffset" : 844,
+            "key.offset" : 839,
+            "key.parsed_declaration" : "public func map<U>(_ transform: (Value) -> U) -> Result<U, Error>",
+            "key.parsed_scope.end" : 34,
+            "key.parsed_scope.start" : 32,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "U",
+                "key.namelength" : 1,
+                "key.nameoffset" : 848,
+                "key.offset" : 848,
+                "key.parsed_declaration" : "public func map<U>(_ transform: (Value) -> U) -> Result<U, Error>",
+                "key.parsed_scope.end" : 32,
+                "key.parsed_scope.start" : 32,
+                "key.typename" : "U.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO3mapyAByqd__q_Gqd__xXElF1UL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, U where Error : Error> (Result<Value, Error>) -> ((Value) -> U) -> Result<U, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyqd__q_Gqd__xXEcluD",
+            "key.usr" : "s:6ResultAAO3mapyAByqd__q_Gqd__xXElF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func flatMap&lt;U&gt;(_ transform: (<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1061
+              }
+            ],
+            "key.bodylength" : 125,
+            "key.bodyoffset" : 1147,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.",
+            "key.doc.declaration" : "public func flatMap<U>(_ transform: (Value) -> Result<U, Error>) -> Result<U, Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"37\" column=\"14\"><Name>flatMap(_:)<\/Name><USR>s:6ResultAAO7flatMapyAByqd__q_GADxXElF<\/USR><Declaration>public func flatMap&lt;U&gt;(_ transform: (Value) -&gt; Result&lt;U, Error&gt;) -&gt; Result&lt;U, Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the result of applying <codeVoice>transform<\/codeVoice> to <codeVoice>Success<\/codeVoice>es’ values, or re-wrapping <codeVoice>Failure<\/codeVoice>’s errors.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 37,
+            "key.doc.name" : "flatMap(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 110,
+            "key.docoffset" : 950,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>flatMap<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>transform<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 205,
+            "key.name" : "flatMap(_:)",
+            "key.namelength" : 52,
+            "key.nameoffset" : 1073,
+            "key.offset" : 1068,
+            "key.parsed_declaration" : "public func flatMap<U>(_ transform: (Value) -> Result<U, Error>) -> Result<U, Error>",
+            "key.parsed_scope.end" : 42,
+            "key.parsed_scope.start" : 37,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "U",
+                "key.namelength" : 1,
+                "key.nameoffset" : 1081,
+                "key.offset" : 1081,
+                "key.parsed_declaration" : "public func flatMap<U>(_ transform: (Value) -> Result<U, Error>) -> Result<U, Error>",
+                "key.parsed_scope.end" : 37,
+                "key.parsed_scope.start" : 37,
+                "key.typename" : "U.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO7flatMapyAByqd__q_GADxXElF1UL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, U where Error : Error> (Result<Value, Error>) -> ((Value) -> Result<U, Error>) -> Result<U, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyqd__q_GACxXEcluD",
+            "key.usr" : "s:6ResultAAO7flatMapyAByqd__q_GADxXElF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func fanout&lt;U&gt;(_ other: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;(<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp\">U<\/Type>), <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1427
+              }
+            ],
+            "key.bodylength" : 75,
+            "key.bodyoffset" : 1525,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns a Result with a tuple of the receiver and `other` values if both\nare `Success`es, or re-wrapping the error of the earlier `Failure`.",
+            "key.doc.declaration" : "public func fanout<U>(_ other: @autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"46\" column=\"14\"><Name>fanout(_:)<\/Name><USR>s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF<\/USR><Declaration>public func fanout&lt;U&gt;(_ other: @autoclosure () -&gt; Result&lt;U, Error&gt;) -&gt; Result&lt;(Value, U), Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns a Result with a tuple of the receiver and <codeVoice>other<\/codeVoice> values if both are <codeVoice>Success<\/codeVoice>es, or re-wrapping the error of the earlier <codeVoice>Failure<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 46,
+            "key.doc.name" : "fanout(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 150,
+            "key.docoffset" : 1276,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>fanout<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>other<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<tuple>(<tuple.element><tuple.element.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/tuple.element.type><\/tuple.element>, <tuple.element><tuple.element.type><ref.generic_type_param usr=\"s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp\">U<\/ref.generic_type_param><\/tuple.element.type><\/tuple.element>)<\/tuple>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 167,
+            "key.name" : "fanout(_:)",
+            "key.namelength" : 55,
+            "key.nameoffset" : 1439,
+            "key.offset" : 1434,
+            "key.parsed_declaration" : "public func fanout<U>(_ other: @autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error>",
+            "key.parsed_scope.end" : 48,
+            "key.parsed_scope.start" : 46,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "U",
+                "key.namelength" : 1,
+                "key.nameoffset" : 1446,
+                "key.offset" : 1446,
+                "key.parsed_declaration" : "public func fanout<U>(_ other: @autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error>",
+                "key.parsed_scope.end" : 46,
+                "key.parsed_scope.start" : 46,
+                "key.typename" : "U.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF1UL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, U where Error : Error> (Result<Value, Error>) -> (@autoclosure () -> Result<U, Error>) -> Result<(Value, U), Error>",
+            "key.typeusr" : "$Sy6ResultAAOyx_qd__tq_GAByqd__q_GyXKcluD",
+            "key.usr" : "s:6ResultAAO6fanoutyAByx_qd__tq_GAByqd__q_GyXKlF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func mapError&lt;Error2&gt;(_ transform: (<Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>) -&gt; <Type usr=\"s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp\">Error2<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp\">Error2<\/Type>&gt; where Error2 : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1717
+              }
+            ],
+            "key.bodylength" : 52,
+            "key.bodyoffset" : 1804,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns a new Result by mapping `Failure`'s values using `transform`, or re-wrapping `Success`es’ values.",
+            "key.doc.declaration" : "public func mapError<Error2>(_ transform: (Error) -> Error2) -> Result<Value, Error2> where Error2 : Error",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"51\" column=\"14\"><Name>mapError(_:)<\/Name><USR>s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF<\/USR><Declaration>public func mapError&lt;Error2&gt;(_ transform: (Error) -&gt; Error2) -&gt; Result&lt;Value, Error2&gt; where Error2 : Error<\/Declaration><CommentParts><Abstract><Para>Returns a new Result by mapping <codeVoice>Failure<\/codeVoice>’s values using <codeVoice>transform<\/codeVoice>, or re-wrapping <codeVoice>Success<\/codeVoice>es’ values.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 51,
+            "key.doc.name" : "mapError(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 112,
+            "key.docoffset" : 1604,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>mapError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp\"><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>transform<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp\">Error2<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp\">Error2<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error2 : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 133,
+            "key.name" : "mapError(_:)",
+            "key.namelength" : 48,
+            "key.nameoffset" : 1729,
+            "key.offset" : 1724,
+            "key.parsed_declaration" : "public func mapError<Error2>(_ transform: (Error) -> Error2) -> Result<Value, Error2>",
+            "key.parsed_scope.end" : 53,
+            "key.parsed_scope.start" : 51,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>Error2<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 6,
+                "key.name" : "Error2",
+                "key.namelength" : 6,
+                "key.nameoffset" : 1738,
+                "key.offset" : 1738,
+                "key.parsed_declaration" : "public func mapError<Error2>(_ transform: (Error) -> Error2) -> Result<Value, Error2>",
+                "key.parsed_scope.end" : 51,
+                "key.parsed_scope.start" : 51,
+                "key.typename" : "Error2.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF6Error2L_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, Error2 where Error : Error, Error2 : Error> (Result<Value, Error>) -> ((Error) -> Error2) -> Result<Value, Error2>",
+            "key.typeusr" : "$Sy6ResultAAOyxqd__Gqd__q_XEcs5ErrorRd__luD",
+            "key.usr" : "s:6ResultAAO8mapErroryAByxqd__Gqd__q_XEs0C0Rd__lF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func flatMapError&lt;Error2&gt;(_ transform: (<Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp\">Error2<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp\">Error2<\/Type>&gt; where Error2 : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1971
+              }
+            ],
+            "key.bodylength" : 125,
+            "key.bodyoffset" : 2077,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns the result of applying `transform` to `Failure`’s errors, or re-wrapping `Success`es’ values.",
+            "key.doc.declaration" : "public func flatMapError<Error2>(_ transform: (Error) -> Result<Value, Error2>) -> Result<Value, Error2> where Error2 : Error",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"56\" column=\"14\"><Name>flatMapError(_:)<\/Name><USR>s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF<\/USR><Declaration>public func flatMapError&lt;Error2&gt;(_ transform: (Error) -&gt; Result&lt;Value, Error2&gt;) -&gt; Result&lt;Value, Error2&gt; where Error2 : Error<\/Declaration><CommentParts><Abstract><Para>Returns the result of applying <codeVoice>transform<\/codeVoice> to <codeVoice>Failure<\/codeVoice>’s errors, or re-wrapping <codeVoice>Success<\/codeVoice>es’ values.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 56,
+            "key.doc.name" : "flatMapError(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 110,
+            "key.docoffset" : 1860,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>flatMapError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp\"><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>transform<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp\">Error2<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp\">Error2<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error2 : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 225,
+            "key.name" : "flatMapError(_:)",
+            "key.namelength" : 67,
+            "key.nameoffset" : 1983,
+            "key.offset" : 1978,
+            "key.parsed_declaration" : "public func flatMapError<Error2>(_ transform: (Error) -> Result<Value, Error2>) -> Result<Value, Error2>",
+            "key.parsed_scope.end" : 61,
+            "key.parsed_scope.start" : 56,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>Error2<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 6,
+                "key.name" : "Error2",
+                "key.namelength" : 6,
+                "key.nameoffset" : 1996,
+                "key.offset" : 1996,
+                "key.parsed_declaration" : "public func flatMapError<Error2>(_ transform: (Error) -> Result<Value, Error2>) -> Result<Value, Error2>",
+                "key.parsed_scope.end" : 56,
+                "key.parsed_scope.start" : 56,
+                "key.typename" : "Error2.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF6Error2L_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, Error2 where Error : Error, Error2 : Error> (Result<Value, Error>) -> ((Error) -> Result<Value, Error2>) -> Result<Value, Error2>",
+            "key.typeusr" : "$Sy6ResultAAOyxqd__GACq_XEcs5ErrorRd__luD",
+            "key.usr" : "s:6ResultAAO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func bimap&lt;U, Error2&gt;(success: (<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp\">U<\/Type>, failure: (<Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>) -&gt; <Type usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp\">Error2<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp\">Error2<\/Type>&gt; where Error2 : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2333
+              }
+            ],
+            "key.bodylength" : 142,
+            "key.bodyoffset" : 2435,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns a new Result by mapping `Success`es’ values using `success`, and by mapping `Failure`'s values using `failure`.",
+            "key.doc.declaration" : "public func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2> where Error2 : Error",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"64\" column=\"14\"><Name>bimap(success:failure:)<\/Name><USR>s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF<\/USR><Declaration>public func bimap&lt;U, Error2&gt;(success: (Value) -&gt; U, failure: (Error) -&gt; Error2) -&gt; Result&lt;U, Error2&gt; where Error2 : Error<\/Declaration><CommentParts><Abstract><Para>Returns a new Result by mapping <codeVoice>Success<\/codeVoice>es’ values using <codeVoice>success<\/codeVoice>, and by mapping <codeVoice>Failure<\/codeVoice>’s values using <codeVoice>failure<\/codeVoice>.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 64,
+            "key.doc.name" : "bimap(success:failure:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 126,
+            "key.docoffset" : 2206,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>bimap<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp\"><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>success<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>failure<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp\">Error2<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp\">Error2<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error2 : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 238,
+            "key.name" : "bimap(success:failure:)",
+            "key.namelength" : 67,
+            "key.nameoffset" : 2345,
+            "key.offset" : 2340,
+            "key.parsed_declaration" : "public func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2>",
+            "key.parsed_scope.end" : 69,
+            "key.parsed_scope.start" : 64,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "U",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2351,
+                "key.offset" : 2351,
+                "key.parsed_declaration" : "public func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2>",
+                "key.parsed_scope.end" : 64,
+                "key.parsed_scope.start" : 64,
+                "key.typename" : "U.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF1UL_qd__mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>Error2<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>Error2<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 6,
+                "key.name" : "Error2",
+                "key.namelength" : 6,
+                "key.nameoffset" : 2354,
+                "key.offset" : 2354,
+                "key.parsed_declaration" : "public func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2>",
+                "key.parsed_scope.end" : 64,
+                "key.parsed_scope.start" : 64,
+                "key.typename" : "Error2.Type",
+                "key.typeusr" : "$Sqd_0_mD",
+                "key.usr" : "s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF6Error2L_qd_0_mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, U, Error2 where Error : Error, Error2 : Error> (Result<Value, Error>) -> ((Value) -> U, (Error) -> Error2) -> Result<U, Error2>",
+            "key.typeusr" : "$S7success7failure6ResultACOyqd__qd_0_Gqd__xXE_qd_0_q_XEtcs5ErrorRd_0_r0_luD",
+            "key.usr" : "s:6ResultAAO5bimap7success7failureAByqd__qd_0_Gqd__xXE_qd_0_q_XEts5ErrorRd_0_r0_lF"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 2582
+          }
+        ],
+        "key.bodylength" : 529,
+        "key.bodyoffset" : 2607,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 548,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2599,
+        "key.offset" : 2589,
+        "key.substructure" : [
+          {
+            "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+            "key.length" : 28,
+            "key.name" : "MARK: Higher-order functions",
+            "key.namelength" : 0,
+            "key.nameoffset" : 0,
+            "key.offset" : 2613
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func recover(_ value: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2751
+              }
+            ],
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 2816,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`",
+            "key.doc.declaration" : "public func recover(_ value: @autoclosure () -> Value) -> Value",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"77\" column=\"14\"><Name>recover(_:)<\/Name><USR>s:6ResultAAO7recoveryxxyXKF<\/USR><Declaration>public func recover(_ value: @autoclosure () -&gt; Value) -&gt; Value<\/Declaration><CommentParts><Abstract><Para>Returns <codeVoice>self.value<\/codeVoice> if this result is a .Success, or the given value otherwise. Equivalent with <codeVoice>??<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 77,
+            "key.doc.name" : "recover(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 106,
+            "key.docoffset" : 2644,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>recover<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 92,
+            "key.name" : "recover(_:)",
+            "key.namelength" : 42,
+            "key.nameoffset" : 2763,
+            "key.offset" : 2758,
+            "key.parsed_declaration" : "public func recover(_ value: @autoclosure () -> Value) -> Value",
+            "key.parsed_scope.end" : 79,
+            "key.parsed_scope.start" : 77,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7recover4withAByxq_GAEyXK_tF\">recover(with:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>) -> (@autoclosure () -> Value) -> Value",
+            "key.typeusr" : "$SyxxyXKcD",
+            "key.usr" : "s:6ResultAAO7recoveryxxyXKF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func recover(with result: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2951
+              }
+            ],
+            "key.bodylength" : 84,
+            "key.bodyoffset" : 3050,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`",
+            "key.doc.declaration" : "public func recover(with result: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"82\" column=\"14\"><Name>recover(with:)<\/Name><USR>s:6ResultAAO7recover4withAByxq_GAEyXK_tF<\/USR><Declaration>public func recover(with result: @autoclosure () -&gt; Result&lt;Value, Error&gt;) -&gt; Result&lt;Value, Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns this result if it is a .Success, or the given result otherwise. Equivalent with <codeVoice>??<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 82,
+            "key.doc.name" : "recover(with:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 97,
+            "key.docoffset" : 2853,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>recover<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>with<\/decl.var.parameter.argument_label> <decl.var.parameter.name>result<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 177,
+            "key.name" : "recover(with:)",
+            "key.namelength" : 61,
+            "key.nameoffset" : 2963,
+            "key.offset" : 2958,
+            "key.parsed_declaration" : "public func recover(with result: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.parsed_scope.end" : 87,
+            "key.parsed_scope.start" : 82,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO7recoveryxxyXKF\">recover(_:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>) -> (@autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.typeusr" : "$S4with6ResultABOyxq_GADyXK_tcD",
+            "key.usr" : "s:6ResultAAO7recover4withAByxq_GAEyXK_tF"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol ErrorConvertible : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 3218
+          }
+        ],
+        "key.bodylength" : 53,
+        "key.bodyoffset" : 3265,
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.",
+        "key.doc.declaration" : "public protocol ErrorConvertible : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+        "key.doc.full_as_xml" : "<Class file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"91\" column=\"17\"><Name>ErrorConvertible<\/Name><USR>s:6Result16ErrorConvertibleP<\/USR><Declaration>public protocol ErrorConvertible : Error<\/Declaration><CommentParts><Abstract><Para>Protocol used to constrain <codeVoice>tryMap<\/codeVoice> to <codeVoice>Result<\/codeVoice>s with compatible <codeVoice>Error<\/codeVoice>s.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 91,
+        "key.doc.name" : "ErrorConvertible",
+        "key.doc.type" : "Class",
+        "key.doclength" : 79,
+        "key.docoffset" : 3139,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 11,
+            "key.offset" : 3252
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>ErrorConvertible<\/decl.name> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.protocol>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Swift.Error"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 94,
+        "key.name" : "ErrorConvertible",
+        "key.namelength" : 16,
+        "key.nameoffset" : 3234,
+        "key.offset" : 3225,
+        "key.parsed_declaration" : "public protocol ErrorConvertible: Swift.Error",
+        "key.parsed_scope.end" : 93,
+        "key.parsed_scope.start" : 91,
+        "key.runtime_name" : "_TtP4main16ErrorConvertible_",
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func error(from error: Swift.<Type usr=\"s:s5ErrorP\">Error<\/Type>) -&gt; <Type usr=\"s:6Result16ErrorConvertibleP4Selfxmfp\">Self<\/Type><\/Declaration>",
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>error<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>from<\/decl.var.parameter.argument_label> <decl.var.parameter.name>error<\/decl.var.parameter.name>: <decl.var.parameter.type>Swift.<ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6Result16ErrorConvertibleP4Selfxmfp\">Self<\/ref.generic_type_param><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 50,
+            "key.name" : "error(from:)",
+            "key.namelength" : 30,
+            "key.nameoffset" : 3279,
+            "key.offset" : 3267,
+            "key.parsed_declaration" : "static func error(from error: Swift.Error) -> Self",
+            "key.parsed_scope.end" : 92,
+            "key.parsed_scope.start" : 92,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ErrorConvertible> (Self.Type) -> (Error) -> Self",
+            "key.typeusr" : "$S4fromxs5Error_p_tcD",
+            "key.usr" : "s:6Result16ErrorConvertibleP5error4fromxs0B0_p_tFZ"
+          }
+        ],
+        "key.typename" : "ErrorConvertible.Protocol",
+        "key.typeusr" : "$S6Result16ErrorConvertible_pmD",
+        "key.usr" : "s:6Result16ErrorConvertibleP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 3321
+          }
+        ],
+        "key.bodylength" : 479,
+        "key.bodyoffset" : 3376,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 528,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 3338,
+        "key.offset" : 3328,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func tryMap&lt;U&gt;(_ transform: (<Type usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE5Valuexmfp\">Value<\/Type>) throws -&gt; <Type usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp\">U<\/Type>) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp\">U<\/Type>, <Type usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE0B0q_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3480
+              }
+            ],
+            "key.bodylength" : 296,
+            "key.bodyoffset" : 3557,
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.",
+            "key.doc.declaration" : "public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"98\" column=\"14\"><Name>tryMap(_:)<\/Name><USR>s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF<\/USR><Declaration>public func tryMap&lt;U&gt;(_ transform: (Value) throws -&gt; U) -&gt; Result&lt;U, Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the result of applying <codeVoice>transform<\/codeVoice> to <codeVoice>Success<\/codeVoice>es’ values, or wrapping thrown errors.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 98,
+            "key.doc.name" : "tryMap(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 100,
+            "key.docoffset" : 3379,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>tryMap<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>transform<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>throws<\/syntaxtype.keyword> -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp\">U<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAOA2A16ErrorConvertibleR_rlE0B0q_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 367,
+            "key.name" : "tryMap(_:)",
+            "key.namelength" : 43,
+            "key.nameoffset" : 3492,
+            "key.offset" : 3487,
+            "key.parsed_declaration" : "public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error>",
+            "key.parsed_scope.end" : 109,
+            "key.parsed_scope.start" : 98,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 1,
+                "key.name" : "U",
+                "key.namelength" : 1,
+                "key.nameoffset" : 3499,
+                "key.offset" : 3499,
+                "key.parsed_declaration" : "public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error>",
+                "key.parsed_scope.end" : 98,
+                "key.parsed_scope.start" : 98,
+                "key.typename" : "U.Type",
+                "key.typeusr" : "$Sqd__mD",
+                "key.usr" : "s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF1UL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<Value, Error, U where Error : ErrorConvertible> (Result<Value, Error>) -> ((Value) throws -> U) -> Result<U, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyqd__q_Gqd__xKXEcluD",
+            "key.usr" : "s:6ResultAAOA2A16ErrorConvertibleR_rlE6tryMapyAByqd__q_Gqd__xKXElF"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 3861
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 440,
+        "key.bodyoffset" : 3939,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 500,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 3890,
+        "key.offset" : 3880,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func == (left: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/Type>&gt;, right: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/Type>&gt;) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 4105
+              }
+            ],
+            "key.bodylength" : 184,
+            "key.bodyoffset" : 4193,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.",
+            "key.doc.declaration" : "public static func == (left: Result<Value, Error>, right: Result<Value, Error>) -> Bool",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"116\" column=\"21\"><Name>==(_:_:)<\/Name><USR>s:6ResultAAOAASQRzSQR_rlE2eeoiySbAByxq_G_ADtFZ<\/USR><Declaration>public static func == (left: Result&lt;Value, Error&gt;, right: Result&lt;Value, Error&gt;) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns <codeVoice>true<\/codeVoice> if <codeVoice>left<\/codeVoice> and <codeVoice>right<\/codeVoice> are both <codeVoice>Success<\/codeVoice>es and their values are equal, or if <codeVoice>left<\/codeVoice> and <codeVoice>right<\/codeVoice> are both <codeVoice>Failure<\/codeVoice>s and their errors are equal.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 116,
+            "key.doc.name" : "==(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 163,
+            "key.docoffset" : 3941,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>== <\/decl.name>(<decl.var.parameter><decl.var.parameter.name>left<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>right<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 266,
+            "key.name" : "==(_:_:)",
+            "key.namelength" : 59,
+            "key.nameoffset" : 4124,
+            "key.offset" : 4112,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:SQ2eeoiySbx_xtFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func ==(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool",
+            "key.parsed_scope.end" : 123,
+            "key.parsed_scope.start" : 116,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6Result7NoErrorO2eeoiySbAC_ACtFZ\">== (_: NoError, _: NoError) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbypXpSg_ABtF\">== (_: Any.Type?, _: Any.Type?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_xtSYRzSQ8RawValueRpzlF\">== &lt;T&gt;(_: T, _: T) -&gt; Bool where T : RawRepresentable, T.RawValue : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbyt_yttF\">== (_: (), _: ()) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_t_x_q_ttSQRzSQR_r0_lF\">== &lt;A, B&gt;(_: (A, B), _: (A, B)) -&gt; Bool where A : Equatable, B : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_t_x_q_q0_ttSQRzSQR_SQR0_r1_lF\">== &lt;A, B, C&gt;(_: (A, B, C), _: (A, B, C)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_t_x_q_q0_q1_ttSQRzSQR_SQR0_SQR1_r2_lF\">== &lt;A, B, C, D&gt;(_: (A, B, C, D), _: (A, B, C, D)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_q2_t_x_q_q0_q1_q2_ttSQRzSQR_SQR0_SQR1_SQR2_r3_lF\">== &lt;A, B, C, D, E&gt;(_: (A, B, C, D, E), _: (A, B, C, D, E)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2eeoiySbx_q_q0_q1_q2_q3_t_x_q_q0_q1_q2_q3_ttSQRzSQR_SQR0_SQR1_SQR2_SQR3_r4_lF\">== &lt;A, B, C, D, E, F&gt;(_: (A, B, C, D, E, F), _: (A, B, C, D, E, F)) -&gt; Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s15ContiguousArrayVsSQRzlE2eeoiySbAByxG_ADtFZ\">== (_: ContiguousArray&lt;ContiguousArray&lt;Element&gt;.Element&gt;, _: ContiguousArray&lt;ContiguousArray&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10ArraySliceVsSQRzlE2eeoiySbAByxG_ADtFZ\">== (_: ArraySlice&lt;ArraySlice&lt;Element&gt;.Element&gt;, _: ArraySlice&lt;ArraySlice&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SasSQRzlE2eeoiySbSayxG_ABtFZ\">== (_: Array&lt;Array&lt;Element&gt;.Element&gt;, _: Array&lt;Array&lt;Element&gt;.Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sb2eeoiyS2b_SbtFZ\">== (_: Bool, _: Bool) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SA2eeoiySbSAyxG_ABtFZ\">== (_: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;, _: AutoreleasingUnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SJ2eeoiySbSJ_SJtFZ\">== (_: Character, _: Character) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SJ17UnicodeScalarViewV5IndexV2eeoiySbAD_ADtFZ\">== (_: Character.UnicodeScalarView.Index, _: Character.UnicodeScalarView.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17CodingUserInfoKeyV2eeoiySbAB_ABtFZ\">== (_: CodingUserInfoKey, _: CodingUserInfoKey) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SNsSxRzSZ6StrideRpzrlE5IndexO2eeoiySbADyx_G_AFtFZ\">== (_: ClosedRange&lt;Bound&gt;.Index, _: ClosedRange&lt;Bound&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SN2eeoiySbSNyxG_ABtFZ\">== (_: ClosedRange&lt;Bound&gt;, _: ClosedRange&lt;Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s13OpaquePointerV2eeoiySbAB_ABtFZ\">== (_: OpaquePointer, _: OpaquePointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SD4KeysV2eeoiySbAByxq__G_ADtFZ\">== (_: Dictionary&lt;Key, Value&gt;.Keys, _: Dictionary&lt;Key, Value&gt;.Keys) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SDsSQR_rlE2eeoiySbSDyxq_G_ABtFZ\">== (_: [Key : Value], _: [Key : Value]) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SD5IndexV2eeoiySbAByxq__G_ADtFZ\">== (_: Dictionary&lt;Key, Value&gt;.Index, _: Dictionary&lt;Key, Value&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s23LazyDropWhileCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: LazyDropWhileCollection&lt;Base&gt;.Index, _: LazyDropWhileCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s15EmptyCollectionV2eeoiySbAByxG_ADtFZ\">== (_: EmptyCollection&lt;Element&gt;, _: EmptyCollection&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SQ2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17FlattenCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: FlattenCollection&lt;Base&gt;.Index, _: FlattenCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s17FloatingPointSignO2eeoiySbAB_ABtFZ\">== (_: FloatingPointSign, _: FloatingPointSign) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SFsE2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11AnyHashableV2eeoiySbAB_ABtFZ\">== (_: AnyHashable, _: AnyHashable) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SzsE2eeoiySbx_qd__tSzRd__lFZ\">== &lt;Other&gt;(_: Self, _: Other) -&gt; Bool where Other : BinaryInteger<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5UInt8V2eeoiySbAB_ABtFZ\">== (_: UInt8, _: UInt8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s4Int8V2eeoiySbAB_ABtFZ\">== (_: Int8, _: Int8) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt16V2eeoiySbAB_ABtFZ\">== (_: UInt16, _: UInt16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int16V2eeoiySbAB_ABtFZ\">== (_: Int16, _: Int16) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt32V2eeoiySbAB_ABtFZ\">== (_: UInt32, _: UInt32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int32V2eeoiySbAB_ABtFZ\">== (_: Int32, _: Int32) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s6UInt64V2eeoiySbAB_ABtFZ\">== (_: UInt64, _: UInt64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s5Int64V2eeoiySbAB_ABtFZ\">== (_: Int64, _: Int64) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Su2eeoiySbSu_SutFZ\">== (_: UInt, _: UInt) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Si2eeoiySbSi_SitFZ\">== (_: Int, _: Int) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s10AnyKeyPathC2eeoiySbAB_ABtFZ\">== (_: AnyKeyPath, _: AnyKeyPath) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s20ManagedBufferPointerV2eeoiySbAByxq_G_ADtFZ\">== (_: ManagedBufferPointer&lt;Header, Element&gt;, _: ManagedBufferPointer&lt;Header, Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s7UnicodeO6ScalarV2eeoiySbAD_ADtFZ\">== (_: Unicode.Scalar, _: Unicode.Scalar) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SO2eeoiySbSO_SOtFZ\">== (_: ObjectIdentifier, _: ObjectIdentifier) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SqsSQRzlE2eeoiySbxSg_ABtFZ\">== (_: Wrapped?, _: Wrapped?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sq2eeoiySbxSg_s26_OptionalNilComparisonTypeVtFZ\">== (_: Wrapped?, _: _OptionalNilComparisonType) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sq2eeoiySbs26_OptionalNilComparisonTypeV_xSgtFZ\">== (_: _OptionalNilComparisonType, _: Wrapped?) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s25LazyPrefixWhileCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: LazyPrefixWhileCollection&lt;Base&gt;.Index, _: LazyPrefixWhileCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sn2eeoiySbSnyxG_ABtFZ\">== (_: Range&lt;Range&lt;Bound&gt;.Bound&gt;, _: Range&lt;Range&lt;Bound&gt;.Bound&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s18ReversedCollectionV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: ReversedCollection&lt;Base&gt;.Index, _: ReversedCollection&lt;Base&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sh2eeoiySbShyxG_ABtFZ\">== (_: Set&lt;Element&gt;, _: Set&lt;Element&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sh5IndexV2eeoiySbAByx_G_ADtFZ\">== (_: Set&lt;Element&gt;.Index, _: Set&lt;Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SxsE2eeoiySbx_xtFZ\">== (_: Self, _: Self) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SysE2eeoiySbx_qd__tSyRd__lFZ\">== &lt;S&gt;(_: Self, _: S) -&gt; Bool where S : StringProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS2eeoiySbSS_SStFZ\">== (_: String, _: String) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SS5IndexV2eeoiySbAB_ABtFZ\">== (_: String.Index, _: String.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s11_UIntBufferV5IndexV2eeoiySbADyxq__G_AFtFZ\">== (_: _UIntBuffer&lt;Storage, Element&gt;.Index, _: _UIntBuffer&lt;Storage, Element&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sp2eeoiySbSpyxG_ABtFZ\">== (_: UnsafeMutablePointer&lt;Pointee&gt;, _: UnsafeMutablePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SP2eeoiySbSPyxG_ABtFZ\">== (_: UnsafePointer&lt;Pointee&gt;, _: UnsafePointer&lt;Pointee&gt;) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:Sv2eeoiySbSv_SvtFZ\">== (_: UnsafeMutableRawPointer, _: UnsafeMutableRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SV2eeoiySbSV_SVtFZ\">== (_: UnsafeRawPointer, _: UnsafeRawPointer) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s21UnicodeDecodingResultO2eeoiySbAB_ABtFZ\">== (_: UnicodeDecodingResult, _: UnicodeDecodingResult) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s16_ValidUTF8BufferV5IndexV2eeoiySbADyx_G_AFtFZ\">== (_: _ValidUTF8Buffer&lt;Storage&gt;.Index, _: _ValidUTF8Buffer&lt;Storage&gt;.Index) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:So30_SwiftNSOperatingSystemVersionasE2eeoiySbAB_ABtFZ\">== (_: _SwiftNSOperatingSystemVersion, _: _SwiftNSOperatingSystemVersion) -&gt; Bool<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s8AnyIndexV2eeoiySbAB_ABtFZ\">== (_: AnyIndex, _: AnyIndex) -&gt; Bool<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let left: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.var.parameter><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.var.parameter.name>left<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAOAASQRzSQR_rlE5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>",
+                "key.kind" : "source.lang.swift.decl.var.parameter",
+                "key.length" : 4,
+                "key.name" : "left",
+                "key.offset" : 4127,
+                "key.parent_loc" : 4124,
+                "key.parsed_declaration" : "public static func ==(left: Result<Value, Error>, right: Result<Value, Error>) -> Bool",
+                "key.parsed_scope.end" : 116,
+                "key.parsed_scope.start" : 116,
+                "key.typename" : "Result<Value, Error>",
+                "key.typeusr" : "$S6ResultAAOyxq_GD",
+                "key.usr" : "s:6ResultAAOAASQRzSQR_rlE2eeoiySbAByxq_G_ADtFZ4leftL_ADvp"
+              }
+            ],
+            "key.typename" : "<Value, Error where Value : Equatable, Error : Equatable, Error : Error> (Result<Value, Error>.Type) -> (Result<Value, Error>, Result<Value, Error>) -> Bool",
+            "key.typeusr" : "$SySb6ResultAAOyxq_G_ACtcD",
+            "key.usr" : "s:6ResultAAOAASQRzSQR_rlE2eeoiySbAByxq_G_ADtFZ"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 1,
+        "key.bodyoffset" : 4470,
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 4418
+          }
+        ],
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 72,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 4410,
+        "key.offset" : 4400,
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum Result&lt;Value, Error&gt; : <Type usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/Type>, <Type usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/Type>, <Type usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/Type> where Error : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 471,
+        "key.bodyoffset" : 4818,
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.",
+        "key.doc.declaration" : "public enum Result<Value, Error> : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error",
+        "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.doc.full_as_xml" : "<Other file=\"Carthage\/Checkouts\/Result\/Result\/Result.swift\" line=\"4\" column=\"13\"><Name>Result<\/Name><USR>s:6ResultAAO<\/USR><Declaration>public enum Result&lt;Value, Error&gt; : ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible where Error : Error<\/Declaration><CommentParts><Abstract><Para>An enum representing either a failure with an explanatory error, or a success with a result value.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 4,
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/Result.swift",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\"><decl.generic_type_param.name>Value<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\"><decl.generic_type_param.name>Error<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:6Result0A8ProtocolP\">ResultProtocol<\/ref.protocol>, <ref.protocol usr=\"s:s23CustomStringConvertibleP\">CustomStringConvertible<\/ref.protocol>, <ref.protocol usr=\"s:s28CustomDebugStringConvertibleP\">CustomDebugStringConvertible<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement>Error : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 490,
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 4810,
+        "key.offset" : 4800,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func ?? (left: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;, right: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>) -&gt; <Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 4913
+              }
+            ],
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 5006,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.",
+            "key.doc.declaration" : "public static func ?? (left: Result<Value, Error>, right: @autoclosure () -> Value) -> Value",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"139\" column=\"21\"><Name>??(_:_:)<\/Name><USR>s:6ResultAAO2qqoiyxAByxq_G_xyXKtFZ<\/USR><Declaration>public static func ?? (left: Result&lt;Value, Error&gt;, right: @autoclosure () -&gt; Value) -&gt; Value<\/Declaration><CommentParts><Abstract><Para>Returns the value of <codeVoice>left<\/codeVoice> if it is a <codeVoice>Success<\/codeVoice>, or <codeVoice>right<\/codeVoice> otherwise. Short-circuits.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 139,
+            "key.doc.name" : "??(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 92,
+            "key.docoffset" : 4820,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>?? <\/decl.name>(<decl.var.parameter><decl.var.parameter.name>left<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>right<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param><\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 120,
+            "key.name" : "??(_:_:)",
+            "key.namelength" : 63,
+            "key.nameoffset" : 4932,
+            "key.offset" : 4920,
+            "key.parsed_declaration" : "public static func ??(left: Result<Value, Error>, right: @autoclosure () -> Value) -> Value",
+            "key.parsed_scope.end" : 141,
+            "key.parsed_scope.start" : 139,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO2qqoiyAByxq_GAD_ADyXKtFZ\">?? (_: Result&lt;Value, Error&gt;, _: @autoclosure () -&gt; Result&lt;Value, Error&gt;) -&gt; Result&lt;Value, Error&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2qqoiyxxSg_xyKXKtKlF\">?? &lt;T&gt;(_: T?, _: @autoclosure () throws -&gt; T) rethrows -&gt; T<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2qqoiyxSgAB_AByKXKtKlF\">?? &lt;T&gt;(_: T?, _: @autoclosure () throws -&gt; T?) rethrows -&gt; T?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let left: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+                "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+                "key.fully_annotated_decl" : "<decl.var.parameter><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.var.parameter.name>left<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>",
+                "key.kind" : "source.lang.swift.decl.var.parameter",
+                "key.length" : 4,
+                "key.name" : "left",
+                "key.offset" : 4935,
+                "key.parent_loc" : 4932,
+                "key.parsed_declaration" : "public static func ??(left: Result<Value, Error>, right: @autoclosure () -> Value) -> Value",
+                "key.parsed_scope.end" : 139,
+                "key.parsed_scope.start" : 139,
+                "key.typename" : "Result<Value, Error>",
+                "key.typeusr" : "$S6ResultAAOyxq_GD",
+                "key.usr" : "s:6ResultAAO2qqoiyxAByxq_G_xyXKtFZ4leftL_ADvp"
+              }
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Result<Value, Error>, @autoclosure () -> Value) -> Value",
+            "key.typeusr" : "$Syx6ResultAAOyxq_G_xyXKtcD",
+            "key.usr" : "s:6ResultAAO2qqoiyxAByxq_G_xyXKtFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func ?? (left: <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;, right: @autoclosure () -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;) -&gt; <Type usr=\"s:6ResultAAO\">Result<\/Type>&lt;<Type usr=\"s:6ResultAAO5Valuexmfp\">Value<\/Type>, <Type usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 5125
+              }
+            ],
+            "key.bodylength" : 39,
+            "key.bodyoffset" : 5248,
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Returns `left` if it is a `Success`es, or `right` otherwise. Short-circuits.",
+            "key.doc.declaration" : "public static func ?? (left: Result<Value, Error>, right: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.doc.file" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift\" line=\"144\" column=\"21\"><Name>??(_:_:)<\/Name><USR>s:6ResultAAO2qqoiyAByxq_GAD_ADyXKtFZ<\/USR><Declaration>public static func ?? (left: Result&lt;Value, Error&gt;, right: @autoclosure () -&gt; Result&lt;Value, Error&gt;) -&gt; Result&lt;Value, Error&gt;<\/Declaration><CommentParts><Abstract><Para>Returns <codeVoice>left<\/codeVoice> if it is a <codeVoice>Success<\/codeVoice>es, or <codeVoice>right<\/codeVoice> otherwise. Short-circuits.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 144,
+            "key.doc.name" : "??(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 81,
+            "key.docoffset" : 5043,
+            "key.filepath" : "Carthage\/Checkouts\/Result\/Result\/ResultProtocol.swift",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>?? <\/decl.name>(<decl.var.parameter><decl.var.parameter.name>left<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>right<\/decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:6ResultAAO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:6ResultAAO5Valuexmfp\">Value<\/ref.generic_type_param>, <ref.generic_type_param usr=\"s:6ResultAAO5Errorq_mfp\">Error<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 156,
+            "key.name" : "??(_:_:)",
+            "key.namelength" : 78,
+            "key.nameoffset" : 5144,
+            "key.offset" : 5132,
+            "key.parsed_declaration" : "public static func ??(left: Result<Value, Error>, right: @autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.parsed_scope.end" : 146,
+            "key.parsed_scope.start" : 144,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:6ResultAAO2qqoiyxAByxq_G_xyXKtFZ\">?? (_: Result&lt;Value, Error&gt;, _: @autoclosure () -&gt; Value) -&gt; Value<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2qqoiyxxSg_xyKXKtKlF\">?? &lt;T&gt;(_: T?, _: @autoclosure () throws -&gt; T) rethrows -&gt; T<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:s2qqoiyxSgAB_AByKXKtKlF\">?? &lt;T&gt;(_: T?, _: @autoclosure () throws -&gt; T?) rethrows -&gt; T?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Value, Error where Error : Error> (Result<Value, Error>.Type) -> (Result<Value, Error>, @autoclosure () -> Result<Value, Error>) -> Result<Value, Error>",
+            "key.typeusr" : "$Sy6ResultAAOyxq_GAC_ACyXKtcD",
+            "key.usr" : "s:6ResultAAO2qqoiyAByxq_GAD_ADyXKtFZ"
+          }
+        ],
+        "key.typename" : "Result<Value, Error>.Type",
+        "key.typeusr" : "$S6ResultAAOyxq_GmD",
+        "key.usr" : "s:6ResultAAO"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 25,
+        "key.name" : "MARK: - migration support",
+        "key.namelength" : 0,
+        "key.nameoffset" : 0,
+        "key.offset" : 5295
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 5378
+          },
+          {
+            "key.attribute" : "source.decl.attribute.available",
+            "key.length" : 55,
+            "key.offset" : 5322
+          }
+        ],
+        "key.bodylength" : 0,
+        "key.bodyoffset" : 5438,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 5420
+          }
+        ],
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ErrorConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 54,
+        "key.name" : "ErrorProtocolConvertible",
+        "key.namelength" : 24,
+        "key.nameoffset" : 5394,
+        "key.offset" : 5385,
+        "key.runtime_name" : "_TtP4main24ErrorProtocolConvertible_"
+      }
+    ]
+  }
+}]

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -29,6 +29,13 @@ class ModuleTests: XCTestCase {
         let commandantModule = Module(xcodeBuildArguments: arguments, name: nil, inPath: commandantPath)!
         compareJSONString(withFixtureNamed: "Commandant", jsonString: commandantModule.docs, rootDirectory: commandantPath)
     }
+
+    func testCommandantResultDocs() {
+        let commandantPath = projectRoot + "/Carthage/Checkouts/Commandant/"
+        let arguments = ["-workspace", "Commandant.xcworkspace", "-scheme", "Result-tvOS", "test"]
+        let commandantModule = Module(xcodeBuildArguments: arguments, name: nil, inPath: commandantPath)!
+        compareJSONString(withFixtureNamed: "CommandantResultTVOS", jsonString: commandantModule.docs, rootDirectory: commandantPath)
+    }
 }
 
 #if SWIFT_PACKAGE

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		141E31572221C9870037E200 /* XcodeBuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E31562221C9870037E200 /* XcodeBuildSetting.swift */; };
 		182F385020753FAD0054F063 /* SwiftDeclarationAttributeKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F384F20753FAD0054F063 /* SwiftDeclarationAttributeKind.swift */; };
 		2C55B3321BEB3CA7002E8C6B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; };
 		2C55B3331BEB3CAB002E8C6B /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; };
@@ -135,6 +136,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		141E31562221C9870037E200 /* XcodeBuildSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeBuildSetting.swift; sourceTree = "<group>"; };
 		182F384F20753FAD0054F063 /* SwiftDeclarationAttributeKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDeclarationAttributeKind.swift; sourceTree = "<group>"; };
 		2ED279151C61E2A100084460 /* StatementKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementKind.swift; sourceTree = "<group>"; };
 		3DEC5005206F7F180097835E /* ModuleInfoCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleInfoCommand.swift; sourceTree = "<group>"; };
@@ -432,11 +434,11 @@
 				E84763691A5A0651000EAE22 /* File.swift */,
 				3F56EACF1BAB251C006433D0 /* JSONOutput.swift */,
 				E8A18A3A1A58971D000362B7 /* Language.swift */,
-				6C4CF5741C78B47F008532C5 /* library_wrapper.swift */,
 				6C4CF6481C79802A008532C5 /* library_wrapper_CXString.swift */,
 				6C4CF6491C79802A008532C5 /* library_wrapper_Documentation.swift */,
 				6C4CF6471C79802A008532C5 /* library_wrapper_Index.swift */,
 				6C4CF5721C78B47F008532C5 /* library_wrapper_sourcekitd.swift */,
+				6C4CF5741C78B47F008532C5 /* library_wrapper.swift */,
 				E82882531DAEEDD1002E0564 /* LinuxCompatibility.swift */,
 				E8241CA41A5E01A10047687E /* Module.swift */,
 				E877D9261B5693E70095BB2B /* ObjCDeclarationKind.swift */,
@@ -447,13 +449,13 @@
 				6CC1639A202AA3AE0086C459 /* SourceKitObject.swift */,
 				D0D1217119E87B05005E4BAA /* SourceKittenFramework.h */,
 				E806D28C1BE0589B00D1BE41 /* SourceLocation.swift */,
+				2ED279151C61E2A100084460 /* StatementKind.swift */,
 				E8AE53C61A5B5FCA0092D24A /* String+SourceKitten.swift */,
 				E834740E1A593B5B00532B9A /* Structure.swift */,
-				E89291A81A5B800300D91568 /* SwiftDeclarationKind.swift */,
 				182F384F20753FAD0054F063 /* SwiftDeclarationAttributeKind.swift */,
+				E89291A81A5B800300D91568 /* SwiftDeclarationKind.swift */,
 				E89291A61A5B7FF800D91568 /* SwiftDocKey.swift */,
 				E8A18A3E1A592246000362B7 /* SwiftDocs.swift */,
-				2ED279151C61E2A100084460 /* StatementKind.swift */,
 				E80F23681A5CB01A00FD2352 /* SyntaxKind.swift */,
 				E8CC8A2C1A587FD300D1FEC7 /* SyntaxMap.swift */,
 				E80F236A1A5CB04100FD2352 /* SyntaxToken.swift */,
@@ -461,6 +463,7 @@
 				6CC1639B202AA3AE0086C459 /* UID.swift */,
 				6CC381621ECACB50000C6F81 /* Version.swift */,
 				E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */,
+				141E31562221C9870037E200 /* XcodeBuildSetting.swift */,
 			);
 			name = SourceKittenFramework;
 			path = Source/SourceKittenFramework;
@@ -715,6 +718,7 @@
 				E806D28F1BE058B100D1BE41 /* Text.swift in Sources */,
 				6CC1639C202AA3AF0086C459 /* SourceKitObject.swift in Sources */,
 				E8241CA51A5E01A10047687E /* Module.swift in Sources */,
+				141E31572221C9870037E200 /* XcodeBuildSetting.swift in Sources */,
 				E877D9271B5693E70095BB2B /* ObjCDeclarationKind.swift in Sources */,
 				6C4CF6521C798082008532C5 /* library_wrapper_CXString.swift in Sources */,
 				E83748C31A5BCD7900862B1B /* OffsetMap.swift in Sources */,


### PR DESCRIPTION
Carried over from https://github.com/jpsim/SourceKitten/pull/578 which I accidentally closed somehow 🤦‍♂️.

---

This PR introduces `XcodeBuildSetting`—a safer, faster alternative to using regex—& improves the module name inference in `Module`. 

The prior solution would fail to build a platform-suffixed target, like `'Result-tvOS'`, due to `moduleName(fromArguments:)`'s assumption that the target/scheme name will be equivalent to the module name. The new implementation will read the module name from the build settings. It will use, in order of priority, the value of the user-defined key `"SWIFT_MODULE_NAME"` & then `"PRODUCT_MODULE_NAME"`. If this fails for whatever reason, it will use `moduleName(fromArguments:)`.