### PR TITLE
Include parsed extension declarations in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Add parsed extension declarations to Swift docs.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -371,29 +371,17 @@ public final class File {
     }
 
     /**
-    Returns true if path is nil or if path has the same last path component as `key.filepath` in the
-    input dictionary.
-
-    - parameter dictionary: Dictionary to parse.
-    */
-    internal func shouldTreatAsSameFile(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
-        return path == SwiftDocKey.getFilePath(dictionary)
-    }
-
-    /**
     Returns true if the input dictionary contains a parseable declaration.
 
     - parameter dictionary: Dictionary to parse.
     */
     private func shouldParseDeclaration(_ dictionary: [String: SourceKitRepresentable]) -> Bool {
         // swiftlint:disable operator_usage_whitespace
-        let sameFile                = shouldTreatAsSameFile(dictionary)
         let hasTypeName             = SwiftDocKey.getTypeName(dictionary) != nil
         let hasAnnotatedDeclaration = SwiftDocKey.getAnnotatedDeclaration(dictionary) != nil
         let hasOffset               = SwiftDocKey.getOffset(dictionary) != nil
-        let isntExtension           = SwiftDocKey.getKind(dictionary) != SwiftDeclarationKind.extension.rawValue
         // swiftlint:enable operator_usage_whitespace
-        return sameFile && hasTypeName && hasAnnotatedDeclaration && hasOffset && isntExtension
+        return hasTypeName && hasAnnotatedDeclaration && hasOffset
     }
 
     /**

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-4.2.json
@@ -282,6 +282,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -349,6 +352,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -424,6 +430,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -857,6 +866,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1569,6 +1581,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1856,6 +1871,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2005,6 +2023,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2112,6 +2133,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3036,6 +3060,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3518,6 +3545,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5973,6 +6003,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6253,6 +6286,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7094,6 +7130,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7587,6 +7626,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-5.0.json
@@ -283,6 +283,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -351,6 +354,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -427,6 +433,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -861,6 +870,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1574,6 +1586,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1862,6 +1877,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2012,6 +2030,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2120,6 +2141,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3045,6 +3069,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3528,6 +3555,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5969,6 +5999,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6250,6 +6283,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7092,6 +7128,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7586,6 +7625,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-4.2.json
@@ -156,6 +156,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 379,
         "key.offset" : 369,
+        "key.parsed_declaration" : "extension AnyError: ErrorConvertible",
+        "key.parsed_scope.end" : 22,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -233,6 +236,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 508,
         "key.offset" : 498,
+        "key.parsed_declaration" : "extension AnyError: CustomStringConvertible",
+        "key.parsed_scope.end" : 28,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -317,6 +323,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 629,
         "key.offset" : 619,
+        "key.parsed_declaration" : "extension AnyError: LocalizedError",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 30,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2041,6 +2050,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4937,
         "key.offset" : 4927,
+        "key.parsed_declaration" : "extension Result where Result.Failure == AnyError",
+        "key.parsed_scope.end" : 165,
+        "key.parsed_scope.start" : 151,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2327,6 +2339,9 @@
         "key.namelength" : 7,
         "key.nameoffset" : 5821,
         "key.offset" : 5811,
+        "key.parsed_declaration" : "extension NSError: ErrorConvertible",
+        "key.parsed_scope.end" : 189,
+        "key.parsed_scope.start" : 181,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2771,6 +2786,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 317,
         "key.offset" : 307,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 70,
+        "key.parsed_scope.start" : 14,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3228,6 +3246,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2585,
         "key.offset" : 2575,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 88,
+        "key.parsed_scope.start" : 72,
         "key.substructure" : [
           {
             "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
@@ -3424,6 +3445,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 3317,
         "key.offset" : 3307,
+        "key.parsed_declaration" : "extension Result where Result.Failure: ErrorConvertible",
+        "key.parsed_scope.end" : 110,
+        "key.parsed_scope.start" : 95,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3513,6 +3537,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 3878,
         "key.offset" : 3868,
+        "key.parsed_declaration" : "extension Result where Result.Success: Equatable, Result.Failure: Equatable",
+        "key.parsed_scope.end" : 124,
+        "key.parsed_scope.start" : 114,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3810,6 +3837,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4416,
         "key.offset" : 4406,
+        "key.parsed_declaration" : "extension Result: Equatable where Result.Success: Equatable, Result.Failure: Equatable",
+        "key.parsed_scope.end" : 127,
+        "key.parsed_scope.start" : 127,
         "key.typename" : "Result<Value, Error>.Type",
         "key.typeusr" : "$S6ResultAAOyxq_GmD",
         "key.usr" : "s:6ResultAAO"
@@ -3834,6 +3864,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4852,
         "key.offset" : 4842,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 147,
+        "key.parsed_scope.start" : 137,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantResultTVOS@swift-5.0.json
@@ -157,6 +157,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 379,
         "key.offset" : 369,
+        "key.parsed_declaration" : "extension AnyError: ErrorConvertible",
+        "key.parsed_scope.end" : 22,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -235,6 +238,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 508,
         "key.offset" : 498,
+        "key.parsed_declaration" : "extension AnyError: CustomStringConvertible",
+        "key.parsed_scope.end" : 28,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -320,6 +326,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 629,
         "key.offset" : 619,
+        "key.parsed_declaration" : "extension AnyError: LocalizedError",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 30,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2044,6 +2053,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4937,
         "key.offset" : 4927,
+        "key.parsed_declaration" : "extension Result where Result.Failure == AnyError",
+        "key.parsed_scope.end" : 165,
+        "key.parsed_scope.start" : 151,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2331,6 +2343,9 @@
         "key.namelength" : 7,
         "key.nameoffset" : 5821,
         "key.offset" : 5811,
+        "key.parsed_declaration" : "extension NSError: ErrorConvertible",
+        "key.parsed_scope.end" : 189,
+        "key.parsed_scope.start" : 181,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2776,6 +2791,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 317,
         "key.offset" : 307,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 70,
+        "key.parsed_scope.start" : 14,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3234,6 +3252,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2585,
         "key.offset" : 2575,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 88,
+        "key.parsed_scope.start" : 72,
         "key.substructure" : [
           {
             "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
@@ -3431,6 +3452,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 3317,
         "key.offset" : 3307,
+        "key.parsed_declaration" : "extension Result where Result.Failure: ErrorConvertible",
+        "key.parsed_scope.end" : 110,
+        "key.parsed_scope.start" : 95,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3521,6 +3545,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 3878,
         "key.offset" : 3868,
+        "key.parsed_declaration" : "extension Result where Result.Success: Equatable, Result.Failure: Equatable",
+        "key.parsed_scope.end" : 124,
+        "key.parsed_scope.start" : 114,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3828,6 +3855,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4416,
         "key.offset" : 4406,
+        "key.parsed_declaration" : "extension Result: Equatable where Result.Success: Equatable, Result.Failure: Equatable",
+        "key.parsed_scope.end" : 127,
+        "key.parsed_scope.start" : 127,
         "key.typename" : "Result<Value, Error>.Type",
         "key.typeusr" : "$s6ResultAAOyxq_GmD",
         "key.usr" : "s:6ResultAAO"
@@ -3890,6 +3920,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 4852,
         "key.offset" : 4842,
+        "key.parsed_declaration" : "extension Result",
+        "key.parsed_scope.end" : 147,
+        "key.parsed_scope.start" : 137,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-4.2.json
@@ -282,6 +282,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -349,6 +352,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -424,6 +430,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -857,6 +866,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1569,6 +1581,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1856,6 +1871,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2005,6 +2023,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2112,6 +2133,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3036,6 +3060,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3518,6 +3545,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5973,6 +6003,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6253,6 +6286,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7094,6 +7130,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7587,6 +7626,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-5.0.json
@@ -283,6 +283,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -351,6 +354,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -427,6 +433,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -861,6 +870,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1574,6 +1586,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1862,6 +1877,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2012,6 +2030,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2120,6 +2141,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3045,6 +3069,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3528,6 +3555,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5969,6 +5999,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6250,6 +6283,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7092,6 +7128,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7586,6 +7625,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Extension@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Extension@swift-4.2.json
@@ -147,6 +147,9 @@
         "key.namelength" : 4,
         "key.nameoffset" : 208,
         "key.offset" : 198,
+        "key.parsed_declaration" : "extension Base",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 16,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -233,6 +236,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 423,
         "key.offset" : 413,
+        "key.parsed_declaration" : "extension Base.Nested",
+        "key.parsed_scope.end" : 29,
+        "key.parsed_scope.start" : 28,
         "key.typename" : "Base.Nested.Type",
         "key.typeusr" : "$S9Extension4BaseC6NestedCmD",
         "key.usr" : "s:9Extension4BaseC6NestedC"
@@ -292,6 +298,9 @@
         "key.namelength" : 9,
         "key.nameoffset" : 490,
         "key.offset" : 480,
+        "key.parsed_declaration" : "extension 🐽.🐧",
+        "key.parsed_scope.end" : 37,
+        "key.parsed_scope.start" : 36,
         "key.typename" : "🐽.🐧.Type",
         "key.typeusr" : "$S9Extension004ipIhC004voIhVmD",
         "key.usr" : "s:9Extension004ipIhC004voIhV"

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Extension@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Extension@swift-5.0.json
@@ -148,6 +148,9 @@
         "key.namelength" : 4,
         "key.nameoffset" : 208,
         "key.offset" : 198,
+        "key.parsed_declaration" : "extension Base",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 16,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -235,6 +238,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 423,
         "key.offset" : 413,
+        "key.parsed_declaration" : "extension Base.Nested",
+        "key.parsed_scope.end" : 29,
+        "key.parsed_scope.start" : 28,
         "key.typename" : "Base.Nested.Type",
         "key.typeusr" : "$s9Extension4BaseC6NestedCmD",
         "key.usr" : "s:9Extension4BaseC6NestedC"
@@ -295,6 +301,9 @@
         "key.namelength" : 9,
         "key.nameoffset" : 490,
         "key.offset" : 480,
+        "key.parsed_declaration" : "extension 🐽.🐧",
+        "key.parsed_scope.end" : 37,
+        "key.parsed_scope.start" : 36,
         "key.typename" : "🐽.🐧.Type",
         "key.typeusr" : "$s9Extension004ipIhC004voIhVmD",
         "key.usr" : "s:9Extension004ipIhC004voIhV"

--- a/Tests/SourceKittenFrameworkTests/Fixtures/LinuxBicycle@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/LinuxBicycle@swift-4.2.json
@@ -32,6 +32,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 151,
         "key.offset" : 141,
+        "key.parsed_declaration" : "public extension NSString",
+        "key.parsed_scope.end" : 5,
+        "key.parsed_scope.start" : 5,
         "key.typename" : "NSString.Type",
         "key.typeusr" : "$S10Foundation8NSStringCmD",
         "key.usr" : "s:10Foundation8NSStringC"

--- a/Tests/SourceKittenFrameworkTests/Fixtures/LinuxBicycle@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/LinuxBicycle@swift-5.0.json
@@ -32,6 +32,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 151,
         "key.offset" : 141,
+        "key.parsed_declaration" : "public extension NSString",
+        "key.parsed_scope.end" : 5,
+        "key.parsed_scope.start" : 5,
         "key.typename" : "NSString.Type",
         "key.typeusr" : "$s10Foundation8NSStringCmD",
         "key.usr" : "s:10Foundation8NSStringC"

--- a/Tests/SourceKittenFrameworkTests/Fixtures/LinuxCommandantSPM@swift-4.2.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/LinuxCommandantSPM@swift-4.2.json
@@ -282,6 +282,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -349,6 +352,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -424,6 +430,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -857,6 +866,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1569,6 +1581,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1856,6 +1871,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2005,6 +2023,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2112,6 +2133,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3036,6 +3060,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3518,6 +3545,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5973,6 +6003,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6253,6 +6286,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7094,6 +7130,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7587,6 +7626,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/LinuxCommandantSPM@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/LinuxCommandantSPM@swift-5.0.json
@@ -283,6 +283,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1288,
         "key.offset" : 1278,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -351,6 +354,9 @@
         "key.namelength" : 8,
         "key.nameoffset" : 1562,
         "key.offset" : 1552,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 54,
+        "key.parsed_scope.start" : 48,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -427,6 +433,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1879,
         "key.offset" : 1869,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 122,
+        "key.parsed_scope.start" : 58,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -861,6 +870,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 589,
         "key.offset" : 579,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 25,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
@@ -1574,6 +1586,9 @@
         "key.namelength" : 3,
         "key.nameoffset" : 455,
         "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -1862,6 +1877,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 604,
         "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2012,6 +2030,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 753,
         "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -2120,6 +2141,9 @@
         "key.namelength" : 16,
         "key.nameoffset" : 951,
         "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3045,6 +3069,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 3443,
         "key.offset" : 3433,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 242,
+        "key.parsed_scope.start" : 119,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -3528,6 +3555,9 @@
         "key.namelength" : 15,
         "key.nameoffset" : 556,
         "key.offset" : 546,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 24,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -5969,6 +5999,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 2826,
         "key.offset" : 2816,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 85,
+        "key.parsed_scope.start" : 81,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -6250,6 +6283,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 5351,
         "key.offset" : 5341,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 274,
+        "key.parsed_scope.start" : 148,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7092,6 +7128,9 @@
         "key.namelength" : 10,
         "key.nameoffset" : 443,
         "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
@@ -7586,6 +7625,9 @@
         "key.namelength" : 6,
         "key.nameoffset" : 1149,
         "key.offset" : 1139,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 46,
+        "key.parsed_scope.start" : 38,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",
@@ -7684,6 +7726,9 @@
         "key.namelength" : 11,
         "key.nameoffset" : 1357,
         "key.offset" : 1347,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 69,
+        "key.parsed_scope.start" : 50,
         "key.substructure" : [
           {
             "key.accessibility" : "source.lang.swift.accessibility.public",


### PR DESCRIPTION
This populates `parsed_declaration` for `extension` declarations.

This is the simplest way I've found to get the actual extension declaration along with any constraints - the cursor-info declarations give us info about the _extended_ type.

Peering back through file history these may have been originally excluded due to overwriting fields from doc-structure with incorrect ones from cursor-info, which was since fixed.  Or there could have been SourceKit bugs now fixed.  At any rate, this version looks to work well for the fixtures here and various jazzy projects.