### PR TITLE
Support response files in Swift compiler arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   for documentation generation.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Support doc generation for modules built with Xcode 11.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * Fix crash with misplaced documentation comment.  

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -140,8 +140,8 @@ public struct Module {
     */
     public init(name: String, compilerArguments: [String]) {
         self.name = name
-        self.compilerArguments = compilerArguments
-        sourceFiles = compilerArguments.filter({
+        self.compilerArguments = compilerArguments.expandingResponseFiles
+        sourceFiles = self.compilerArguments.filter({
             $0.bridge().isSwiftFile() && $0.isFile
         }).map {
             return URL(fileURLWithPath: $0).resolvingSymlinksInPath().path

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -672,3 +672,20 @@ extension String {
         return String(UnescapingSequence(iterator: makeIterator()))
     }
 }
+
+extension Array where Element == String {
+    /// Return the full list of compiler arguments, replacing any response files with their contents.
+    var expandingResponseFiles: [String] {
+        return flatMap { arg -> [String] in
+            guard arg.starts(with: "@") else {
+                return [arg]
+            }
+            let responseFile = String(arg.dropFirst())
+            return (try? String(contentsOf: URL(fileURLWithPath: responseFile))).flatMap {
+                $0.trimmingCharacters(in: .newlines)
+                  .components(separatedBy: "\n")
+                  .expandingResponseFiles
+            } ?? [arg]
+        }
+    }
+}

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import SourceKittenFramework
+@testable import SourceKittenFramework
 import XCTest
 
 class StringTests: XCTestCase {
@@ -228,6 +228,15 @@ class StringTests: XCTestCase {
         // no crash on bad input
         XCTAssertEqual("ab\\".unescaped, "ab")
     }
+
+    func testResponseFiles() throws {
+        let responseContents = "3 4\n5\n"
+        let responseUrl = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString).rsp")
+        try responseContents.data(using: .utf8)?.write(to: responseUrl)
+        let xcodeArgs = ["1", "2", "@\(responseUrl.path)", "6"]
+        let expandedArgs = xcodeArgs.expandingResponseFiles
+        XCTAssertEqual("1,2,3 4,5,6", expandedArgs.joined(separator: ","))
+    }
 }
 
 typealias LineRangeType = (start: Int, end: Int)
@@ -265,7 +274,8 @@ extension StringTests {
             ("testLineAndCharacterForByteOffset", testLineAndCharacterForByteOffset),
             ("testByteRangeToNSRange", testByteRangeToNSRange),
             ("testLineAndCharacterForCharacterOffset", testLineAndCharacterForCharacterOffset),
-            ("testUnescaping", testUnescaping)
+            ("testUnescaping", testUnescaping),
+            ("testResponseFiles", testResponseFiles)
         ]
     }
 }


### PR DESCRIPTION
This adds Xcode11 support to docs generation, reading the new response file to figure out the source files.

It turns out SourceKit doesn't support response files ("_filename_ is not part of the input files" error) so we expand them before passing on.

Added a quick test that could go away when the SourceKitten tests pass with Xcode11; jazzy specs all build fine with this change.