### PR TITLE
Add markup delimiters supported by Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Update Yams to 3.0.0.  
   [Keith Smiley](https://github.com/keith)
+* Extract all supported delimiters from document XML.
+  [Eneko Alonso](https://github.com/eneko)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -459,6 +459,10 @@ public func parseFullXMLDocs(_ xmlDocs: String) -> [String: SourceKitRepresentab
         .replacingOccurrences(of: "</rawHTML>", with: "")
         .replacingOccurrences(of: "<codeVoice>", with: "`")
         .replacingOccurrences(of: "</codeVoice>", with: "`")
+        .replacingOccurrences(of: "<emphasis>", with: "_")
+        .replacingOccurrences(of: "</emphasis>", with: "_")
+//        .replacingOccurrences(of: "<strong>", with: "**")
+//        .replacingOccurrences(of: "</strong>", with: "**")
     return SWXMLHash.parse(cleanXMLDocs).children.first.map { rootXML in
         var docs = [String: SourceKitRepresentable]()
         docs[SwiftDocKey.docType.rawValue] = rootXML.element?.name
@@ -484,10 +488,38 @@ public func parseFullXMLDocs(_ xmlDocs: String) -> [String: SourceKitRepresentab
             }
             docs[SwiftDocKey.docParameters.rawValue] = parameters.map(docParameters(from:)) as [SourceKitRepresentable]
         }
+        docs[SwiftDocKey.docAbstract.rawValue] = commentPartsXML["Abstract"].childrenAsArray()
         docs[SwiftDocKey.docDiscussion.rawValue] = commentPartsXML["Discussion"].childrenAsArray()
         docs[SwiftDocKey.docResultDiscussion.rawValue] = commentPartsXML["ResultDiscussion"].childrenAsArray()
+        docs[SwiftDocKey.docThrowsDiscussion.rawValue] = commentPartsXML["ThrowsDiscussion"].childrenAsArray()
+        populateDelimiters(docs: &docs, discussion: commentPartsXML["Discussion"])
         return docs
     }
+}
+
+/// Delimiters extracted from discussion (supported by Xcode)
+/// - see: https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/MarkupFunctionality.html
+func populateDelimiters(docs: inout [String: SourceKitRepresentable], discussion: XMLIndexer) {
+    docs[SwiftDocKey.docAttention.rawValue] = discussion["Attention"].childrenAsArray()
+    docs[SwiftDocKey.docAuthor.rawValue] = discussion["Author"].childrenAsArray()
+    docs[SwiftDocKey.docAuthors.rawValue] = discussion["Authors"].childrenAsArray()
+    docs[SwiftDocKey.docBug.rawValue] = discussion["Bug"].childrenAsArray()
+    docs[SwiftDocKey.docComplexity.rawValue] = discussion["Complexity"].childrenAsArray()
+    docs[SwiftDocKey.docCopyright.rawValue] = discussion["Copyright"].childrenAsArray()
+    docs[SwiftDocKey.docDate.rawValue] = discussion["Date"].childrenAsArray()
+    docs[SwiftDocKey.docExperiment.rawValue] = discussion["Experiment"].childrenAsArray()
+    docs[SwiftDocKey.docImportant.rawValue] = discussion["Important"].childrenAsArray()
+    docs[SwiftDocKey.docInvariant.rawValue] = discussion["Invariant"].childrenAsArray()
+    docs[SwiftDocKey.docNote.rawValue] = discussion["Note"].childrenAsArray()
+    docs[SwiftDocKey.docPostcondition.rawValue] = discussion["Postcondition"].childrenAsArray()
+    docs[SwiftDocKey.docPrecondition.rawValue] = discussion["Precondition"].childrenAsArray()
+    docs[SwiftDocKey.docRemark.rawValue] = discussion["Remark"].childrenAsArray()
+    docs[SwiftDocKey.docRequires.rawValue] = discussion["Requires"].childrenAsArray()
+    docs[SwiftDocKey.docSeeAlso.rawValue] = discussion["See"].childrenAsArray()
+    docs[SwiftDocKey.docSince.rawValue] = discussion["Since"].childrenAsArray()
+    docs[SwiftDocKey.docToDo.rawValue] = discussion["TODO"].childrenAsArray()
+    docs[SwiftDocKey.docVersion.rawValue] = discussion["Version"].childrenAsArray()
+    docs[SwiftDocKey.docWarning.rawValue] = discussion["Warning"].childrenAsArray()
 }
 
 private extension XMLIndexer {

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -53,6 +53,8 @@ public enum SwiftDocKey: String {
     case documentationComment = "key.doc.comment"
     /// Declaration of documented token (String).
     case docDeclaration       = "key.doc.declaration"
+    /// Abstract of documented token
+    case docAbstract          = "key.doc.abstract"
     /// Discussion documentation of documented token ([SourceKitRepresentable]).
     case docDiscussion        = "key.doc.discussion"
     /// File where the documented token is located (String).
@@ -65,6 +67,8 @@ public enum SwiftDocKey: String {
     case docParameters        = "key.doc.parameters"
     /// Parsed declaration (String).
     case docResultDiscussion  = "key.doc.result_discussion"
+    /// Throws delimiter from documented token
+    case docThrowsDiscussion  = "key.doc.throws_discussion"
     /// Parsed scope start (Int64).
     case docType              = "key.doc.type"
     /// Parsed scope start end (Int64).
@@ -89,6 +93,49 @@ public enum SwiftDocKey: String {
     case unavailableMessage   = "key.unavailable_message"
     /// Annotations ([String]).
     case annotations          = "key.annotations"
+
+    // MARK: Delimiters extracted from discussion
+
+    /// Content of `- attention:` delimiter
+    case docAttention         = "key.doc.attention"
+    /// Content of `- author:` delimiter
+    case docAuthor            = "key.doc.author"
+    /// Content of `- authors:` delimiter
+    case docAuthors           = "key.doc.authors"
+    /// Content of `- bug:` delimiter
+    case docBug               = "key.doc.bug"
+    /// Content of `- complexity:` delimiter
+    case docComplexity        = "key.doc.complexity"
+    /// Content of `- copyright:` delimiter
+    case docCopyright         = "key.doc.copyright"
+    /// Content of `- date:` delimiter
+    case docDate              = "key.doc.date"
+    /// Content of `- experiment:` delimiter
+    case docExperiment        = "key.doc.experiment"
+    /// Content of `- important:` delimiter
+    case docImportant         = "key.doc.important"
+    /// Content of `- invariant:` delimiter
+    case docInvariant         = "key.doc.invariant"
+    /// Content of `- note:` delimiter
+    case docNote              = "key.doc.note"
+    /// Content of `- postcondition:` delimiter
+    case docPostcondition     = "key.doc.postcondition"
+    /// Content of `- precondition:` delimiter
+    case docPrecondition      = "key.doc.precondition"
+    /// Content of `- remark:` delimiter
+    case docRemark            = "key.doc.remark"
+    /// Content of `- requires:` delimiter
+    case docRequires          = "key.doc.requires"
+    /// Content of `- see:` and `- seealso:` delimiters
+    case docSeeAlso           = "key.doc.see_also"
+    /// Content of `- since:` delimiter
+    case docSince             = "key.doc.since"
+    /// Content of `- toDo:` delimiter
+    case docToDo              = "key.doc.to_do"
+    /// Content of `- version:` delimiter
+    case docVersion           = "key.doc.version"
+    /// Content of `- warning:` delimiter
+    case docWarning           = "key.doc.warning"
 
     // MARK: Typed SwiftDocKey Getters
 

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Bicycle@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Bicycle@swift-5.0.json
@@ -53,6 +53,11 @@
         ],
         "key.bodylength" : 2222,
         "key.bodyoffset" : 248,
+        "key.doc.abstract" : [
+          {
+            "Para" : "🚲 A two-wheeled, human-powered mode of transportation."
+          }
+        ],
         "key.doc.column" : 14,
         "key.doc.comment" : "🚲 A two-wheeled, human-powered mode of transportation.",
         "key.doc.declaration" : "public class Bicycle",
@@ -88,6 +93,11 @@
             ],
             "key.bodylength" : 49,
             "key.bodyoffset" : 492,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Frame and construction style."
+              }
+            ],
             "key.doc.column" : 17,
             "key.doc.comment" : "Frame and construction style.\n\n- Road: For streets or trails.\n- Touring: For long journeys.\n- Cruiser: For casual trips around town.\n- Hybrid: For general-purpose transportation.",
             "key.doc.declaration" : "public enum Bicycle.Bicycle.Style",
@@ -213,6 +223,11 @@
             ],
             "key.bodylength" : 60,
             "key.bodyoffset" : 733,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Mechanism for converting pedal power into motion."
+              }
+            ],
             "key.doc.column" : 17,
             "key.doc.comment" : "Mechanism for converting pedal power into motion.\n\n- Fixed: A single, fixed gear.\n- Freewheel: A variable-speed, disengageable gear.",
             "key.doc.declaration" : "public enum Bicycle.Bicycle.Gearing",
@@ -304,6 +319,11 @@
             "key.annotated_decl" : "<Declaration>enum <Type usr=\"s:7BicycleAAC\">Bicycle<\/Type>.Handlebar<\/Declaration>",
             "key.bodylength" : 47,
             "key.bodyoffset" : 1009,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Hardware used for steering."
+              }
+            ],
             "key.doc.column" : 10,
             "key.doc.comment" : "Hardware used for steering.\n\n- Riser: A casual handlebar.\n- Café: An upright handlebar.\n- Drop: A classic handlebar.\n- Bullhorn: A powerful handlebar.",
             "key.doc.declaration" : "enum Bicycle.Bicycle.Handlebar",
@@ -420,6 +440,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let style: <Type usr=\"s:7BicycleAAC5StyleO\">Style<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The style of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The style of the bicycle.",
             "key.doc.declaration" : "let style: Style",
@@ -448,6 +473,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let gearing: <Type usr=\"s:7BicycleAAC7GearingO\">Gearing<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The gearing of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The gearing of the bicycle.",
             "key.doc.declaration" : "let gearing: Gearing",
@@ -476,6 +506,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let handlebar: <Type usr=\"s:7BicycleAAC9HandlebarO\">Handlebar<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The handlebar of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The handlebar of the bicycle.",
             "key.doc.declaration" : "let handlebar: Handlebar",
@@ -504,6 +539,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let frameSize: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The size of the frame, in centimeters."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The size of the frame, in centimeters.",
             "key.doc.declaration" : "let frameSize: Int",
@@ -537,6 +577,11 @@
                 "key.attribute" : "source.decl.attribute.setter_access.private",
                 "key.length" : 12,
                 "key.offset" : 1374
+              }
+            ],
+            "key.doc.abstract" : [
+              {
+                "Para" : "The number of trips travelled by the bicycle."
               }
             ],
             "key.doc.column" : 22,
@@ -575,6 +620,11 @@
                 "key.offset" : 1479
               }
             ],
+            "key.doc.abstract" : [
+              {
+                "Para" : "The total distance travelled by the bicycle, in meters."
+              }
+            ],
             "key.doc.column" : 22,
             "key.doc.comment" : "The total distance travelled by the bicycle, in meters.",
             "key.doc.declaration" : "private(set) var distanceTravelled: Double {\n    get\n    }",
@@ -606,6 +656,11 @@
             "key.annotated_decl" : "<Declaration>init(style: <Type usr=\"s:7BicycleAAC5StyleO\">Style<\/Type>, gearing: <Type usr=\"s:7BicycleAAC7GearingO\">Gearing<\/Type>, handlebar: <Type usr=\"s:7BicycleAAC9HandlebarO\">Handlebar<\/Type>, frameSize centimeters: <Type usr=\"s:Si\">Int<\/Type>)<\/Declaration>",
             "key.bodylength" : 192,
             "key.bodyoffset" : 2010,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Initializes a new bicycle with the provided parts and specifications."
+              }
+            ],
             "key.doc.column" : 5,
             "key.doc.comment" : "Initializes a new bicycle with the provided parts and specifications.\n\n- parameter style: The style of the bicycle\n- parameter gearing: The gearing of the bicycle\n- parameter handlebar: The handlebar of the bicycle\n- parameter centimeters: The frame size of the bicycle, in centimeters\n\n- returns: A beautiful, brand-new, custom built just for you.",
             "key.doc.declaration" : "init(style: Style, gearing: Gearing, handlebar: Handlebar, frameSize centimeters: Int)",
@@ -678,6 +733,11 @@
             "key.annotated_decl" : "<Declaration>func travel(distance meters: <Type usr=\"s:Sd\">Double<\/Type>)<\/Declaration>",
             "key.bodylength" : 112,
             "key.bodyoffset" : 2356,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Take a bike out for a spin."
+              }
+            ],
             "key.doc.column" : 10,
             "key.doc.comment" : "Take a bike out for a spin.\n\n- parameter meters: The distance to travel in meters.",
             "key.doc.declaration" : "func travel(distance meters: Double)",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Bicycle@swift-5.1.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Bicycle@swift-5.1.json
@@ -53,6 +53,11 @@
         ],
         "key.bodylength" : 2222,
         "key.bodyoffset" : 248,
+        "key.doc.abstract" : [
+          {
+            "Para" : "🚲 A two-wheeled, human-powered mode of transportation."
+          }
+        ],
         "key.doc.column" : 14,
         "key.doc.comment" : "🚲 A two-wheeled, human-powered mode of transportation.",
         "key.doc.declaration" : "public class Bicycle",
@@ -88,6 +93,11 @@
             ],
             "key.bodylength" : 49,
             "key.bodyoffset" : 492,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Frame and construction style."
+              }
+            ],
             "key.doc.column" : 17,
             "key.doc.comment" : "Frame and construction style.\n\n- Road: For streets or trails.\n- Touring: For long journeys.\n- Cruiser: For casual trips around town.\n- Hybrid: For general-purpose transportation.",
             "key.doc.declaration" : "public enum Bicycle.Bicycle.Style",
@@ -213,6 +223,11 @@
             ],
             "key.bodylength" : 60,
             "key.bodyoffset" : 733,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Mechanism for converting pedal power into motion."
+              }
+            ],
             "key.doc.column" : 17,
             "key.doc.comment" : "Mechanism for converting pedal power into motion.\n\n- Fixed: A single, fixed gear.\n- Freewheel: A variable-speed, disengageable gear.",
             "key.doc.declaration" : "public enum Bicycle.Bicycle.Gearing",
@@ -304,6 +319,11 @@
             "key.annotated_decl" : "<Declaration>enum <Type usr=\"s:7BicycleAAC\">Bicycle<\/Type>.Handlebar<\/Declaration>",
             "key.bodylength" : 47,
             "key.bodyoffset" : 1009,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Hardware used for steering."
+              }
+            ],
             "key.doc.column" : 10,
             "key.doc.comment" : "Hardware used for steering.\n\n- Riser: A casual handlebar.\n- Café: An upright handlebar.\n- Drop: A classic handlebar.\n- Bullhorn: A powerful handlebar.",
             "key.doc.declaration" : "enum Bicycle.Bicycle.Handlebar",
@@ -420,6 +440,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let style: <Type usr=\"s:7BicycleAAC5StyleO\">Style<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The style of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The style of the bicycle.",
             "key.doc.declaration" : "let style: Style",
@@ -448,6 +473,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let gearing: <Type usr=\"s:7BicycleAAC7GearingO\">Gearing<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The gearing of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The gearing of the bicycle.",
             "key.doc.declaration" : "let gearing: Gearing",
@@ -476,6 +506,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let handlebar: <Type usr=\"s:7BicycleAAC9HandlebarO\">Handlebar<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The handlebar of the bicycle."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The handlebar of the bicycle.",
             "key.doc.declaration" : "let handlebar: Handlebar",
@@ -504,6 +539,11 @@
           {
             "key.accessibility" : "source.lang.swift.accessibility.internal",
             "key.annotated_decl" : "<Declaration>let frameSize: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.doc.abstract" : [
+              {
+                "Para" : "The size of the frame, in centimeters."
+              }
+            ],
             "key.doc.column" : 9,
             "key.doc.comment" : "The size of the frame, in centimeters.",
             "key.doc.declaration" : "let frameSize: Int",
@@ -537,6 +577,11 @@
                 "key.attribute" : "source.decl.attribute.setter_access.private",
                 "key.length" : 12,
                 "key.offset" : 1374
+              }
+            ],
+            "key.doc.abstract" : [
+              {
+                "Para" : "The number of trips travelled by the bicycle."
               }
             ],
             "key.doc.column" : 22,
@@ -575,6 +620,11 @@
                 "key.offset" : 1479
               }
             ],
+            "key.doc.abstract" : [
+              {
+                "Para" : "The total distance travelled by the bicycle, in meters."
+              }
+            ],
             "key.doc.column" : 22,
             "key.doc.comment" : "The total distance travelled by the bicycle, in meters.",
             "key.doc.declaration" : "private(set) var distanceTravelled: Double {\n    get\n    }",
@@ -606,6 +656,11 @@
             "key.annotated_decl" : "<Declaration>init(style: <Type usr=\"s:7BicycleAAC5StyleO\">Style<\/Type>, gearing: <Type usr=\"s:7BicycleAAC7GearingO\">Gearing<\/Type>, handlebar: <Type usr=\"s:7BicycleAAC9HandlebarO\">Handlebar<\/Type>, frameSize centimeters: <Type usr=\"s:Si\">Int<\/Type>)<\/Declaration>",
             "key.bodylength" : 192,
             "key.bodyoffset" : 2010,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Initializes a new bicycle with the provided parts and specifications."
+              }
+            ],
             "key.doc.column" : 5,
             "key.doc.comment" : "Initializes a new bicycle with the provided parts and specifications.\n\n- parameter style: The style of the bicycle\n- parameter gearing: The gearing of the bicycle\n- parameter handlebar: The handlebar of the bicycle\n- parameter centimeters: The frame size of the bicycle, in centimeters\n\n- returns: A beautiful, brand-new, custom built just for you.",
             "key.doc.declaration" : "init(style: Style, gearing: Gearing, handlebar: Handlebar, frameSize centimeters: Int)",
@@ -678,6 +733,11 @@
             "key.annotated_decl" : "<Declaration>func travel(distance meters: <Type usr=\"s:Sd\">Double<\/Type>)<\/Declaration>",
             "key.bodylength" : 112,
             "key.bodyoffset" : 2356,
+            "key.doc.abstract" : [
+              {
+                "Para" : "Take a bike out for a spin."
+              }
+            ],
             "key.doc.column" : 10,
             "key.doc.comment" : "Take a bike out for a spin.\n\n- parameter meters: The distance to travel in meters.",
             "key.doc.declaration" : "func travel(distance meters: Double)",

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Subscript@swift-5.0.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Subscript@swift-5.0.json
@@ -29,6 +29,11 @@
             "key.doc.column" : 5,
             "key.doc.comment" : "Returns or sets Void.",
             "key.doc.declaration" : "subscript(key: String) -> () { get set }",
+            "key.doc.abstract" : [
+              {
+                "Para" : "Returns or sets Void."
+              }
+            ],
             "key.doc.file" : "Subscript.swift",
             "key.doc.full_as_xml" : "<Other file=\"Subscript.swift\" line=\"3\" column=\"5\"><Name>subscript(_:)<\/Name><USR>s:9Subscript10VoidStructVyySScip<\/USR><Declaration>subscript(key: String) -&gt; () { get set }<\/Declaration><CommentParts><Abstract><Para>Returns or sets Void.<\/Para><\/Abstract><\/CommentParts><\/Other>",
             "key.doc.line" : 3,

--- a/Tests/SourceKittenFrameworkTests/SwiftDocMarkupDelimiterTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocMarkupDelimiterTests.swift
@@ -1,0 +1,352 @@
+//
+//  SwiftDocMarkupDelimiterTests.swift
+//  SourceKittenFrameworkTests
+//
+//  Created by Eneko Alonso on 5/28/20.
+//  Copyright © 2020 SourceKitten. All rights reserved.
+//
+
+import SourceKittenFramework
+import XCTest
+
+let markupDelmitersXML = """
+<Function file=\"/path/to/file.swift\" line=\"126\" column=\"17\">\
+<Name>hello(name:)</Name>\
+<USR>s:14SourceDocsDemo10FullMarkupV5hello4nameS2S_tKF</USR>\
+<Declaration>public func hello(name: String) throws -&gt; String</Declaration>\
+<CommentParts>\
+<Abstract>\
+<Para>Method to say hello to a person or thing</Para>\
+</Abstract>\
+<Parameters>\
+<Parameter>\
+<Name>name</Name>\
+<Direction isExplicit=\"0\">in</Direction>\
+<Discussion>\
+<Para>Name of the person or thing to salute</Para>\
+</Discussion>\
+</Parameter>\
+<Parameter>\
+<Name>name</Name>\
+<Direction isExplicit=\"0\">in</Direction>\
+<Discussion>\
+<Para>Name of the person or thing to salute</Para>\
+</Discussion>\
+</Parameter>\
+</Parameters>\
+<ResultDiscussion>\
+<Para>\
+<codeVoice>String</codeVoice> with salute (eg. “Hello, Kelly!”)</Para>\
+</ResultDiscussion>\
+<ThrowsDiscussion>\
+<Para>\
+<codeVoice>Error.noName</codeVoice> when name is empty</Para>\
+</ThrowsDiscussion>\
+<Discussion>\
+<Para>This should be the discussion, where we can ellaborate what the method does, providing details and examples.</Para>\
+<rawHTML>\
+<![CDATA[<hr/>]]>\
+</rawHTML>\
+<rawHTML>\
+<![CDATA[<h1>]]>\
+</rawHTML>Heading 1<rawHTML>\
+<![CDATA[</h1>]]>\
+</rawHTML>\
+<Para>Foo</Para>\
+<rawHTML>\
+<![CDATA[<h2>]]>\
+</rawHTML>Heading 2<rawHTML>\
+<![CDATA[</h2>]]>\
+</rawHTML>\
+<Para>Bar</Para>\
+<rawHTML>\
+<![CDATA[<h3>]]>\
+</rawHTML>Heading 3<rawHTML>\
+<![CDATA[</h3>]]>\
+</rawHTML>\
+<Para>Baz</Para>\
+<CodeListing language=\"swift\">\
+<zCodeLineNumbered>\
+<![CDATA[print(\"This is some code\")]]>\
+</zCodeLineNumbered>\
+<zCodeLineNumbered>\
+</zCodeLineNumbered>\
+</CodeListing>\
+<Para>This should be blockquoted text</Para>\
+<CodeListing language=\"swift\">\
+<zCodeLineNumbered>\
+<![CDATA[dump(\"Code block with backquotes\")]]>\
+</zCodeLineNumbered>\
+<zCodeLineNumbered>\
+</zCodeLineNumbered>\
+</CodeListing>\
+<Para>An ordered list of elements:</Para>\
+<List-Number>\
+<Item>\
+<Para>Foo</Para>\
+</Item>\
+<Item>\
+<Para>Bar</Para>\
+</Item>\
+<Item>\
+<Para>Baz</Para>\
+</Item>\
+</List-Number>\
+<Para>A bulleted list:</Para>\
+<List-Bullet>\
+<Item>\
+<Para>Foo</Para>\
+</Item>\
+<Item>\
+<Para>Bar</Para>\
+</Item>\
+<Item>\
+<Para>Baz</Para>\
+</Item>\
+</List-Bullet>\
+<Para>\
+<emphasis>Italics</emphasis> and <emphasis>italics</emphasis> <bold>Bold</bold> and <bold>bold</bold>\
+</Para>\
+<Para>* This is not a bullet item</Para>\
+<rawHTML>\
+<![CDATA[<hr/>]]>\
+</rawHTML>\
+<Attention>\
+<Para>Use the callout to highlight information for the user of the symbol.</Para>\
+</Attention>\
+<Author>\
+<Para>Use the callout to display the author of the code for a symbol.</Para>\
+</Author>\
+<Authors>\
+<Para> A</Para>\
+<Para>List</Para>\
+<Para>Of Authors</Para>\
+</Authors>\
+<Bug>\
+<Para>Use the callout to display a bug for a symbol.</Para>\
+</Bug>\
+<Complexity>\
+<Para>Use the callout to display the algorithmic complexity of a method or function.</Para>\
+</Complexity>\
+<Copyright>\
+<Para>Use the callout to display copyright information for a symbol.</Para>\
+</Copyright>\
+<Date>\
+<Para>May 28, 2020</Para>\
+</Date>\
+<Experiment>\
+<Para>Here is some example code:</Para>\
+<CodeListing language=\"swift\">\
+<zCodeLineNumbered>\
+<![CDATA[FullMarkup.hello(name: \"Foo\")]]>\
+</zCodeLineNumbered>\
+<zCodeLineNumbered>\
+</zCodeLineNumbered>\
+</CodeListing>\
+</Experiment>\
+<Important>\
+<Para>Use the callout to highlight information that can have adverse effects on the tasks a user is trying to accomplish.</Para>\
+</Important>\
+<Invariant>\
+<Para>Use the callout to display a condition that is guaranteed to be true during the execution of the documented symbol.</Para>\
+</Invariant>\
+<Note>\
+<Para>This is a note, that I’m sure of</Para>\
+</Note>\
+<Postcondition>\
+<Para>Use the callout to document conditions which have guaranteed values upon completion of the execution of the symbol.</Para>\
+</Postcondition>\
+<Precondition>\
+<Para>Use the callout to document any conditions that are held for the documented symbol to work.</Para>\
+</Precondition>\
+<Remark>\
+<Para>This is <emphasis>remarkable</emphasis>\
+</Para>\
+</Remark>\
+<Requires>\
+<Para>Non-empty name</Para>\
+</Requires>\
+<See>\
+<Para>Use the callout to add references to other information.</Para>\
+</See>\
+<Since>\
+<Para>Use the callout to add information about when the symbol became available. Some example of the types of information include dates, \
+framework versions, and operating system versions.</Para>\
+</Since>\
+<TODO>\
+<Para>Use the callout to add tasks required to complete or update the functionality of the symbol.</Para>\
+</TODO>\
+<Version>\
+<Para>v1.2.3</Para>\
+</Version>\
+<Warning>\
+<Para>So many delimiters</Para>\
+</Warning>\
+<List-Bullet>\
+<Item>\
+<Para>Foo: Custom unsuported delimiters, appear as bulleted list items</Para>\
+</Item>\
+</List-Bullet>\
+<Para>This is more text after all the delimiters list. Still part of the main discussion.</Para>\
+</Discussion>\
+</CommentParts>\
+</Function>
+"""
+
+class SwiftDocMarkupDelimiterTests: XCTestCase {
+
+    func testAbstract() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Method to say hello to a person or thing"]]
+        XCTAssertEqual(dictionary?.get(.docAbstract), expectation)
+    }
+
+    func testThrowsDiscussion() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "`Error.noName` when name is empty"]]
+        XCTAssertEqual(dictionary?.get(.docThrowsDiscussion), expectation)
+    }
+
+    func testAttentionDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to highlight information for the user of the symbol."]]
+        XCTAssertEqual(dictionary?.get(.docAttention), expectation)
+    }
+
+    func testAuthorDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to display the author of the code for a symbol."]]
+        XCTAssertEqual(dictionary?.get(.docAuthor), expectation)
+    }
+
+    func testAuthorsDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [
+            ["Para": " A"],
+            ["Para": "List"],
+            ["Para": "Of Authors"]
+        ]
+        XCTAssertEqual(dictionary?.get(.docAuthors), expectation)
+    }
+
+    func testBugDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to display a bug for a symbol."]]
+        XCTAssertEqual(dictionary?.get(.docBug), expectation)
+    }
+
+    func testComplexityDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to display the algorithmic complexity of a method or function."]]
+        XCTAssertEqual(dictionary?.get(.docComplexity), expectation)
+    }
+
+    func testCopyrightDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to display copyright information for a symbol."]]
+        XCTAssertEqual(dictionary?.get(.docCopyright), expectation)
+    }
+
+    func testDateDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "May 28, 2020"]]
+        XCTAssertEqual(dictionary?.get(.docDate), expectation)
+    }
+
+    /// - toDo: Figure out a way to extract paragraphs and any other type of nested elements (lists, code blocks, etc)
+    func testExperimentDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [
+            ["Para": "Here is some example code:"],
+            ["CodeListing": ""]
+        ]
+        XCTAssertEqual(dictionary?.get(.docExperiment), expectation)
+    }
+
+    func testImportantDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [
+            ["Para": "Use the callout to highlight information that can have adverse effects on the tasks a user is trying to accomplish."]
+        ]
+        XCTAssertEqual(dictionary?.get(.docImportant), expectation)
+    }
+
+    func testInvariantDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [
+            ["Para": "Use the callout to display a condition that is guaranteed to be true during the execution of the documented symbol."]
+        ]
+        XCTAssertEqual(dictionary?.get(.docInvariant), expectation)
+    }
+
+    func testNoteDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "This is a note, that I’m sure of"]]
+        XCTAssertEqual(dictionary?.get(.docNote), expectation)
+    }
+
+    func testPostconditionDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to document conditions which have guaranteed values upon completion of the execution of the symbol."]]
+        XCTAssertEqual(dictionary?.get(.docPostcondition), expectation)
+    }
+
+    func testPreconditionDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to document any conditions that are held for the documented symbol to work."]]
+        XCTAssertEqual(dictionary?.get(.docPrecondition), expectation)
+    }
+
+    func testRemarkDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "This is _remarkable_"]]
+        XCTAssertEqual(dictionary?.get(.docRemark), expectation)
+    }
+
+    func testRequiresDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Non-empty name"]]
+        XCTAssertEqual(dictionary?.get(.docRequires), expectation)
+    }
+
+    func testSeeAlsoDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to add references to other information."]]
+        XCTAssertEqual(dictionary?.get(.docSeeAlso), expectation)
+    }
+
+    func testSinceDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": """
+            Use the callout to add information about when the symbol became available. \
+            Some example of the types of information include dates, \
+            framework versions, and operating system versions.
+            """]
+        ]
+        XCTAssertEqual(dictionary?.get(.docSince), expectation)
+    }
+
+    func testToDoDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "Use the callout to add tasks required to complete or update the functionality of the symbol."]]
+        XCTAssertEqual(dictionary?.get(.docToDo), expectation)
+    }
+
+    func testVersionDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "v1.2.3"]]
+        XCTAssertEqual(dictionary?.get(.docVersion), expectation)
+    }
+
+    func testWarningDelimiter() {
+        let dictionary = parseFullXMLDocs(markupDelmitersXML)
+        let expectation = [["Para": "So many delimiters"]]
+        XCTAssertEqual(dictionary?.get(.docWarning), expectation)
+    }
+}
+
+extension Dictionary where Key == String, Value == SourceKitRepresentable {
+    func get(_ key: SwiftDocKey) -> [[String: String]]? {
+        return self[key.rawValue] as? [[String: String]]
+    }
+}

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -140,6 +140,7 @@ class SwiftDocsTests: XCTestCase {
             "key.doc.name": "name",
             "key.usr": "usr",
             "key.doc.declaration": "declaration",
+            "key.doc.abstract": [["Para": "discussion"]],
             "key.doc.parameters": [[
                 "name": "param1",
                 "discussion": [["Para": "param1_discussion"]]

--- a/sourcekitten.xcodeproj/project.pbxproj
+++ b/sourcekitten.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		6CCFCE8E1CFED000003239EB /* Commandant.framework in Embed Frameworks into SourceKittenFramework.framework */ = {isa = PBXBuildFile; fileRef = E8EBAA5D1A5D374B002F1B8E /* Commandant.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8F935B342288C05A00971070 /* File+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F935B332288C05A00971070 /* File+Hashable.swift */; };
 		8FB50D0623BFF035004F0F2B /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB50D0523BFF035004F0F2B /* Line.swift */; };
+		9C57920B2480C60800ADCD37 /* SwiftDocMarkupDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C57920A2480C60800ADCD37 /* SwiftDocMarkupDelimiterTests.swift */; };
 		BCF9238E228AD94E0008C684 /* CursorInfoUSRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF9238D228AD94E0008C684 /* CursorInfoUSRTests.swift */; };
 		C236E84B1DFF5120003807D2 /* YamlRequestCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */; };
 		CDB51F33203E2899007563AE /* SwiftDocKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */; };
@@ -173,6 +174,7 @@
 		6CC381621ECACB50000C6F81 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		8F935B332288C05A00971070 /* File+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "File+Hashable.swift"; sourceTree = "<group>"; };
 		8FB50D0523BFF035004F0F2B /* Line.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
+		9C57920A2480C60800ADCD37 /* SwiftDocMarkupDelimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocMarkupDelimiterTests.swift; sourceTree = "<group>"; };
 		BCF9238D228AD94E0008C684 /* CursorInfoUSRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInfoUSRTests.swift; sourceTree = "<group>"; };
 		C236E84A1DFF5120003807D2 /* YamlRequestCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlRequestCommand.swift; sourceTree = "<group>"; };
 		CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDocKeyTests.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 				E8C9EA071A5C99C400A6D4D1 /* StringTests.swift */,
 				E8C9EA031A5C986A00A6D4D1 /* StructureTests.swift */,
 				CDB51F32203E2899007563AE /* SwiftDocKeyTests.swift */,
+				9C57920A2480C60800ADCD37 /* SwiftDocMarkupDelimiterTests.swift */,
 				E80F23661A5CADD900FD2352 /* SwiftDocsTests.swift */,
 				D0DB09A319EA354200234B16 /* SyntaxTests.swift */,
 				BCF9238D228AD94E0008C684 /* CursorInfoUSRTests.swift */,
@@ -803,6 +806,7 @@
 				E8C9EA081A5C99C400A6D4D1 /* StringTests.swift in Sources */,
 				CDB51F33203E2899007563AE /* SwiftDocKeyTests.swift in Sources */,
 				E8C9EA041A5C986A00A6D4D1 /* StructureTests.swift in Sources */,
+				9C57920B2480C60800ADCD37 /* SwiftDocMarkupDelimiterTests.swift in Sources */,
 				E80F23671A5CADD900FD2352 /* SwiftDocsTests.swift in Sources */,
 				D0DB09A419EA354200234B16 /* SyntaxTests.swift in Sources */,
 			);


### PR DESCRIPTION
## Summary
This PR adds support for documentation markup delimiters supported by Xcode (see [full list of markup delimiters](https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/MarkupFunctionality.html)).

### Code changes
- Update `parseFullXMLDocs` method in `File.swift` to extract `Abstract`, `ThrowsDiscussion` and other supported delimiters from XML document
- Update `parseFullXMLDocs` to support _emphasis_ by replacing `<emphasis>` with `_`
- Add new keys to `SwiftDocKey` enum
- Add `SwiftDocMarkupDelimiterTests` to test each supported delimiter
- Update test fixtures as needed


_Note_: Some fixtures are pending to be updated, will fix soon. Any help by maintainers would be appreciated.

