### PR TITLE
Change `Module.init?(spmName:)` to `Module.init?(spmName:inPath:)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ##### Breaking
 
-* None.
+* Change `Module.init?(spmName:)` to `Module.init?(spmName:inPath:)`.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ##### Enhancements
 
@@ -10,7 +11,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix `testCommandantDocsSPM` failed on using Swift Package in Xcode 11, because
+  Xcode 11 does not use `SRCROOT` as current directory on executing tests in
+  `Package.swift`.  
+  [Norio Nomura](https://github.com/norio-nomura)
 
 ## 0.23.2
 

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -34,8 +34,8 @@ public struct Module {
         }
     }
 
-    public init?(spmName: String) {
-        let yamlPath = ".build/debug.yaml"
+    public init?(spmName: String, inPath path: String = FileManager.default.currentDirectoryPath) {
+        let yamlPath = URL(fileURLWithPath: path).appendingPathComponent(".build/debug.yaml").path
         guard let yaml = try? Yams.compose(yaml: String(contentsOfFile: yamlPath, encoding: .utf8)),
             let commands = (yaml as Node?)?["commands"]?.mapping?.values else {
             fatalError("SPM build manifest does not exist at `\(yamlPath)` or does not match expected format.")

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -100,7 +100,7 @@ extension ModuleTests {
             XCTFail("Can't find Commandant")
             return
         }
-        let commandantModule = Module(spmName: "Commandant")!
+        let commandantModule = Module(spmName: "Commandant", inPath: projectRoot)!
         compareJSONString(withFixtureNamed: "CommandantSPM", jsonString: commandantModule.docs, rootDirectory: commandantPath)
     }
 


### PR DESCRIPTION
It is required for Xcode 11, because Xcode 11 does not use `SRCROOT` as current directory on executing tests
  in `Package.swift`.
I got an answer from apple that this Xcode 11's behavior is expected. (FB6115942)