### PR TITLE
Fix crash with raw strings in Swift 5.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix crash in `NSString.location(fromByteOffset:)` when run on strings
+  containing raw string literals in Swift 5.0 or later.  
+  [JP Simard](https://github.com/jpsim)
+  [realm/SwiftLint#2793](https://github.com/realm/SwiftLint/issues/2793)
 
 ## 0.23.2
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -145,7 +145,7 @@ extension NSString {
         - returns: UTF16 based offset of string.
         */
         func location(fromByteOffset byteOffset: Int) -> Int {
-            if lines.isEmpty {
+            guard let lastLine = lines.last else {
                 return 0
             }
             let index = lines.indexAssumingSorted { line in
@@ -157,13 +157,11 @@ extension NSString {
                 return .orderedSame
             }
             // byteOffset may be out of bounds when sourcekitd points end of string.
-            guard let line = (index.map { lines[$0] } ?? lines.last) else {
-                fatalError()
-            }
+            let line = index.map { lines[$0] } ?? lastLine
             let diff = byteOffset - line.byteRange.location
             if diff == 0 {
                 return line.range.location
-            } else if line.byteRange.length == diff {
+            } else if line.byteRange.length <= diff {
                 return NSMaxRange(line.range)
             }
             let utf8View = line.content.utf8


### PR DESCRIPTION
Fix crash in `NSString.location(fromByteOffset:)` when run on strings containing raw string literals in Swift 5.0 or later. https://github.com/realm/SwiftLint/issues/2793