### PR TITLE
Add `key.attributes` and `key.attribute` enum cases to SwiftDocKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ##### Enhancements
 
-* Add `key.attributes` and `key.attribute` enum cases to SwiftDocKey
+* Add `key.attributes` and `key.attribute` enum cases to SwiftDocKey.  
   [Erick Sanchez](https://github.com/ErickESGoogle)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Add `key.attributes` and `key.attribute` enum cases to SwiftDocKey
+  [Erick Sanchez](https://github.com/ErickESGoogle)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -81,6 +81,10 @@ public enum SwiftDocKey: String {
     case unavailableMessage   = "key.unavailable_message"
     /// Annotations ([String]).
     case annotations          = "key.annotations"
+    /// Attributes ([[String: SourceKitRepresentable]]).
+    case attributes           = "key.attributes"
+    /// Attribute (String).
+    case attribute            = "key.attribute"
 
     // MARK: Typed SwiftDocKey Getters
 


### PR DESCRIPTION
This PR simply adds the missing enum cases for attributes

Here's an example protocol:
```
public protocol MyService {

  ...

  @available(iOS 13.0, *)
  func myFunctionOnlyOniOS13()

  ...
}
```
Here's the debugging description:
```
Printing description of node: SourceKitRepresentable
▿ 12 elements
  ▿ 0 : ...
  ▿ 3 : 2 elements
    - key : "key.attributes"
    ▿ value : 1 element
      ▿ 0 : 3 elements
        ▿ 0 : 2 elements
          - key : "key.length"
          - value : 78
        ▿ 1 : 2 elements
          - key : "key.attribute"
          - value : "source.decl.attribute.available"
        ▿ 2 : 2 elements
          - key : "key.offset"
          - value : 523
  ▿ 4 : ...
```