### PR TITLE
Add ability to specify which files should be included and excluded when documenting a module.

### DIFF
--- a/Source/sourcekitten/Doc.swift
+++ b/Source/sourcekitten/Doc.swift
@@ -10,6 +10,10 @@ extension SourceKitten {
         var singleFile: Bool = false
         @Option(help: "Name of Swift module to document (can't be used with `--single-file`)")
         var moduleName: String = ""
+        @Option(help: "Source file pathnames to be included in documentation. Supports wildcards. (can't be used with `--single-file`)")
+        var include: [String] = []
+        @Option(help: "Source file pathnames to be excluded from documentation. Supports wildcards. (can't be used with `--single-file`)")
+        var exclude: [String] = []
         @Flag(help: "Document a Swift Package Manager module")
         var spm: Bool = false
         @Flag(help: "Document Objective-C headers instead of Swift code")
@@ -21,7 +25,7 @@ extension SourceKitten {
             let moduleName = self.moduleName.isEmpty ? nil : self.moduleName
 
             if spm {
-                if let docs = Module(spmArguments: arguments, spmName: moduleName)?.docs {
+                if let docs = Module(spmArguments: arguments, spmName: moduleName, include: include, exclude: exclude)?.docs {
                     print(docs)
                     return
                 }
@@ -55,7 +59,7 @@ extension SourceKitten {
                 throw SourceKittenError.readFailed(path: arguments[0])
             }
 
-            let module = Module(xcodeBuildArguments: arguments, name: moduleName)
+            let module = Module(xcodeBuildArguments: arguments, name: moduleName, include: include, exclude: exclude)
             if let docs = module?.docs {
                 print(docs)
                 return


### PR DESCRIPTION
This change allows us to pass in a list of files to explicitly include and explicitly exclude from the doc command. This can dramatically improve parsing performance for large projects where we only need to document a subset of the files. 

This change is specifically targeted at jazzy's use case and is meant to mirror the behavior of the `include` and `exclude` flags from that package. Currently the entire module is parsed even if jazzy is given `include` and `exclude` flags. With this change jazzy should be able to forward these flags to `sourcekitten`

In our case this change was able to reduce the parsing time by 80% when generating docs, going from 15 minutes to 3 minutes.