### PR TITLE
Include Glibc to support stderr.

### DIFF
--- a/Source/SourceKittenFramework/SwiftDocs.swift
+++ b/Source/SourceKittenFramework/SwiftDocs.swift
@@ -2,6 +2,10 @@
 import SourceKit
 #endif
 
+#if os(Linux)
+import Glibc
+#endif
+
 /// Represents docs for a Swift file.
 public struct SwiftDocs {
     /// Documented File.


### PR DESCRIPTION
Include Glibc to support stderr in order to compile successfully in a Linux environment.