### PR TITLE
Workaround for crash using repo https://gitlab.com/eyeo/adblockplus/ABPKit

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -167,7 +167,7 @@ extension NSString {
                 return NSMaxRange(line.range)
             }
             let utf8View = line.content.utf8
-            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex)!
+            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex) ?? utf8View.startIndex
             let utf16Diff = line.content.utf16.distance(from: line.content.utf16.startIndex, to: endUTF8Index)
             return line.range.location + utf16Diff
         }

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -167,7 +167,7 @@ extension NSString {
                 return NSMaxRange(line.range)
             }
             let utf8View = line.content.utf8
-            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex) ?? utf8View.endIndex
+            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex) ?? utf8View.startIndex
             let utf16Diff = line.content.utf16.distance(from: line.content.utf16.startIndex, to: endUTF8Index)
             return line.range.location + utf16Diff
         }

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -167,7 +167,7 @@ extension NSString {
                 return NSMaxRange(line.range)
             }
             let utf8View = line.content.utf8
-            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex) ?? utf8View.startIndex
+            let endUTF8Index = utf8View.index(utf8View.startIndex, offsetBy: diff, limitedBy: utf8View.endIndex) ?? utf8View.endIndex
             let utf16Diff = line.content.utf16.distance(from: line.content.utf16.startIndex, to: endUTF8Index)
             return line.range.location + utf16Diff
         }


### PR DESCRIPTION
Hi,

I’ve been experiencing a crash linting https://gitlab.com/eyeo/adblockplus/ABPKit. I can’t say I’ve looked into exactly what the problem is but this “makes it go away”.

Process:               swiftlint [22181]
Path:                  /Users/USER/Library/Developer/Xcode/DerivedData/SwiftLint-ecybgkmnkylbfzcbxorvkntspvqn/Build/Products/Debug/swiftlint.app/Contents/MacOS/swiftlint
Identifier:            swiftlint
Version:               0
Code Type:             X86-64 (Native)
Parent Process:        ??? [22180]
Responsible:           swiftlint [22181]
User ID:               501

Date/Time:             2019-10-10 10:47:28.476 +0200
OS Version:            Mac OS X 10.14.6 (18G95)
Report Version:        12
Anonymous UUID:        02D2198B-1242-6CEF-1917-5BF2C565B7C4


Time Awake Since Boot: 590000 seconds

System Integrity Protection: enabled

Crashed Thread:        3  Dispatch queue: com.apple.root.user-initiated-qos

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Illegal instruction: 4
Termination Reason:    Namespace SIGNAL, Code 0x4
Terminating Process:   exc handler [22181]

Application Specific Information:
Fatal error: Unexpectedly found nil while unwrapping an Optional value: file /Users/USER/Developer/SwiftLint/Carthage/Checkouts/SourceKitten/Source/SourceKittenFramework/String+SourceKitten.swift, line 170
…
 
Cheers!