### PR TITLE
Add sourcekitten completion results formatting options

### DIFF
--- a/Source/SourceKittenFramework/JSONOutput.swift
+++ b/Source/SourceKittenFramework/JSONOutput.swift
@@ -4,24 +4,29 @@ import Foundation
  JSON Object to JSON String.
 
  - parameter object: Object to convert to JSON.
+ - parameter options: Serialization options
 
  - returns: JSON string representation of the input object.
  */
-public func toJSON(_ object: Any) -> String {
+public func toJSON(_ object: Any, options: JSONSerialization.WritingOptions? = nil) -> String {
     if let array = object as? [Any], array.isEmpty {
         return "[\n\n]"
     }
     do {
-        let options: JSONSerialization.WritingOptions
-#if os(Linux)
-        options = [.prettyPrinted, .sortedKeys]
-#else
-        if #available(macOS 10.13, *) {
+        func defaultOptions() -> JSONSerialization.WritingOptions {
+            let options: JSONSerialization.WritingOptions
+            #if os(Linux)
             options = [.prettyPrinted, .sortedKeys]
-        } else {
-            options = .prettyPrinted
+            #else
+            if #available(macOS 10.13, *) {
+                options = [.prettyPrinted, .sortedKeys]
+            } else {
+                options = .prettyPrinted
+            }
+            #endif
+            return options
         }
-#endif
+        let options = options ?? defaultOptions()
         let prettyJSONData = try JSONSerialization.data(withJSONObject: object, options: options)
         if let jsonString = String(data: prettyJSONData, encoding: .utf8) {
             return jsonString


### PR DESCRIPTION
Since JSON-formatting of code completion results can take a lot of time in some cases, additional format options can be passed to the sourcekitten.

Two additional options added:
- `prettified` - whether JSON results should be user-friendly prettified
- `sorted-keys` - whether the keys in JSON should be sorted keys


This fixes #710