### PR TITLE
Fix response file parsing for escaped characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix Swift response files for paths including special characters.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ## 0.25.0
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -684,6 +684,7 @@ extension Array where Element == String {
             return (try? String(contentsOf: URL(fileURLWithPath: responseFile))).flatMap {
                 $0.trimmingCharacters(in: .newlines)
                   .components(separatedBy: "\n")
+                  .map { $0.unescaped }
                   .expandingResponseFiles
             } ?? [arg]
         }

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -230,12 +230,12 @@ class StringTests: XCTestCase {
     }
 
     func testResponseFiles() throws {
-        let responseContents = "3 4\n5\n"
+        let responseContents = "3 4\n5\n6\\\\7\n8\\ 9\n"
         let responseUrl = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString).rsp")
         try responseContents.data(using: .utf8)?.write(to: responseUrl)
-        let xcodeArgs = ["1", "2", "@\(responseUrl.path)", "6"]
+        let xcodeArgs = ["1", "2", "@\(responseUrl.path)", "e"]
         let expandedArgs = xcodeArgs.expandingResponseFiles
-        XCTAssertEqual("1,2,3 4,5,6", expandedArgs.joined(separator: ","))
+        XCTAssertEqual("1,2,3 4,5,6\\7,8 9,e", expandedArgs.joined(separator: ","))
     }
 }
 


### PR DESCRIPTION
The Xcode 11 Swift response files contain backslash escapes for spaces etc.  I'd somehow convinced myself they didn't.

Addresses realm/jazzy#1108.

_Technically_ unescaped spaces are supposed to delimit separate arguments, but Xcode doesn't use this today.  We would need to reimplement [this code](https://github.com/apple/swift-llvm/blob/c5340df2d1aed4cd16fb43e1ce11139a407f2055/lib/Support/CommandLine.cpp#L702) -- I think this version is OK for now.