### PR TITLE
Refactor SourceKitObject to release memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
   [Norio Nomura](https://github.com/norio-nomura)
 
 * `SourceKitObjectConvertible` now has `SourceKitObject` parameter requirement
-  instead of `sourcekitd_object_t`. SourceKitObject isn't publically
+  instead of `sourcekitd_object_t`. SourceKitObject isn't publicly
   initializable (this helps memory management).  
   [Colton Schlosser](https://github.com/cltnschlosser)
 
-* `Dictionary` and `Array` now has conditional conformance on
+* `Dictionary` and `Array` now conditionally conform to
   `SourceKitObjectConvertible`, instead of crashing when using
   unexpected types.  
   [Colton Schlosser](https://github.com/cltnschlosser)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * Change `Module.init?(spmName:)` to `Module.init?(spmName:inPath:)`.  
   [Norio Nomura](https://github.com/norio-nomura)
 
+* `SourceKitObjectConvertible` now has `SourceKitObject` parameter requirement
+  instead of `sourcekitd_object_t`. SourceKitObject isn't publically
+  initializable (this helps memory management).  
+  [Colton Schlosser](https://github.com/cltnschlosser)
+
+* `Dictionary` and `Array` now has conditional conformance on
+  `SourceKitObjectConvertible`, instead of crashing when using
+  unexpected types.  
+  [Colton Schlosser](https://github.com/cltnschlosser)
+
 ##### Enhancements
 
 * None.
@@ -15,6 +25,9 @@
   Xcode 11 does not use `SRCROOT` as current directory on executing tests in
   `Package.swift`.  
   [Norio Nomura](https://github.com/norio-nomura)
+
+* Release memory created for sourcekitd requests.  
+  [Colton Schlosser](https://github.com/cltnschlosser)
 
 ## 0.23.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 * Release memory created for sourcekitd requests.  
   [Colton Schlosser](https://github.com/cltnschlosser)
+  [realm/SwiftLint#2812](https://github.com/realm/SwiftLint/issues/2812)
 
 ## 0.23.2
 

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -203,7 +203,7 @@ public enum Request {
         case let .customRequest(request):
             return request
         case let .yamlRequest(yaml):
-            return .init(sourcekitd_request_create_from_yaml(yaml, nil)!)
+            return SourceKitObject(yaml: yaml)
         case let .codeCompletionRequest(file, contents, offset, arguments):
             return [
                 "key.request": UID("source.request.codecomplete"),
@@ -342,7 +342,7 @@ public enum Request {
     */
     public func send() throws -> [String: SourceKitRepresentable] {
         initializeSourceKitFailable
-        let response = sourcekitd_send_request_sync(sourcekitObject.sourcekitdObject!)
+        let response = sourcekitObject.sendSync()
         defer { sourcekitd_response_dispose(response!) }
         if sourcekitd_response_is_error(response!) {
             let error = Request.Error(response: response!)

--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -63,10 +63,10 @@ extension UID: SourceKitObjectConvertible {
 /// Swift representation of sourcekitd_object_t
 public final class SourceKitObject {
     fileprivate let sourcekitdObject: sourcekitd_object_t
-    
+
     /// Other SourceKitObjects whose lifetime is tied to this one (ex: array elements, dictionary values)
     private let children: [SourceKitObject?]
-    
+
     init(yaml: String) {
         self.sourcekitdObject = sourcekitd_request_create_from_yaml(yaml, nil)!
         self.children = []
@@ -76,7 +76,7 @@ public final class SourceKitObject {
         self.sourcekitdObject = sourcekitdObject
         self.children = children
     }
-    
+
     deinit {
         sourcekitd_request_release(sourcekitdObject)
     }
@@ -100,7 +100,7 @@ public final class SourceKitObject {
     public func updateValue<T>(_ value: SourceKitObjectConvertible, forKey key: T) where T: RawRepresentable, T.RawValue == String {
         updateValue(value, forKey: UID(key.rawValue))
     }
-    
+
     /// Swift wrapper for sourcekitd_send_request_sync
     /// Must call sourcekitd_response_dispose on the resulting object.
     func sendSync() -> sourcekitd_response_t? {

--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -28,7 +28,7 @@ extension Array: SourceKitObjectConvertible where Element: SourceKitObjectConver
 extension Dictionary: SourceKitObjectConvertible where Key: UIDRepresentable, Value: SourceKitObjectConvertible {
     public var sourceKitObject: SourceKitObject? {
         let keys: [sourcekitd_uid_t?] = self.keys.map { $0.uid.sourcekitdUID }
-        let children = values.map { $0.sourceKitObject }
+        let children = self.values.map { $0.sourceKitObject }
         let values = children.map { $0?.sourcekitdObject }
         return sourcekitd_request_dictionary_create(keys, values, count).map { SourceKitObject($0, children: children) }
     }

--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -14,63 +14,71 @@ import SourceKit
 // MARK: - SourceKitObjectConvertible
 
 public protocol SourceKitObjectConvertible {
-    var sourcekitdObject: sourcekitd_object_t? { get }
+    var sourceKitObject: SourceKitObject? { get }
 }
 
-extension Array: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        guard Element.self is SourceKitObjectConvertible.Type else {
-            fatalError("Array conforms to SourceKitObjectConvertible when Elements is SourceKitObjectConvertible!")
-        }
-        let objects: [sourcekitd_object_t?] = map { ($0 as! SourceKitObjectConvertible).sourcekitdObject }
-        return sourcekitd_request_array_create(objects, objects.count)
+extension Array: SourceKitObjectConvertible where Element: SourceKitObjectConvertible {
+    public var sourceKitObject: SourceKitObject? {
+        let children = map { $0.sourceKitObject }
+        let objects = children.map { $0?.sourcekitdObject }
+        return sourcekitd_request_array_create(objects, objects.count).map { SourceKitObject($0, children: children) }
     }
 }
 
-extension Dictionary: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        let keys: [sourcekitd_uid_t?]
-        if Key.self is UID.Type {
-            keys = self.keys.map { ($0 as! UID).uid }
-        } else if Key.self is String.Type {
-            keys = self.keys.map { UID($0 as! String).uid }
-        } else {
-            fatalError("Dictionary conforms to SourceKitObjectConvertible when `Key` is `UID` or `String`!")
-        }
-        guard Value.self is SourceKitObjectConvertible.Type else {
-            fatalError("Dictionary conforms to SourceKitObjectConvertible when `Value` is `SourceKitObjectConvertible`!")
-        }
-        let values: [sourcekitd_object_t?] = self.map { ($0.value as! SourceKitObjectConvertible).sourcekitdObject }
-        return sourcekitd_request_dictionary_create(keys, values, count)
+extension Dictionary: SourceKitObjectConvertible where Key: UIDRepresentable, Value: SourceKitObjectConvertible {
+    public var sourceKitObject: SourceKitObject? {
+        let keys: [sourcekitd_uid_t?] = self.keys.map { $0.uid.sourcekitdUID }
+        let children = values.map { $0.sourceKitObject }
+        let values = children.map { $0?.sourcekitdObject }
+        return sourcekitd_request_dictionary_create(keys, values, count).map { SourceKitObject($0, children: children) }
     }
 }
 
 extension Int: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        return sourcekitd_request_int64_create(Int64(self))
+    public var sourceKitObject: SourceKitObject? {
+        return Int64(self).sourceKitObject
     }
 }
 
 extension Int64: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        return sourcekitd_request_int64_create(self)
+    public var sourceKitObject: SourceKitObject? {
+        return sourcekitd_request_int64_create(self).map { SourceKitObject($0) }
     }
 }
 
 extension String: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        return sourcekitd_request_string_create(self)
+    public var sourceKitObject: SourceKitObject? {
+        return sourcekitd_request_string_create(self).map { SourceKitObject($0) }
+    }
+}
+
+extension UID: SourceKitObjectConvertible {
+    public var sourceKitObject: SourceKitObject? {
+        return sourcekitd_request_uid_create(sourcekitdUID).map { SourceKitObject($0) }
     }
 }
 
 // MARK: - SourceKitObject
 
 /// Swift representation of sourcekitd_object_t
-public struct SourceKitObject {
-    public let sourcekitdObject: sourcekitd_object_t?
+public final class SourceKitObject {
+    fileprivate let sourcekitdObject: sourcekitd_object_t
+    
+    /// Other SourceKitObjects whose lifetime is tied to this one (ex: array elements, dictionary values)
+    private let children: [SourceKitObject?]
+    
+    init(yaml: String) {
+        self.sourcekitdObject = sourcekitd_request_create_from_yaml(yaml, nil)!
+        self.children = []
+    }
 
-    public init(_ sourcekitdObject: sourcekitd_object_t) {
+    fileprivate init(_ sourcekitdObject: sourcekitd_object_t, children: [SourceKitObject?] = []) {
         self.sourcekitdObject = sourcekitdObject
+        self.children = children
+    }
+    
+    deinit {
+        sourcekitd_request_release(sourcekitdObject)
     }
 
     /// Updates the value stored in the dictionary for the given key,
@@ -81,9 +89,8 @@ public struct SourceKitObject {
     ///   - key: The key to associate with value. If key already exists in the dictionary, 
     ///     value replaces the existing associated value. If key isn't already a key of the dictionary
     public func updateValue(_ value: SourceKitObjectConvertible, forKey key: UID) {
-        precondition(sourcekitdObject != nil)
-        precondition(value.sourcekitdObject != nil)
-        sourcekitd_request_dictionary_set_value(sourcekitdObject!, key.uid, value.sourcekitdObject!)
+        precondition(value.sourceKitObject != nil)
+        sourcekitd_request_dictionary_set_value(sourcekitdObject, key.sourcekitdUID, value.sourceKitObject!.sourcekitdObject)
     }
 
     public func updateValue(_ value: SourceKitObjectConvertible, forKey key: String) {
@@ -93,41 +100,52 @@ public struct SourceKitObject {
     public func updateValue<T>(_ value: SourceKitObjectConvertible, forKey key: T) where T: RawRepresentable, T.RawValue == String {
         updateValue(value, forKey: UID(key.rawValue))
     }
+    
+    /// Swift wrapper for sourcekitd_send_request_sync
+    /// Must call sourcekitd_response_dispose on the resulting object.
+    func sendSync() -> sourcekitd_response_t? {
+        return sourcekitd_send_request_sync(sourcekitdObject)
+    }
 }
 
-extension SourceKitObject: SourceKitObjectConvertible {}
+extension SourceKitObject: SourceKitObjectConvertible {
+    public var sourceKitObject: SourceKitObject? {
+        return self
+    }
+}
 
 extension SourceKitObject: CustomStringConvertible {
     public var description: String {
-        guard let object = sourcekitdObject else { return "" }
-        let bytes = sourcekitd_request_description_copy(object)!
+        let bytes = sourcekitd_request_description_copy(sourcekitdObject)!
         let length = Int(strlen(bytes))
         return String(bytesNoCopy: bytes, length: length, encoding: .utf8, freeWhenDone: true)!
     }
 }
 
 extension SourceKitObject: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: SourceKitObject...) {
-        sourcekitdObject = elements.sourcekitdObject
+    public convenience init(arrayLiteral elements: SourceKitObject...) {
+        let objects: [sourcekitd_object_t?] = elements.map { $0.sourcekitdObject }
+        self.init(sourcekitd_request_array_create(objects, objects.count)!, children: elements)
     }
 }
 
 extension SourceKitObject: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (UID, SourceKitObjectConvertible)...) {
-        let keys: [sourcekitd_uid_t?] = elements.map { $0.0.uid }
-        let values: [sourcekitd_object_t?] = elements.map { $0.1.sourcekitdObject }
-        sourcekitdObject = sourcekitd_request_dictionary_create(keys, values, elements.count)
+    public convenience init(dictionaryLiteral elements: (UID, SourceKitObjectConvertible)...) {
+        let keys: [sourcekitd_uid_t?] = elements.map { $0.0.sourcekitdUID }
+        let children = elements.map { $0.1.sourceKitObject }
+        let values: [sourcekitd_object_t?] = children.map { $0?.sourcekitdObject }
+        self.init(sourcekitd_request_dictionary_create(keys, values, elements.count)!, children: children)
     }
 }
 
 extension SourceKitObject: ExpressibleByIntegerLiteral {
-    public init(integerLiteral value: IntegerLiteralType) {
-        sourcekitdObject = value.sourcekitdObject
+    public convenience init(integerLiteral value: IntegerLiteralType) {
+        self.init(sourcekitd_request_int64_create(Int64(value))!)
     }
 }
 
 extension SourceKitObject: ExpressibleByStringLiteral {
-    public init(stringLiteral value: StringLiteralType) {
-       sourcekitdObject = value.sourcekitdObject
+    public convenience init(stringLiteral value: StringLiteralType) {
+        self.init(sourcekitd_request_string_create(value)!)
     }
 }

--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -65,7 +65,7 @@ public final class SourceKitObject {
     fileprivate let sourcekitdObject: sourcekitd_object_t
 
     /// Other SourceKitObjects whose lifetime is tied to this one (ex: array elements, dictionary values)
-    private let children: [SourceKitObject?]
+    private var children: [SourceKitObject?]
 
     init(yaml: String) {
         self.sourcekitdObject = sourcekitd_request_create_from_yaml(yaml, nil)!
@@ -90,7 +90,9 @@ public final class SourceKitObject {
     ///     value replaces the existing associated value. If key isn't already a key of the dictionary
     public func updateValue(_ value: SourceKitObjectConvertible, forKey key: UID) {
         precondition(value.sourceKitObject != nil)
-        sourcekitd_request_dictionary_set_value(sourcekitdObject, key.sourcekitdUID, value.sourceKitObject!.sourcekitdObject)
+        let sourceKitObject = value.sourceKitObject
+        children.append(sourceKitObject)
+        sourcekitd_request_dictionary_set_value(sourcekitdObject, key.sourcekitdUID, sourceKitObject!.sourcekitdObject)
     }
 
     public func updateValue(_ value: SourceKitObjectConvertible, forKey key: String) {

--- a/Source/SourceKittenFramework/UID.swift
+++ b/Source/SourceKittenFramework/UID.swift
@@ -12,9 +12,9 @@ import SourceKit
 
 /// Swift representation of sourcekitd_uid_t
 public struct UID: Hashable {
-    let uid: sourcekitd_uid_t
+    let sourcekitdUID: sourcekitd_uid_t
     init(_ uid: sourcekitd_uid_t) {
-        self.uid = uid
+        self.sourcekitdUID = uid
     }
 
     public init(_ string: String) {
@@ -26,7 +26,7 @@ public struct UID: Hashable {
     }
 
     var string: String {
-        return String(cString: sourcekitd_uid_get_string_ptr(uid)!)
+        return String(cString: sourcekitd_uid_get_string_ptr(sourcekitdUID)!)
     }
 }
 
@@ -39,11 +39,5 @@ extension UID: CustomStringConvertible {
 extension UID: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self.init(value)
-    }
-}
-
-extension UID: SourceKitObjectConvertible {
-    public var sourcekitdObject: sourcekitd_object_t? {
-        return sourcekitd_request_uid_create(uid)
     }
 }

--- a/Source/SourceKittenFramework/UIDRepresentable.swift
+++ b/Source/SourceKittenFramework/UIDRepresentable.swift
@@ -1,0 +1,23 @@
+//
+//  UIDRepresentable.swift
+//  SourceKittenFramework
+//
+//  Created by Colton Schlosser on 7/16/19.
+//  Copyright © 2019 SourceKitten. All rights reserved.
+//
+
+public protocol UIDRepresentable {
+    var uid: UID { get }
+}
+
+extension UID: UIDRepresentable {
+    public var uid: UID {
+        return self
+    }
+}
+
+extension String: UIDRepresentable {
+    public var uid: UID {
+        return UID(self)
+    }
+}

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3DEF4C591DBF9C2D00B3B54A /* DocInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEF4C581DBF9C2D00B3B54A /* DocInfoTests.swift */; };
 		3F0CBB411BAAFF160015BBA8 /* Clang+SourceKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0CBB401BAAFF160015BBA8 /* Clang+SourceKitten.swift */; };
 		3F56EAD01BAB251C006433D0 /* JSONOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56EACF1BAB251C006433D0 /* JSONOutput.swift */; };
+		55DB6A9722DEABD100666C6A /* UIDRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DB6A9622DEABD000666C6A /* UIDRepresentable.swift */; };
 		6C4CF5761C78B47F008532C5 /* library_wrapper_sourcekitd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4CF5721C78B47F008532C5 /* library_wrapper_sourcekitd.swift */; };
 		6C4CF5771C78B47F008532C5 /* library_wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4CF5741C78B47F008532C5 /* library_wrapper.swift */; };
 		6C4CF6521C798082008532C5 /* library_wrapper_CXString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4CF6481C79802A008532C5 /* library_wrapper_CXString.swift */; };
@@ -147,6 +148,7 @@
 		3F56EACF1BAB251C006433D0 /* JSONOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONOutput.swift; sourceTree = "<group>"; };
 		5499CA961A2394B700783309 /* Components.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Components.plist; sourceTree = "<group>"; };
 		5499CA971A2394B700783309 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		55DB6A9622DEABD000666C6A /* UIDRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDRepresentable.swift; sourceTree = "<group>"; };
 		6C4981EB1FE33F4500633AC8 /* Mac-XCTest.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Mac-XCTest.xcconfig"; sourceTree = "<group>"; };
 		6C4CF5721C78B47F008532C5 /* library_wrapper_sourcekitd.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = library_wrapper_sourcekitd.swift; sourceTree = "<group>"; };
 		6C4CF5741C78B47F008532C5 /* library_wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = library_wrapper.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 				E80F236A1A5CB04100FD2352 /* SyntaxToken.swift */,
 				E806D28E1BE058B100D1BE41 /* Text.swift */,
 				6CC1639B202AA3AE0086C459 /* UID.swift */,
+				55DB6A9622DEABD000666C6A /* UIDRepresentable.swift */,
 				6CC381621ECACB50000C6F81 /* Version.swift */,
 				E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */,
 				141E31562221C9870037E200 /* XcodeBuildSetting.swift */,
@@ -729,6 +732,7 @@
 				141E31572221C9870037E200 /* XcodeBuildSetting.swift in Sources */,
 				E877D9271B5693E70095BB2B /* ObjCDeclarationKind.swift in Sources */,
 				6C4CF6521C798082008532C5 /* library_wrapper_CXString.swift in Sources */,
+				55DB6A9722DEABD100666C6A /* UIDRepresentable.swift in Sources */,
 				E83748C31A5BCD7900862B1B /* OffsetMap.swift in Sources */,
 				E806D2911BE058C400D1BE41 /* Parameter.swift in Sources */,
 				E868473A1A587B4D0043DC65 /* Request.swift in Sources */,


### PR DESCRIPTION
I moved all code that interacts with `sourcekitd_object_t` into `SourceKitObject.swift`. This way it's easier to manage the lifecycle of `sourcekitd_object_t` pointers.

Relates to: https://github.com/realm/SwiftLint/issues/2812

I think this could be simplified/improved even more by exposing SourceKitObject as a typealias for `[String: SourceKitObjectConvertible]`. Then when we make the request, converting to `sourcekitd_object_t` pointers, making the request, then freeing the pointers. This means that for the most part you're only working with swift types and the `sourcekitd_object_t` lifecycle is greatly shorted and simplified.