### PR TITLE
Stop and report an error if xcodebuild fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Stop the program immediately if the `xcodebuild` command fails.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#643](https://github.com/jpsim/SourceKitten/issues/643)
 
 ## 0.29.0
 

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -37,7 +37,7 @@ internal enum XcodeBuild {
     - returns: `xcodebuild`'s STDERR+STDOUT output combined.
     */
     internal static func run(arguments: [String], inPath path: String) -> String? {
-        return String(data: launch(arguments: arguments, inPath: path, pipingStandardError: true), encoding: .utf8)
+        return launch(arguments: arguments, inPath: path, pipingStandardError: true).string
     }
 
     /**
@@ -47,13 +47,13 @@ internal enum XcodeBuild {
      - parameter path:                Path to run `xcodebuild` from.
      - parameter pipingStandardError: Whether to pipe the standard error output. The default value is `true`.
 
-     - returns: `xcodebuild`'s STDOUT output and, optionally, both STDERR+STDOUT output combined.
+     - returns: `Exec.Result` containing `xcodebuild`'s exit status, STDOUT output and, optionally, both STDERR+STDOUT output combined.
      */
-    internal static func launch(arguments: [String], inPath path: String, pipingStandardError: Bool = true) -> Data {
+    internal static func launch(arguments: [String], inPath path: String, pipingStandardError: Bool = true) -> Exec.Results {
         return Exec.run("/usr/bin/xcodebuild",
                         arguments,
                         currentDirectory: path,
-                        stderr: pipingStandardError ? .merge : .inherit).data
+                        stderr: pipingStandardError ? .merge : .inherit)
     }
 
     /**
@@ -67,8 +67,8 @@ internal enum XcodeBuild {
     internal static func showBuildSettings(arguments xcodeBuildArguments: [String],
                                            inPath: String) -> [XcodeBuildSetting]? {
         let arguments = xcodeBuildArguments + ["-showBuildSettings", "-json"]
-        let outputData = XcodeBuild.launch(arguments: arguments, inPath: inPath, pipingStandardError: false)
-        return try? JSONDecoder().decode([XcodeBuildSetting].self, from: outputData)
+        let results = XcodeBuild.launch(arguments: arguments, inPath: inPath, pipingStandardError: false)
+        return try? JSONDecoder().decode([XcodeBuildSetting].self, from: results.data)
     }
 }
 


### PR DESCRIPTION
Fixes #643. (and probably the inexplicable stuff in realm/jazzy#1087)

This has happened since SourceKitten started running `xcodebuild` multiple times with the 'new' build system.  If the initial build fails then SourceKitten doesn't notice and can proceed to generate docs from the build manifest that the failing `xcodebuild` invocation has just created.

There are two things that can happen next:
1. Empty docs are generated.  This means `xcodebuild` has created the build manifest but _not_ populated the Swift response file.  Well proven in #643.
2. Partially complete docs are generated.  This time the response file is there, but there is probably a compilation error in one of the files meaning the SourceKit cursorinfo will silently fail in some places.  I don't _think_ this is a feature?

I can add a test -- I think would mean adding a failing Xcode project into fixtures.