### PR TITLE
Remove unused declarations

### DIFF
--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -478,6 +478,7 @@ internal func libraryWrapperForModule(_ module: String, loadPath: String, linuxP
     } else {
         library = "private let library = toolchainLoader.load(path: \"\(loadPath)\")\n"
     }
+    let swiftlintDisableComment = "// swiftlint:disable unused_declaration - We don't care if some of these are unused.\n"
     let startPlatformCheck: String
     let endPlatformCheck: String
     if linuxPath == nil {
@@ -487,5 +488,5 @@ internal func libraryWrapperForModule(_ module: String, loadPath: String, linuxP
         startPlatformCheck = ""
         endPlatformCheck = "\n"
     }
-    return startPlatformCheck + spmImport + library + freeFunctions.joined(separator: "\n") + endPlatformCheck
+    return startPlatformCheck + spmImport + library + swiftlintDisableComment + freeFunctions.joined(separator: "\n") + endPlatformCheck
 }

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -237,17 +237,6 @@ public enum SwiftDocKey: String {
     }
 
     /**
-    Get file path string from dictionary.
-
-    - parameter dictionary: Dictionary to get value from.
-
-    - returns: File path string if successful.
-    */
-    internal static func getFilePath(_ dictionary: [String: SourceKitRepresentable]) -> String? {
-        return get(.filePath, dictionary)
-    }
-
-    /**
     Get full xml docs string from dictionary.
 
     - parameter dictionary: Dictionary to get value from.

--- a/Source/SourceKittenFramework/XcodeBuildSetting.swift
+++ b/Source/SourceKittenFramework/XcodeBuildSetting.swift
@@ -9,12 +9,8 @@
 @dynamicMemberLookup
 struct XcodeBuildSetting: Codable {
 
-    /// The build action.
-    let action: String
     /// The build settings.
     let buildSettings: [String: String]
-    /// The target name.
-    let target: String
 
     subscript(dynamicMember member: String) -> String? {
         return buildSettings[member]

--- a/Source/SourceKittenFramework/library_wrapper_CXString.swift
+++ b/Source/SourceKittenFramework/library_wrapper_CXString.swift
@@ -3,6 +3,7 @@
 import Clang_C
 #endif
 private let library = toolchainLoader.load(path: "libclang.dylib")
+// swiftlint:disable unused_declaration - We don't care if some of these are unused.
 internal let clang_getCString: @convention(c) (CXString) -> (UnsafePointer<Int8>?) = library.load(symbol: "clang_getCString")
 internal let clang_disposeString: @convention(c) (CXString) -> () = library.load(symbol: "clang_disposeString")
 internal let clang_disposeStringSet: @convention(c) (UnsafeMutablePointer<CXStringSet>?) -> () = library.load(symbol: "clang_disposeStringSet")

--- a/Source/SourceKittenFramework/library_wrapper_Documentation.swift
+++ b/Source/SourceKittenFramework/library_wrapper_Documentation.swift
@@ -3,6 +3,7 @@
 import Clang_C
 #endif
 private let library = toolchainLoader.load(path: "libclang.dylib")
+// swiftlint:disable unused_declaration - We don't care if some of these are unused.
 internal let clang_Cursor_getParsedComment: @convention(c) (CXCursor) -> (CXComment) = library.load(symbol: "clang_Cursor_getParsedComment")
 internal let clang_Comment_getKind: @convention(c) (CXComment) -> (CXCommentKind) = library.load(symbol: "clang_Comment_getKind")
 internal let clang_Comment_getNumChildren: @convention(c) (CXComment) -> (UInt32) = library.load(symbol: "clang_Comment_getNumChildren")

--- a/Source/SourceKittenFramework/library_wrapper_Index.swift
+++ b/Source/SourceKittenFramework/library_wrapper_Index.swift
@@ -3,6 +3,7 @@
 import Clang_C
 #endif
 private let library = toolchainLoader.load(path: "libclang.dylib")
+// swiftlint:disable unused_declaration - We don't care if some of these are unused.
 internal let clang_createIndex: @convention(c) (Int32, Int32) -> (CXIndex?) = library.load(symbol: "clang_createIndex")
 internal let clang_disposeIndex: @convention(c) (CXIndex?) -> () = library.load(symbol: "clang_disposeIndex")
 internal let clang_CXIndex_setGlobalOptions: @convention(c) (CXIndex?, UInt32) -> () = library.load(symbol: "clang_CXIndex_setGlobalOptions")

--- a/Source/SourceKittenFramework/library_wrapper_sourcekitd.swift
+++ b/Source/SourceKittenFramework/library_wrapper_sourcekitd.swift
@@ -7,6 +7,7 @@ private let path = "libsourcekitdInProc.so"
 private let path = "sourcekitd.framework/Versions/A/sourcekitd"
 #endif
 private let library = toolchainLoader.load(path: path)
+// swiftlint:disable unused_declaration - We don't care if some of these are unused.
 internal let sourcekitd_initialize: @convention(c) () -> () = library.load(symbol: "sourcekitd_initialize")
 internal let sourcekitd_shutdown: @convention(c) () -> () = library.load(symbol: "sourcekitd_shutdown")
 internal let sourcekitd_set_interrupted_connection_handler: @convention(c) (@escaping sourcekitd_interrupted_connection_handler_t) -> () = library.load(symbol: "sourcekitd_set_interrupted_connection_handler")


### PR DESCRIPTION
Also restructure `library_wrapper.swift` to only expose the declarations needed on Darwin and Linux to that platform.