### PR TITLE
Add `key.attributes` and `key.attribute` enum cases to SwiftDocKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   [Brian Osborn](https://github.com/bosborn)
   [#705](https://github.com/jpsim/SourceKitten/issues/705)
 
+* Add `key.attributes` and `key.attribute` enum cases to `SwiftDocKey`.  
+  [Erick Sanchez](https://github.com/ErickESGoogle)
+
 ##### Bug Fixes
 
 * None.

--- a/Source/SourceKittenFramework/SwiftDocKey.swift
+++ b/Source/SourceKittenFramework/SwiftDocKey.swift
@@ -81,6 +81,10 @@ public enum SwiftDocKey: String {
     case unavailableMessage   = "key.unavailable_message"
     /// Annotations ([String]).
     case annotations          = "key.annotations"
+    /// Attributes ([[String: SourceKitRepresentable]]).
+    case attributes           = "key.attributes"
+    /// Attribute (String).
+    case attribute            = "key.attribute"
 
     // MARK: Typed SwiftDocKey Getters
 


### PR DESCRIPTION
#703 continued, GitHub too clever for me with combo of conflicts + first-time contributor.