### PR TITLE
Autodetect SPM module name for docs generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Enhancements
 
-* None.
+* Add `--spm` option to guess the name of a Swift Package Manager module
+  for documentation generation.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -104,12 +104,18 @@ extension ModuleTests {
         compareJSONString(withFixtureNamed: "CommandantSPM", jsonString: commandantModule.docs, rootDirectory: commandantPath)
     }
 
+    func testSpmDefaultModule() {
+        let skModule = Module(spmName: nil, inPath: projectRoot)!
+        XCTAssertEqual("SourceKittenFramework", skModule.name)
+    }
+
     static var allTests: [(String, (ModuleTests) -> () throws -> Void)] {
         return [
             // Disabled on Linux because these tests require Xcode
             // ("testModuleNilInPathWithNoXcodeProject", testModuleNilInPathWithNoXcodeProject),
             // ("testCommandantDocs", testCommandantDocs),
-            ("testCommandantDocsSPM", testCommandantDocsSPM)
+            ("testCommandantDocsSPM", testCommandantDocsSPM),
+            ("testSpmDefaultModule", testSpmDefaultModule)
         ]
     }
 }


### PR DESCRIPTION
This adds an `--spm` option to auto-detect a sensible module name.

This is in aid of bringing spm support up to parity with xcodebuild in jazzy -- wanted to get some feedback before going further.

If the idea and this piece look OK then the next is to add a `swift build` call somewhere along the way to make sure the build DB is present and up to date, as we do with xcodebuild.  I think it makes sense to add this call to sourcekitten (vs. jazzy) to preserve the existing layering & keep sourcekitten self-consistent?

Jazzy prototype with this in realm/jazzy#1089