### PR TITLE
Add package build step to SPM docs generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Support doc generation for modules built with Xcode 11.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Add `Module.init?(spmArguments:spmName:inPath)` and use in `doc` commmand
+  to ensure Swift Package Manager module documentation is up to date.  
+  [John Fairhurst](https://github.com/johnfairh)
+
 ##### Bug Fixes
 
 * Fix crash with misplaced documentation comment.  

--- a/Source/SourceKittenFramework/Exec.swift
+++ b/Source/SourceKittenFramework/Exec.swift
@@ -82,7 +82,7 @@ enum Exec {
         }
 
         do {
-        #if canImport(Darwin)
+#if canImport(Darwin)
             if #available(macOS 10.13, *) {
                 process.executableURL = URL(fileURLWithPath: command)
                 process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
@@ -92,15 +92,15 @@ enum Exec {
                 process.currentDirectoryPath = currentDirectory
                 process.launch()
             }
-        #elseif compiler(>=5)
+#elseif compiler(>=5)
             process.executableURL = URL(fileURLWithPath: command)
             process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
             try process.run()
-        #else
+#else
             process.launchPath = command
             process.currentDirectoryPath = currentDirectory
             process.launch()
-        #endif
+#endif
         } catch {
             return Results(terminationStatus: -1, data: Data())
         }

--- a/Source/SourceKittenFramework/Exec.swift
+++ b/Source/SourceKittenFramework/Exec.swift
@@ -1,0 +1,113 @@
+//
+//  Exec.swift
+//  SourceKittenFramework
+//
+//  Copyright © 2019 SourceKitten. All rights reserved.
+//
+
+import Foundation
+
+/// Namespace for utilities to execute a child process.
+enum Exec {
+    /// How to handle stderr output from the child process.
+    enum Stderr {
+        /// Treat stderr same as parent process.
+        case inherit
+        /// Send stderr to /dev/null.
+        case discard
+        /// Merge stderr with stdout.
+        case merge
+    }
+
+    /// The result of running the child process.
+    struct Results {
+        /// The process's exit status.
+        let terminationStatus: Int32
+        /// The data from stdout and optionally stderr.
+        let data: Data
+        /// The `data` reinterpreted as a string with whitespace trimmed; `nil` for the empty string.
+        var string: String? {
+            let encoded = String(data: data, encoding: .utf8) ?? ""
+            let trimmed = encoded.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    /**
+    Run a command with arguments and return its output and exit status.
+
+    - parameter command: Absolute path of the command to run.
+    - parameter arguments: Arguments to pass to the command.
+    - parameter currentDirectory: Current directory for the command.  By default
+                                  the parent process's current directory.
+    - parameter stderr: What to do with stderr output from the command.  By default
+                        whatever the parent process does.
+    */
+    static func run(_ command: String,
+                    _ arguments: String...,
+                    currentDirectory: String = FileManager.default.currentDirectoryPath,
+                    stderr: Stderr = .inherit) -> Results {
+        return run(command, arguments, currentDirectory: currentDirectory, stderr: stderr)
+    }
+
+    /**
+     Run a command with arguments and return its output and exit status.
+
+     - parameter command: Absolute path of the command to run.
+     - parameter arguments: Arguments to pass to the command.
+     - parameter currentDirectory: Current directory for the command.  By default
+                                   the parent process's current directory.
+     - parameter stderr: What to do with stderr output from the command.  By default
+                         whatever the parent process does.
+     */
+     static func run(_ command: String,
+                     _ arguments: [String] = [],
+                     currentDirectory: String = FileManager.default.currentDirectoryPath,
+                     stderr: Stderr = .inherit) -> Results {
+        let process = Process()
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        switch stderr {
+        case .discard:
+            // FileHandle.nullDevice does not work here, as it consists of an invalid file descriptor,
+            // causing process.launch() to abort with an EBADF.
+            process.standardError = FileHandle(forWritingAtPath: "/dev/null")!
+        case .merge:
+            process.standardError = pipe
+        case .inherit:
+            break
+        }
+
+        do {
+        #if canImport(Darwin)
+            if #available(macOS 10.13, *) {
+                process.executableURL = URL(fileURLWithPath: command)
+                process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+                try process.run()
+            } else {
+                process.launchPath = command
+                process.currentDirectoryPath = currentDirectory
+                process.launch()
+            }
+        #elseif compiler(>=5)
+            process.executableURL = URL(fileURLWithPath: command)
+            process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+            try process.run()
+        #else
+            process.launchPath = command
+            process.currentDirectoryPath = currentDirectory
+            process.launch()
+        #endif
+        } catch {
+            return Results(terminationStatus: -1, data: Data())
+        }
+
+        let file = pipe.fileHandleForReading
+        let data = file.readDataToEndOfFile()
+        process.waitUntilExit()
+        return Results(terminationStatus: process.terminationStatus, data: data)
+    }
+}

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -103,7 +103,7 @@ public struct Module {
         let buildResults = Exec.run("/usr/bin/env", ["swift", "build"] + spmArguments, currentDirectory: path, stderr: .merge)
         guard buildResults.terminationStatus == 0 else {
             let file = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("swift-build-\(UUID().uuidString).log")
-            try! buildResults.data.write(to: file)
+            _ = try? buildResults.data.write(to: file)
             fputs("Build failed, saved `swift build` log file: \(file.path)\n", stderr)
             return nil
         }
@@ -149,7 +149,7 @@ public struct Module {
             fputs("Could not parse compiler arguments from `xcodebuild` output.\n", stderr)
             fputs("Please confirm that `xcodebuild` is building a Swift module.\n", stderr)
             let file = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("xcodebuild-\(NSUUID().uuidString).log")
-            try! xcodeBuildOutput.data(using: .utf8)?.write(to: file)
+            _ = try? xcodeBuildOutput.data(using: .utf8)?.write(to: file)
             fputs("Saved `xcodebuild` log file: \(file.path)\n", stderr)
             return nil
         }

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -198,8 +198,7 @@ public func sdkPath() -> String {
     // xcrun does not exist on Linux
     return ""
 #else
-    return Exec.run("/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx").string?
-        .replacingOccurrences(of: "\n", with: "") ?? ""
+    return Exec.run("/usr/bin/xcrun", "--show-sdk-path", "--sdk", "macosx").string ?? ""
 #endif
 }
 

--- a/Source/sourcekitten/DocCommand.swift
+++ b/Source/sourcekitten/DocCommand.swift
@@ -49,7 +49,7 @@ struct DocCommand: CommandProtocol {
                 <*> mode <| Option(key: "spm-module", defaultValue: "",
                                    usage: "equivalent to --spm --module-name (string)")
                 <*> mode <| Argument(defaultValue: [],
-                                     usage: "Arguments list that passed to xcodebuild. If `-` prefixed argument exists, place ` -- ` before that.")
+                                     usage: "Arguments passed to `xcodebuild` or `swift build`. If `-` prefixed argument exists, place ` -- ` before that.")
         }
     }
 
@@ -57,7 +57,7 @@ struct DocCommand: CommandProtocol {
         let args = options.arguments
         let moduleName: String? = options.moduleName.isEmpty ? nil : options.moduleName
         if options.spm {
-            return runSPMModule(moduleName: moduleName)
+            return runSPMModule(moduleName: moduleName, args: args)
         } else if options.objc {
             return runObjC(options: options, args: args)
         } else if options.singleFile {
@@ -66,8 +66,8 @@ struct DocCommand: CommandProtocol {
         return runSwiftModule(moduleName: moduleName, args: args)
     }
 
-    func runSPMModule(moduleName: String?) -> Result<(), SourceKittenError> {
-        if let docs = Module(spmName: moduleName)?.docs {
+    func runSPMModule(moduleName: String?, args: [String]) -> Result<(), SourceKittenError> {
+        if let docs = Module(spmArguments: args, spmName: moduleName)?.docs {
             print(docs)
             return .success(())
         }

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -67,7 +67,7 @@ extension ModuleTests {
             XCTFail("Can't find Commandant")
             return
         }
-        let commandantModule = Module(spmName: "Commandant", inPath: projectRoot)!
+        let commandantModule = Module(spmArguments: [], spmName: "Commandant", inPath: projectRoot)!
         compareJSONString(withFixtureNamed: "CommandantSPM", jsonString: commandantModule.docs, rootDirectory: commandantPath)
     }
 

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0225685722F2E06E0068A7AC /* Exec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225685622F2E06E0068A7AC /* Exec.swift */; };
 		141E31572221C9870037E200 /* XcodeBuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E31562221C9870037E200 /* XcodeBuildSetting.swift */; };
 		182F385020753FAD0054F063 /* SwiftDeclarationAttributeKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182F384F20753FAD0054F063 /* SwiftDeclarationAttributeKind.swift */; };
 		2C55B3321BEB3CA7002E8C6B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; };
@@ -141,6 +142,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0225685622F2E06E0068A7AC /* Exec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exec.swift; sourceTree = "<group>"; };
 		141E31562221C9870037E200 /* XcodeBuildSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeBuildSetting.swift; sourceTree = "<group>"; };
 		182F384F20753FAD0054F063 /* SwiftDeclarationAttributeKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDeclarationAttributeKind.swift; sourceTree = "<group>"; };
 		2ED279151C61E2A100084460 /* StatementKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementKind.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 				6CC381621ECACB50000C6F81 /* Version.swift */,
 				E8A9B88F1B56CB5500CD17D4 /* Xcode.swift */,
 				141E31562221C9870037E200 /* XcodeBuildSetting.swift */,
+				0225685622F2E06E0068A7AC /* Exec.swift */,
 			);
 			name = SourceKittenFramework;
 			path = Source/SourceKittenFramework;
@@ -717,6 +720,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0225685722F2E06E0068A7AC /* Exec.swift in Sources */,
 				E82882541DAEEDD1002E0564 /* LinuxCompatibility.swift in Sources */,
 				E806D2931BE058D600D1BE41 /* Documentation.swift in Sources */,
 				6CC1639D202AA3AF0086C459 /* UID.swift in Sources */,


### PR DESCRIPTION
Final part of jazzy+SPM support: this runs `swift build` as part of generating docs for SPM modules.  This makes sure that the build manifest (a) exists and (b) is consistent with the latest changes to the source code, same as Xcode path.  (No need to do a `clean` so is v. cheap if the package has already been built.)

First commit is a pure refactor of all the popen-ish code because I couldn't stand duplicating it again.  Accounts for most of the changed LOC.

Second commit adds a `Module` initializer that runs `swift build` before going to SourceKit.

I tentatively kept the existing SPM initializer to keep semantics for existing users (SourceDocs uses it, didn't look further).
