### PR TITLE
Bump Commandant to 0.17.0 + Drop Swift 4.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Carthage/Commandant" ~> 0.16
+github "Carthage/Commandant" ~> 0.17
 github "jspahrsummers/xcconfigs" ~> 0.12

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
-github "Carthage/Commandant" "0.16.0"
-github "antitypical/Result" "4.1.0"
+github "Carthage/Commandant" "0.17.0"
 github "drmohundro/SWXMLHash" "4.8.0"
 github "jpsim/Yams" "2.0.0"
 github "jspahrsummers/xcconfigs" "0.12"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "2cd0210f897fe46c6ce42f52ccfa72b3bbb621a0",
-          "version": "0.16.0"
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": "0.17.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -24,17 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0b4ed6c706dd0cce923b5019a605a9bcc6b1b600",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
-          "version": "4.1.0"
+          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "SourceKittenFramework", targets: ["SourceKittenFramework"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.16.0")),
+        .package(url: "https://github.com/Carthage/Commandant.git", .upToNextMinor(from: "0.17.0")),
         .package(url: "https://github.com/drmohundro/SWXMLHash.git", .upToNextMinor(from: "4.9.0")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
     ],

--- a/SourceKittenFramework.podspec
+++ b/SourceKittenFramework.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author              = { 'JP Simard' => 'jp@jpsim.com' }
   s.platform            = :osx, '10.9'
   s.source_files        = 'Source/Clang_C/include/*.h', 'Source/SourceKit/include/*.h', 'Source/SourceKittenFramework/*.swift'
-  s.swift_versions      = ['4.2', '5.0']
+  s.swift_versions      = ['5.0']
   s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   s.dependency            'SWXMLHash', '~> 4.7'
   s.dependency            'Yams', '~> 2.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,14 +8,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      swift420:
-        containerImage: norionomura/swiftlint:swift-4.2.0
-      swift421:
-        containerImage: norionomura/swiftlint:swift-4.2.1
-      swift422:
-        containerImage: norionomura/swiftlint:swift-4.2.2
-      swift423:
-        containerImage: norionomura/swiftlint:swift-4.2.3
       swift50:
         containerImage: swift:5.0
   container: $[ variables['containerImage'] ]
@@ -41,10 +33,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      xcode10:
-        DEVELOPER_DIR: /Applications/Xcode_10.app
-      xcode101:
-        DEVELOPER_DIR: /Applications/Xcode_10.1.app
       xcode102:
         DEVELOPER_DIR: /Applications/Xcode_10.2.app
   steps:


### PR DESCRIPTION
Bump `Commandant` to 0.17.0 to drop the unnecessary `Result` dependency, and, as an extension, drop Swift 4.2 support.