### PR TITLE
Bypass codesign when building Xcode projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Always bypass codesigning when building Xcode projects.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1183](https://github.com/realm/jazzy/issues/1183)
 
 ## 0.30.1
 

--- a/Source/SourceKittenFramework/ClangTranslationUnit.swift
+++ b/Source/SourceKittenFramework/ClangTranslationUnit.swift
@@ -78,7 +78,7 @@ public struct ClangTranslationUnit {
     - parameter path:                Path to run `xcodebuild` from. Uses current path by default.
     */
     public init?(headerFiles: [String], xcodeBuildArguments: [String], inPath path: String = FileManager.default.currentDirectoryPath) {
-        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments + ["-dry-run"], inPath: path) ?? ""
+        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments + ["-dry-run"], inPath: path).string ?? ""
         guard let clangArguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput, language: .objc, moduleName: nil) else {
             fputs("could not parse compiler arguments\n\(xcodeBuildOutput)\n", stderr)
             return nil

--- a/Source/SourceKittenFramework/Module.swift
+++ b/Source/SourceKittenFramework/Module.swift
@@ -128,8 +128,7 @@ public struct Module {
             ?? moduleName(fromArguments: xcodeBuildArguments)
 
         // Executing normal build
-        fputs("Running xcodebuild\n", stderr)
-        let results = XcodeBuild.launch(arguments: xcodeBuildArguments, inPath: path)
+        let results = XcodeBuild.build(arguments: xcodeBuildArguments, inPath: path)
         if results.terminationStatus != 0 {
             fputs("Could not successfully run `xcodebuild`.\n", stderr)
             fputs("Please check the build arguments.\n", stderr)
@@ -153,7 +152,7 @@ public struct Module {
             return
         }
         // Executing `clean build` is a fallback.
-        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments, inPath: path) ?? ""
+        let xcodeBuildOutput = XcodeBuild.cleanBuild(arguments: xcodeBuildArguments, inPath: path).string ?? ""
         guard let arguments = parseCompilerArguments(xcodebuildOutput: xcodeBuildOutput, language: .swift, moduleName: name) else {
             fputs("Could not parse compiler arguments from `xcodebuild` output.\n", stderr)
             fputs("Please confirm that `xcodebuild` is building a Swift module.\n", stderr)

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -11,33 +11,32 @@ import Yams
 
 internal enum XcodeBuild {
     /**
-    Run `xcodebuild clean build` along with any passed in build arguments.
+    Run `xcodebuild clean build` bypassing signing, along with any passed in build arguments.
 
     - parameter arguments: Arguments to pass to `xcodebuild`.
     - parameter path:      Path to run `xcodebuild` from.
 
-    - returns: `xcodebuild`'s STDERR+STDOUT output combined.
+    - returns: results including `xcodebuild`'s STDERR+STDOUT output combined.
     */
-    internal static func cleanBuild(arguments: [String], inPath path: String) -> String? {
-        let arguments = arguments + ["clean",
-                                     "build",
-                                     "CODE_SIGN_IDENTITY=",
-                                     "CODE_SIGNING_REQUIRED=NO",
-                                     "CODE_SIGNING_ALLOWED=NO"]
-        fputs("Running xcodebuild\n", stderr)
-        return run(arguments: arguments, inPath: path)
+    internal static func cleanBuild(arguments: [String], inPath path: String) -> Exec.Results {
+        let arguments = arguments + ["clean", "build"]
+        return build(arguments: arguments, inPath: path)
     }
 
     /**
-    Run `xcodebuild` along with any passed in build arguments.
+    Run `xcodebuild` bypassing signing, along with any passed in build arguments.
 
     - parameter arguments: Arguments to pass to `xcodebuild`.
     - parameter path:      Path to run `xcodebuild` from.
 
-    - returns: `xcodebuild`'s STDERR+STDOUT output combined.
+    - returns: results including `xcodebuild`'s STDERR+STDOUT output combined.
     */
-    internal static func run(arguments: [String], inPath path: String) -> String? {
-        return launch(arguments: arguments, inPath: path, pipingStandardError: true).string
+    internal static func build(arguments: [String], inPath path: String) -> Exec.Results {
+        let arguments = arguments + ["CODE_SIGN_IDENTITY=",
+                                     "CODE_SIGNING_REQUIRED=NO",
+                                     "CODE_SIGNING_ALLOWED=NO"]
+        fputs("Running xcodebuild\n", stderr)
+        return launch(arguments: arguments, inPath: path, pipingStandardError: true)
     }
 
     /**
@@ -49,7 +48,7 @@ internal enum XcodeBuild {
 
      - returns: `Exec.Result` containing `xcodebuild`'s exit status, STDOUT output and, optionally, both STDERR+STDOUT output combined.
      */
-    internal static func launch(arguments: [String], inPath path: String, pipingStandardError: Bool = true) -> Exec.Results {
+    private static func launch(arguments: [String], inPath path: String, pipingStandardError: Bool = true) -> Exec.Results {
         return Exec.run("/usr/bin/xcodebuild",
                         arguments,
                         currentDirectory: path,


### PR DESCRIPTION
Continuation of / fixup for #646, fixes realm/jazzy#1183.

If we're going to stop when `xcodebuild` fails we must make sure to set the vars that
disable code signing otherwise it will just fail for signing-related reasons and never
make it to the 'clean build' part.

Build with this change makes the projects from the jazzy issue build cleanly.