### PR TITLE
Add ByteRange to prevent disambiguation when working with ranges and byte ranges

### DIFF
--- a/Source/SourceKittenFramework/ByteOffset.swift
+++ b/Source/SourceKittenFramework/ByteOffset.swift
@@ -2,7 +2,7 @@
 //  ByteOffset.swift
 //  SourceKitten
 //
-//  Created by JP Simard on 2019-11-02.
+//  Created by Paul Taykalo on 2019-11-02.
 //  Copyright (c) 2019 SourceKitten. All rights reserved.
 //
 

--- a/Source/SourceKittenFramework/ByteOffset.swift
+++ b/Source/SourceKittenFramework/ByteOffset.swift
@@ -1,0 +1,75 @@
+//
+//  ByteOffset.swift
+//  SourceKitten
+//
+//  Created by JP Simard on 2019-11-02.
+//  Copyright (c) 2019 SourceKitten. All rights reserved.
+//
+
+/// Wrapper over a string offset to represent offset in bytes.
+public struct ByteOffset: ExpressibleByIntegerLiteral {
+    /// The byte value as an integer.
+    var value: Int
+
+    /// Create a byte offset by its integer value.
+    ///
+    /// - parameter value: Integer offset value.
+    public init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    /// Create a byte offset by its integer value.
+    ///
+    /// - parameter value: Integer offset value.
+    public init(_ value: Int) {
+        self.value = value
+    }
+}
+
+extension ByteOffset: CustomStringConvertible {
+    public var description: String {
+        return value.description
+    }
+}
+
+extension ByteOffset: Comparable {
+    public static func < (lhs: ByteOffset, rhs: ByteOffset) -> Bool {
+        return lhs.value < rhs.value
+    }
+}
+
+extension ByteOffset: AdditiveArithmetic {
+    public static func - (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+        return ByteOffset(lhs.value - rhs.value)
+    }
+
+    public static func -= (lhs: inout ByteOffset, rhs: ByteOffset) {
+        lhs.value -= rhs.value
+    }
+
+    public static func + (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+        return ByteOffset(lhs.value + rhs.value)
+    }
+
+    public static func += (lhs: inout ByteOffset, rhs: ByteOffset) {
+        lhs.value += rhs.value
+    }
+}
+
+public extension ByteOffset {
+    /// Adds an integer value to a byte offset.
+    ///
+    /// - parameter lhs: Byte offset.
+    /// - parameter rhs: Value to add.
+    static func + (lhs: ByteOffset, rhs: Int) -> ByteOffset {
+        return ByteOffset(lhs.value + rhs)
+    }
+
+    /// Subtracts an integer value from a byte offset.
+    ///
+    /// - parameter lhs: Byte offset.
+    /// - parameter rhs: Value to subtract.
+    static func - (lhs: ByteOffset, rhs: Int) -> ByteOffset {
+        return ByteOffset(lhs.value - rhs)
+    }
+}

--- a/Source/SourceKittenFramework/ByteOffset.swift
+++ b/Source/SourceKittenFramework/ByteOffset.swift
@@ -55,21 +55,3 @@ extension ByteOffset: AdditiveArithmetic {
         lhs.value += rhs.value
     }
 }
-
-public extension ByteOffset {
-    /// Adds an integer value to a byte offset.
-    ///
-    /// - parameter lhs: Byte offset.
-    /// - parameter rhs: Value to add.
-    static func + (lhs: ByteOffset, rhs: Int) -> ByteOffset {
-        return ByteOffset(lhs.value + rhs)
-    }
-
-    /// Subtracts an integer value from a byte offset.
-    ///
-    /// - parameter lhs: Byte offset.
-    /// - parameter rhs: Value to subtract.
-    static func - (lhs: ByteOffset, rhs: Int) -> ByteOffset {
-        return ByteOffset(lhs.value - rhs)
-    }
-}

--- a/Source/SourceKittenFramework/ByteRange.swift
+++ b/Source/SourceKittenFramework/ByteRange.swift
@@ -50,19 +50,19 @@ extension ByteOffset: Comparable {
 }
 
 public extension ByteOffset {
-    static func +(lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+    static func + (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
         return ByteOffset(lhs.value + rhs.value)
     }
 
-    static func +(lhs: ByteOffset, rhs: Int) -> ByteOffset {
+    static func + (lhs: ByteOffset, rhs: Int) -> ByteOffset {
         return ByteOffset(lhs.value + rhs)
     }
 
-    static func -(lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+    static func - (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
         return ByteOffset(lhs.value - rhs.value)
     }
 
-    static func -(lhs: ByteOffset, rhs: Int) -> ByteOffset {
+    static func - (lhs: ByteOffset, rhs: Int) -> ByteOffset {
         return ByteOffset(lhs.value - rhs)
     }
 

--- a/Source/SourceKittenFramework/ByteRange.swift
+++ b/Source/SourceKittenFramework/ByteRange.swift
@@ -1,69 +1,30 @@
-/// Structture that represents range in bytes
-public struct ByteRange {
+//
+//  ByteRange.swift
+//  SourceKitten
+//
+//  Created by JP Simard on 2019-11-02.
+//  Copyright (c) 2019 SourceKitten. All rights reserved.
+//
 
+/// Structure that represents a string range in bytes
+public struct ByteRange: Equatable {
+    /// The starting location of the range.
     public let location: ByteOffset
 
+    /// The length of the range.
     public let length: Int
 
+    /// Creates a byte range from a location and a length.
+    ///
+    /// - parameter location: The starting location of the range.
+    /// - parameter length:   The length of the range.
     public init(location: ByteOffset, length: Int) {
         self.location = location
         self.length = length
     }
 
-    var maxRange: ByteOffset {
+    /// The range's upper bound.
+    var upperBound: ByteOffset {
         return location + length
     }
-}
-
-extension ByteRange: Equatable {
-    public static func == (lhs: ByteRange, rhs: ByteRange) -> Bool {
-        return lhs.location == rhs.location && lhs.length == rhs.length
-    }
-}
-
-/// Wrapper over the offset to represent offset in bytes
-public struct ByteOffset {
-    var value: Int
-
-    public init(_ value: Int) {
-        self.value = value
-    }
-
-    static let zero = ByteOffset(0)
-}
-
-extension ByteOffset: CustomStringConvertible {
-    public var description: String {
-        return value.description
-    }
-}
-
-extension ByteOffset: Comparable {
-
-    public static func == (lhs: ByteOffset, rhs: ByteOffset) -> Bool {
-        return lhs.value == rhs.value
-    }
-
-    public static func < (lhs: ByteOffset, rhs: ByteOffset) -> Bool {
-        return lhs.value < rhs.value
-    }
-}
-
-public extension ByteOffset {
-    static func + (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
-        return ByteOffset(lhs.value + rhs.value)
-    }
-
-    static func + (lhs: ByteOffset, rhs: Int) -> ByteOffset {
-        return ByteOffset(lhs.value + rhs)
-    }
-
-    static func - (lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
-        return ByteOffset(lhs.value - rhs.value)
-    }
-
-    static func - (lhs: ByteOffset, rhs: Int) -> ByteOffset {
-        return ByteOffset(lhs.value - rhs)
-    }
-
 }

--- a/Source/SourceKittenFramework/ByteRange.swift
+++ b/Source/SourceKittenFramework/ByteRange.swift
@@ -25,6 +25,6 @@ public struct ByteRange: Equatable {
 
     /// The range's upper bound.
     var upperBound: ByteOffset {
-        return location + length
+        return ByteOffset(location.value + length)
     }
 }

--- a/Source/SourceKittenFramework/ByteRange.swift
+++ b/Source/SourceKittenFramework/ByteRange.swift
@@ -1,0 +1,69 @@
+/// Structture that represents range in bytes
+public struct ByteRange {
+
+    public let location: ByteOffset
+
+    public let length: Int
+
+    public init(location: ByteOffset, length: Int) {
+        self.location = location
+        self.length = length
+    }
+
+    var maxRange: ByteOffset {
+        return location + length
+    }
+}
+
+extension ByteRange: Equatable {
+    public static func == (lhs: ByteRange, rhs: ByteRange) -> Bool {
+        return lhs.location == rhs.location && lhs.length == rhs.length
+    }
+}
+
+/// Wrapper over the offset to represent offset in bytes
+public struct ByteOffset {
+    var value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    static let zero = ByteOffset(0)
+}
+
+extension ByteOffset: CustomStringConvertible {
+    public var description: String {
+        return value.description
+    }
+}
+
+extension ByteOffset: Comparable {
+
+    public static func == (lhs: ByteOffset, rhs: ByteOffset) -> Bool {
+        return lhs.value == rhs.value
+    }
+
+    public static func < (lhs: ByteOffset, rhs: ByteOffset) -> Bool {
+        return lhs.value < rhs.value
+    }
+}
+
+public extension ByteOffset {
+    static func +(lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+        return ByteOffset(lhs.value + rhs.value)
+    }
+
+    static func +(lhs: ByteOffset, rhs: Int) -> ByteOffset {
+        return ByteOffset(lhs.value + rhs)
+    }
+
+    static func -(lhs: ByteOffset, rhs: ByteOffset) -> ByteOffset {
+        return ByteOffset(lhs.value - rhs.value)
+    }
+
+    static func -(lhs: ByteOffset, rhs: Int) -> ByteOffset {
+        return ByteOffset(lhs.value - rhs)
+    }
+
+}

--- a/Source/SourceKittenFramework/ByteRange.swift
+++ b/Source/SourceKittenFramework/ByteRange.swift
@@ -2,7 +2,7 @@
 //  ByteRange.swift
 //  SourceKitten
 //
-//  Created by JP Simard on 2019-11-02.
+//  Created by Paul Taykalo on 2019-11-02.
 //  Copyright (c) 2019 SourceKitten. All rights reserved.
 //
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -142,9 +142,9 @@ public final class File {
         }
         let substring: String?
         if let end = SwiftDocKey.getBodyOffset(dictionary) {
-            substring = contents.bridge().substringStartingLinesWithByteRange(start: start, length: Int(end) - start.value)
+            substring = contents.bridge().substringStartingLinesWithByteRange(ByteRange(location: start, length: Int(end) - start.value))
         } else {
-            substring = contents.bridge().substringLinesWithByteRange(start: start, length: 0)
+            substring = contents.bridge().substringLinesWithByteRange(ByteRange(location: start, length: 0))
         }
         return substring?.removingCommonLeadingWhitespaceFromLines()
                          .trimmingWhitespaceAndOpeningCurlyBrace()
@@ -168,8 +168,8 @@ public final class File {
                     return ByteOffset(Int(bodyOffset + bodyLength))
                 }
             } ?? start
-            let length = end - start
-            return contents.bridge().lineRangeWithByteRange(start: start, length: length.value)
+            let byteRange = ByteRange(location: start, length: (end - start).value)
+            return contents.bridge().lineRangeWithByteRange(byteRange)
         }
     }
 
@@ -410,7 +410,9 @@ public final class File {
            let commentRange = finder.getRangeForDeclaration(atOffset: Int(offset)),
            case let start = commentRange.lowerBound,
            case let end = commentRange.upperBound,
-           let nsRange = contents.bridge().byteRangeToNSRange(start: ByteOffset(start), length: end - start),
+           let nsRange = contents.bridge().byteRangeToNSRange(
+               ByteRange(location: ByteOffset(start), length: end - start)
+           ),
            let commentBody = contents.commentBody(range: nsRange) {
            dictionary[SwiftDocKey.documentationComment.rawValue] = commentBody
         }

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -47,7 +47,7 @@ public struct SourceDeclaration {
     public let availability: ClangAvailability?
 
     /// Range
-    public var range: NSRange {
+    public var range: ByteRange {
         return extent.start.range(toEnd: extent.end)
     }
 

--- a/Source/SourceKittenFramework/SourceDeclaration.swift
+++ b/Source/SourceKittenFramework/SourceDeclaration.swift
@@ -19,11 +19,12 @@ public func insertMarks(declarations: [SourceDeclaration], limit: NSRange? = nil
         fatalError("can't extract marks without a file.")
     }
     let currentMarks = file.contents.pragmaMarks(filename: path, excludeRanges: declarations.map({
-        file.contents.byteRangeToNSRange(start: $0.range.location, length: $0.range.length) ?? NSRange()
+        file.contents.byteRangeToNSRange(ByteRange(location: $0.range.location, length: $0.range.length))
+            ?? NSRange()
     }), limit: limit)
     let newDeclarations: [SourceDeclaration] = declarations.map { declaration in
         var varDeclaration = declaration
-        let range = file.contents.byteRangeToNSRange(start: declaration.range.location, length: declaration.range.length)
+        let range = file.contents.byteRangeToNSRange(declaration.range)
         varDeclaration.children = insertMarks(declarations: declaration.children, limit: range)
         return varDeclaration
     }

--- a/Source/SourceKittenFramework/SourceLocation.swift
+++ b/Source/SourceKittenFramework/SourceLocation.swift
@@ -19,8 +19,11 @@ public struct SourceLocation {
     public let column: UInt32
     public let offset: UInt32
 
-    public func range(toEnd end: SourceLocation) -> NSRange {
-        return NSRange(location: Int(offset), length: Int(end.offset - offset))
+    public var byteOffset: ByteOffset {
+        return ByteOffset(Int(offset))
+    }
+    public func range(toEnd end: SourceLocation) -> ByteRange {
+        return ByteRange(location: byteOffset, length: Int(end.offset - offset))
     }
 }
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -199,7 +199,7 @@ extension NSString {
             if diff == 0 {
                 return line.byteRange.location
             } else if line.range.length == diff {
-                return line.byteRange.maxRange
+                return line.byteRange.upperBound
             }
             let utf16View = line.content.utf16
             let endUTF8index = utf16View.index(utf16View.startIndex, offsetBy: diff, limitedBy: utf16View.endIndex)!

--- a/Source/sourcekitten/CompleteCommand.swift
+++ b/Source/sourcekitten/CompleteCommand.swift
@@ -55,7 +55,7 @@ struct CompleteCommand: CommandProtocol {
         var args: [String]
         if options.spmModule.isEmpty {
             args = ["-c", path] + options.compilerargs
-            if args.firstIndex(of: "-sdk") == nil {
+            if !args.contains("-sdk") {
                 args.append(contentsOf: ["-sdk", sdkPath()])
             }
         } else {

--- a/Tests/SourceKittenFrameworkTests/FileTests.swift
+++ b/Tests/SourceKittenFrameworkTests/FileTests.swift
@@ -24,7 +24,7 @@ class FileTests: XCTestCase {
     func testLinesRangesWhenUsingLineSeparator() {
         let file = File(contents: "// There're two U+2028 invisible characters after the colon:\u{2028}\u{2028}\nclass X {}")
         XCTAssertEqual(file.lines.count, 2)
-        XCTAssertEqual(file.lines.last?.byteRange, ByteRange(location: ByteOffset(67), length: 10))
+        XCTAssertEqual(file.lines.last?.byteRange, ByteRange(location: 67, length: 10))
     }
 }
 

--- a/Tests/SourceKittenFrameworkTests/FileTests.swift
+++ b/Tests/SourceKittenFrameworkTests/FileTests.swift
@@ -24,7 +24,7 @@ class FileTests: XCTestCase {
     func testLinesRangesWhenUsingLineSeparator() {
         let file = File(contents: "// There're two U+2028 invisible characters after the colon:\u{2028}\u{2028}\nclass X {}")
         XCTAssertEqual(file.lines.count, 2)
-        XCTAssertEqual(file.lines.last?.byteRange, NSRange(location: 67, length: 10))
+        XCTAssertEqual(file.lines.last?.byteRange, ByteRange(location: ByteOffset(67), length: 10))
     }
 }
 

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -146,32 +146,32 @@ class StringTests: XCTestCase {
 
     func testSubstringWithByteRange() {
         let string = "👨‍👩‍👧‍👧123"
-        XCTAssertEqual(string.bridge().substringWithByteRange(start: ByteOffset(0), length: 25)!, "👨‍👩‍👧‍👧")
-        XCTAssertEqual(string.bridge().substringWithByteRange(start: ByteOffset(25), length: 1)!, "1")
+        XCTAssertEqual(string.bridge().substringWithByteRange(ByteRange(location: 0, length: 25))!, "👨‍👩‍👧‍👧")
+        XCTAssertEqual(string.bridge().substringWithByteRange(ByteRange(location: 25, length: 1))!, "1")
     }
 
     func testSubstringLinesWithByteRange() {
         let string = "👨‍👩‍👧‍👧\n123"
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 0)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 25)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 26)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 27)!, string)
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(27), length: 0)!, "123")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(ByteRange(location: 0, length: 0))!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(ByteRange(location: 0, length: 25))!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(ByteRange(location: 0, length: 26))!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(ByteRange(location: 0, length: 27))!, string)
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(ByteRange(location: 27, length: 0))!, "123")
     }
 
     func testLineRangeWithByteRange() {
-        XCTAssert("".bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 0) == nil)
+        XCTAssert("".bridge().lineRangeWithByteRange(ByteRange(location: 0, length: 0)) == nil)
         let string = "👨‍👩‍👧‍👧\n123"
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 0), (1, 1))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 25), (1, 1))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 26), (1, 2))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 27), (1, 2))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(27), length: 0), (2, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(ByteRange(location: 0, length: 0)), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(ByteRange(location: 0, length: 25)), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(ByteRange(location: 0, length: 26)), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(ByteRange(location: 0, length: 27)), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(ByteRange(location: 27, length: 0)), (2, 2))
     }
 
     func testLineAndCharacterForByteOffset() {
         let string = "public typealias 🔳 = QRCode"
-        XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: ByteOffset(17)), (1, 18))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: 17), (1, 18))
     }
 
     func testByteRangeToNSRange() {
@@ -191,7 +191,7 @@ class StringTests: XCTestCase {
                 }
             }
             """
-        XCTAssertEqual(string.bridge().byteRangeToNSRange(start: ByteOffset(115), length: 41), NSRange(location: 115, length: 38))
+        XCTAssertEqual(string.bridge().byteRangeToNSRange(ByteRange(location: 115, length: 41)), NSRange(location: 115, length: 38))
     }
 
     func testLineAndCharacterForCharacterOffset() {

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -146,32 +146,32 @@ class StringTests: XCTestCase {
 
     func testSubstringWithByteRange() {
         let string = "👨‍👩‍👧‍👧123"
-        XCTAssertEqual(string.bridge().substringWithByteRange(start: 0, length: 25)!, "👨‍👩‍👧‍👧")
-        XCTAssertEqual(string.bridge().substringWithByteRange(start: 25, length: 1)!, "1")
+        XCTAssertEqual(string.bridge().substringWithByteRange(start: ByteOffset(0), length: 25)!, "👨‍👩‍👧‍👧")
+        XCTAssertEqual(string.bridge().substringWithByteRange(start: ByteOffset(25), length: 1)!, "1")
     }
 
     func testSubstringLinesWithByteRange() {
         let string = "👨‍👩‍👧‍👧\n123"
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: 0, length: 0)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: 0, length: 25)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: 0, length: 26)!, "👨‍👩‍👧‍👧\n")
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: 0, length: 27)!, string)
-        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: 27, length: 0)!, "123")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 0)!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 25)!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 26)!, "👨‍👩‍👧‍👧\n")
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(0), length: 27)!, string)
+        XCTAssertEqual(string.bridge().substringLinesWithByteRange(start: ByteOffset(27), length: 0)!, "123")
     }
 
     func testLineRangeWithByteRange() {
-        XCTAssert("".bridge().lineRangeWithByteRange(start: 0, length: 0) == nil)
+        XCTAssert("".bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 0) == nil)
         let string = "👨‍👩‍👧‍👧\n123"
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 0), (1, 1))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 25), (1, 1))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 26), (1, 2))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 0, length: 27), (1, 2))
-        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: 27, length: 0), (2, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 0), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 25), (1, 1))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 26), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(0), length: 27), (1, 2))
+        XCTAssertEqual(string.bridge().lineRangeWithByteRange(start: ByteOffset(27), length: 0), (2, 2))
     }
 
     func testLineAndCharacterForByteOffset() {
         let string = "public typealias 🔳 = QRCode"
-        XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: 17), (1, 18))
+        XCTAssertEqual(string.bridge().lineAndCharacter(forByteOffset: ByteOffset(17)), (1, 18))
     }
 
     func testByteRangeToNSRange() {
@@ -191,7 +191,7 @@ class StringTests: XCTestCase {
                 }
             }
             """
-        XCTAssertEqual(string.bridge().byteRangeToNSRange(start: 115, length: 41), NSRange(location: 115, length: 38))
+        XCTAssertEqual(string.bridge().byteRangeToNSRange(start: ByteOffset(115), length: 41), NSRange(location: 115, length: 38))
     }
 
     func testLineAndCharacterForCharacterOffset() {

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		6CCFCE8E1CFED000003239EB /* Commandant.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6CCFCE901CFED005003239EB /* Result.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E834D61D1B2D054B002AA1FE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8F935B342288C05A00971070 /* File+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F935B332288C05A00971070 /* File+Hashable.swift */; };
+		8FFFD346236F8A4200AE9310 /* ByteRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFFD345236F8A4200AE9310 /* ByteRange.swift */; };
+		8FFFD348236F8A5500AE9310 /* ByteOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFFD347236F8A5500AE9310 /* ByteOffset.swift */; };
 		BCF9238E228AD94E0008C684 /* CursorInfoUSRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF9238D228AD94E0008C684 /* CursorInfoUSRTests.swift */; };
 		C236E84B1DFF5120003807D2 /* YamlRequestCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */; };
 		CDB51F33203E2899007563AE /* SwiftDocKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */; };
@@ -167,6 +169,8 @@
 		6CC1639B202AA3AE0086C459 /* UID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UID.swift; sourceTree = "<group>"; };
 		6CC381621ECACB50000C6F81 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		8F935B332288C05A00971070 /* File+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "File+Hashable.swift"; sourceTree = "<group>"; };
+		8FFFD345236F8A4200AE9310 /* ByteRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByteRange.swift; sourceTree = "<group>"; };
+		8FFFD347236F8A5500AE9310 /* ByteOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteOffset.swift; sourceTree = "<group>"; };
 		BCF9238D228AD94E0008C684 /* CursorInfoUSRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInfoUSRTests.swift; sourceTree = "<group>"; };
 		C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlRequestCommand.swift; sourceTree = "<group>"; };
 		CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocKeyTests.swift; sourceTree = "<group>"; };
@@ -438,6 +442,8 @@
 			isa = PBXGroup;
 			children = (
 				D0D1216F19E87B05005E4BAA /* Supporting Files */,
+				8FFFD345236F8A4200AE9310 /* ByteRange.swift */,
+				8FFFD347236F8A5500AE9310 /* ByteOffset.swift */,
 				3F0CBB401BAAFF160015BBA8 /* Clang+SourceKitten.swift */,
 				E8D4743A1A648F290011A49C /* ClangTranslationUnit.swift */,
 				E8EE34BE1B9A502F00947605 /* CodeCompletionItem.swift */,
@@ -746,7 +752,9 @@
 				55DB6A9722DEABD100666C6A /* UIDRepresentable.swift in Sources */,
 				E83748C31A5BCD7900862B1B /* OffsetMap.swift in Sources */,
 				E806D2911BE058C400D1BE41 /* Parameter.swift in Sources */,
+				8FFFD348236F8A5500AE9310 /* ByteOffset.swift in Sources */,
 				E868473A1A587B4D0043DC65 /* Request.swift in Sources */,
+				8FFFD346236F8A4200AE9310 /* ByteRange.swift in Sources */,
 				E8A9B8921B56D1B100CD17D4 /* SourceDeclaration.swift in Sources */,
 				E806D28D1BE0589B00D1BE41 /* SourceLocation.swift in Sources */,
 				E8AE53C71A5B5FCA0092D24A /* String+SourceKitten.swift in Sources */,


### PR DESCRIPTION
## What
Add ByteRange and ByteOffset wrapper to prevent disambiguation between NSRange (byte range ) and NSRange that represents ByteOffset range

## Why
While working with ranges and tokens and string in `Swiftlint` I realized that it is very easy to use one range when you need totally another one. And since NSRange represents both (byte and string,) and those aren't typed, the idea was to use a type that will reprensents values when youre' working in bytes and not-character/strings world.

## Pros
- It is hard to misguide NSRange with ByteRange
- Problems can only happen where conversion is made

## Cons
Breaks backward compatibility

## Additional
All the data that comes from SourceKit can be wrapped with ByteOffset/ByteRange. We can choose at what level we're about to stop.

## Alternatives
User ByteRange<ByteOffset, ByteOffset> types. This probably will do even better.