### PR TITLE
Make `File` conform to `Equatable` and `Hashable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Add parsed extension declarations to Swift docs.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Make `File` conform to `Equatable` and `Hashable`.  
+  [Elliott Williams](https://github.com/elliottwilliams)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SourceKittenFramework/File+Hashable.swift
+++ b/Source/SourceKittenFramework/File+Hashable.swift
@@ -1,0 +1,24 @@
+//
+//  File+Hashable.swift
+//  SourceKitten
+//
+//  Created by JP Simard on 2019-05-12.
+//  Copyright (c) 2019 SourceKitten. All rights reserved.
+//
+
+extension File: Hashable {
+    public static func == (lhs: File, rhs: File) -> Bool {
+        switch (lhs.path, rhs.path) {
+        case let (.some(lhsPath), .some(rhsPath)):
+            return lhsPath == rhsPath
+        case (.none, .none):
+            return lhs.contents == rhs.contents
+        default:
+            return false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(path ?? contents)
+    }
+}

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		6CCFCE8C1CFECFF1003239EB /* Yams.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E80678041CF2749300AFC816 /* Yams.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6CCFCE8E1CFED000003239EB /* Commandant.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6CCFCE901CFED005003239EB /* Result.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8F935B342288C05A00971070 /* File+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F935B332288C05A00971070 /* File+Hashable.swift */; };
 		C236E84B1DFF5120003807D2 /* YamlRequestCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */; };
 		CDB51F33203E2899007563AE /* SwiftDocKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */; };
 		D0AAAB5019FB0960007B24B3 /* SourceKittenFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D1216D19E87B05005E4BAA /* SourceKittenFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -156,6 +157,7 @@
 		6CC1639A202AA3AE0086C459 /* SourceKitObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceKitObject.swift; sourceTree = "<group>"; };
 		6CC1639B202AA3AE0086C459 /* UID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UID.swift; sourceTree = "<group>"; };
 		6CC381621ECACB50000C6F81 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		8F935B332288C05A00971070 /* File+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "File+Hashable.swift"; sourceTree = "<group>"; };
 		C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlRequestCommand.swift; sourceTree = "<group>"; };
 		CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocKeyTests.swift; sourceTree = "<group>"; };
 		D0D1211B19E87861005E4BAA /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; usesTabs = 0; };
@@ -432,6 +434,7 @@
 				E852418E1A5F4FB3007099FB /* Dictionary+Merge.swift */,
 				E806D2921BE058D600D1BE41 /* Documentation.swift */,
 				E84763691A5A0651000EAE22 /* File.swift */,
+				8F935B332288C05A00971070 /* File+Hashable.swift */,
 				3F56EACF1BAB251C006433D0 /* JSONOutput.swift */,
 				E8A18A3A1A58971D000362B7 /* Language.swift */,
 				6C4CF6481C79802A008532C5 /* library_wrapper_CXString.swift */,
@@ -634,6 +637,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -714,6 +718,7 @@
 				E847636A1A5A0651000EAE22 /* File.swift in Sources */,
 				6C4CF5771C78B47F008532C5 /* library_wrapper.swift in Sources */,
 				3F56EAD01BAB251C006433D0 /* JSONOutput.swift in Sources */,
+				8F935B342288C05A00971070 /* File+Hashable.swift in Sources */,
 				E8A18A3B1A58971D000362B7 /* Language.swift in Sources */,
 				E806D28F1BE058B100D1BE41 /* Text.swift in Sources */,
 				6CC1639C202AA3AF0086C459 /* SourceKitObject.swift in Sources */,


### PR DESCRIPTION
Implemented pulled verbatim from https://github.com/realm/SwiftLint/pull/2714, since it was correct right off the bat!