### PR TITLE
Fix docs generation with Swift 5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ##### Enhancements
 
-* None.
+* Support docs generation on Swift 5.6.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/File.swift
+++ b/Source/SourceKittenFramework/File.swift
@@ -290,8 +290,8 @@ public final class File {
         if kind == SyntaxKind.commentMark.rawValue, let markName = parseMarkName(dictionary) {
             // Update comment marks
             return [SwiftDocKey.name.rawValue: markName]
-        } else if let decl = SwiftDeclarationKind(rawValue: kind), decl != .varParameter {
-            // Update if kind is a declaration (but not a parameter)
+        } else if let decl = SwiftDeclarationKind(rawValue: kind), decl != .varParameter, decl != .enumcase {
+            // Update if kind is a declaration (but not a parameter or the enumcase wrapper)
             let innerTypeNameOffset = SwiftDocKey.getName(dictionary)?.byteOffsetOfInnerTypeName() ?? 0
             let offset = SwiftDocKey.getNameOffset(dictionary)! + innerTypeNameOffset
             var updateDict = Request.send(cursorInfoRequest: cursorInfoRequest, atOffset: offset) ?? [:]


### PR DESCRIPTION
Swift 5.6 SourceKit has changed the `source.lang.swift.decl.enumcase` attributes in a way that crashes `sourcekitten doc` on any code with enum cases.

Recall that `enumcase` is the wrapper around a set of `enumelement`s with actual info.  In earlier Swift, `enumcase` had `key.nameoffset` and `key.namelength` fields but these were always 0.  In Swift 5.6 they're entirely gone.

A net gain for sourcekitten because it turns out we were doing useless cursorinfo queries.

This patch is enough to make jazzy work normally, not found any other breakage.