### PR TITLE
Fix type on Linux with Swift 5.2

### DIFF
--- a/Source/SourceKittenFramework/CodeCompletionItem.swift
+++ b/Source/SourceKittenFramework/CodeCompletionItem.swift
@@ -15,7 +15,7 @@ fileprivate extension Dictionary {
 }
 
 public struct CodeCompletionItem: CustomStringConvertible {
-    #if os(Linux)
+    #if os(Linux) && swift(<5.2)
     public typealias NumBytesInt = Int
     #else
     public typealias NumBytesInt = Int64


### PR DESCRIPTION
With Swift 5.2 this code produced this warning:

```
Source/SourceKittenFramework/CodeCompletionItem.swift:65:65: error: cast from 'SourceKitRepresentable?' to unrelated type 'CodeCompletionItem.NumBytesInt' (aka 'Int') always fails
                numBytesToErase: dict["key.num_bytes_to_erase"] as? NumBytesInt)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^   ~~~~~~~~~~~
```

Switching this to use `Int64` as it does on Darwin seems to fix this.
I've left the conditional here for older versions of Swift on Linux

https://github.com/jpsim/sourcekitten/commit/61b3edf36f4042b7069d9deaa41df5b758542d91