### PR TITLE
Add InProc Option for Sourcekitd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Support docs generation on Swift 5.6.  
   [John Fairhurst](https://github.com/johnfairh)
 
-* Add `USE_INPROC_SOURCEKIT` environment variable, which causes to use
+* Add `IN_PROCESS_SOURCEKIT` environment variable, which causes to use
   the in-process version of sourcekitd on macOS. This avoids the use of
   XPC, which is prohibited in some sandboxed environments, such as in
   Swift Package Manager plugins.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 * Support docs generation on Swift 5.6.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Add `USE_INPROC_SOURCEKIT` environment variable, which causes to use
+  the in-process version of sourcekitd on macOS. This avoids the use of
+  XPC, which is prohibited in some sandboxed environments, such as in
+  Swift Package Manager plugins.  
+  [Juozas Valancius](https://github.com/juozasvalancius)
+
 ##### Bug Fixes
 
 * None.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ On Linux, SourceKit is expected to be located in
 `/usr/lib/libsourcekitdInProc.so` or specified by the `LINUX_SOURCEKIT_LIB_PATH`
 environment variable.
 
+On macOS, `sourcekitd.framework` is used, which uses XPC to communicate with the
+sourcekit daemon. If you want to use the in-process version
+(`sourcekitdInProc.framework`), specify `USE_INPROC_SOURCEKIT=YES`
+environment variable.
+
 ## Projects Built With SourceKitten
 
 * [SwiftLint](https://github.com/realm/SwiftLint):

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ environment variable.
 
 On macOS, `sourcekitd.framework` is used, which uses XPC to communicate with the
 sourcekit daemon. If you want to use the in-process version
-(`sourcekitdInProc.framework`), specify `USE_INPROC_SOURCEKIT=YES`
+(`sourcekitdInProc.framework`), specify `IN_PROCESS_SOURCEKIT=YES`
 environment variable.
 
 ## Projects Built With SourceKitten

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -481,7 +481,7 @@ internal func libraryWrapperForModule(_ module: String,
             }()
             #endif
             private let library = toolchainLoader.load(path: path)
-            
+
             """
     } else {
         library = "private let library = toolchainLoader.load(path: \"\(loadPath)\")\n"

--- a/Source/SourceKittenFramework/Request.swift
+++ b/Source/SourceKittenFramework/Request.swift
@@ -473,7 +473,7 @@ internal func libraryWrapperForModule(_ module: String,
             private let path = "\(linuxPath)"
             #else
             private let path: String = {
-                if useInProcSourceKit {
+                if SourceKittenConfiguration.preferInProcessSourceKit {
                     return "\(inProcLoadPath)"
                 } else {
                     return "\(loadPath)"

--- a/Source/SourceKittenFramework/SourceKittenConfiguration.swift
+++ b/Source/SourceKittenFramework/SourceKittenConfiguration.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Options for configuring SourceKitten.
+public enum SourceKittenConfiguration {
+    /// On macOS, prefer using the in-process version of sourcekitd. This avoids the use of XPC, which is
+    /// prohibited in some sandboxed environments, such as in Swift Package Manager plugins.
+    ///
+    /// - note: Setting this value has no effect if SourceKit requests have already been sent from this process.
+    public static var preferInProcessSourceKit = envBool("IN_PROCESS_SOURCEKIT")
+}
+
+private func envBool(_ name: String) -> Bool {
+    guard let value = ProcessInfo.processInfo.environment[name] else {
+        return false
+    }
+
+    return ["1", "YES", "TRUE"].contains(value.uppercased())
+}

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -36,6 +36,13 @@ private func env(_ name: String) -> String? {
     return ProcessInfo.processInfo.environment[name]
 }
 
+private func envBool(_ name: String) -> Bool {
+    guard let value = env(name) else {
+        return false
+    }
+    return ["1", "YES", "TRUE"].contains(value.uppercased())
+}
+
 private extension String {
     func appending(pathComponent: String) -> String {
         return URL(fileURLWithPath: self).appendingPathComponent(pathComponent).path
@@ -123,6 +130,8 @@ let toolchainLoader = Loader(searchPaths: [
     }
     return nil
 })
+
+let useInProcSourceKit = envBool("USE_INPROC_SOURCEKIT")
 
 /// Returns "XCODE_DEFAULT_TOOLCHAIN_OVERRIDE" environment variable
 ///

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -36,13 +36,6 @@ private func env(_ name: String) -> String? {
     return ProcessInfo.processInfo.environment[name]
 }
 
-private func envBool(_ name: String) -> Bool {
-    guard let value = env(name) else {
-        return false
-    }
-    return ["1", "YES", "TRUE"].contains(value.uppercased())
-}
-
 private extension String {
     func appending(pathComponent: String) -> String {
         return URL(fileURLWithPath: self).appendingPathComponent(pathComponent).path
@@ -130,8 +123,6 @@ let toolchainLoader = Loader(searchPaths: [
     }
     return nil
 })
-
-let useInProcSourceKit = envBool("USE_INPROC_SOURCEKIT")
 
 /// Returns "XCODE_DEFAULT_TOOLCHAIN_OVERRIDE" environment variable
 ///

--- a/Source/SourceKittenFramework/library_wrapper_SourceKit.swift
+++ b/Source/SourceKittenFramework/library_wrapper_SourceKit.swift
@@ -5,7 +5,7 @@ import SourceKit
 private let path = "libsourcekitdInProc.so"
 #else
 private let path: String = {
-    if useInProcSourceKit {
+    if SourceKittenConfiguration.preferInProcessSourceKit {
         return "sourcekitdInProc.framework/Versions/A/sourcekitdInProc"
     } else {
         return "sourcekitd.framework/Versions/A/sourcekitd"

--- a/Source/SourceKittenFramework/library_wrapper_SourceKit.swift
+++ b/Source/SourceKittenFramework/library_wrapper_SourceKit.swift
@@ -4,7 +4,13 @@ import SourceKit
 #if os(Linux)
 private let path = "libsourcekitdInProc.so"
 #else
-private let path = "sourcekitd.framework/Versions/A/sourcekitd"
+private let path: String = {
+    if useInProcSourceKit {
+        return "sourcekitdInProc.framework/Versions/A/sourcekitdInProc"
+    } else {
+        return "sourcekitd.framework/Versions/A/sourcekitd"
+    }
+}()
 #endif
 private let library = toolchainLoader.load(path: path)
 // swiftlint:disable unused_declaration - We don't care if some of these are unused.

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -227,15 +227,17 @@ class SourceKitTests: XCTestCase {
         XCTAssert(docsJSON.range(of: "error type") == nil)
         let jsonArray = try JSONSerialization.jsonObject(with: docsJSON.data(using: .utf8)!, options: []) as? NSArray
         XCTAssertNotNil(jsonArray, "JSON should be properly parsed")
-        let modules: [(module: String, path: String, linuxPath: String?)] = [
-            ("Clang_C", "libclang.dylib", nil),
-            ("SourceKit", "sourcekitd.framework/Versions/A/sourcekitd", "libsourcekitdInProc.so")
+        let sourcekitd = "sourcekitd.framework/Versions/A/sourcekitd"
+        let sourcekitdInProc = "sourcekitdInProc.framework/Versions/A/sourcekitdInProc"
+        let modules: [(module: String, path: String, inProcPath: String?, linuxPath: String?)] = [
+            ("Clang_C", "libclang.dylib", nil, nil),
+            ("SourceKit", sourcekitd, sourcekitdInProc, "libsourcekitdInProc.so")
         ]
-        for (module, path, linuxPath) in modules {
+        for (module, path, inProcPath, linuxPath) in modules {
             let wrapperPath = "\(projectRoot)/Source/SourceKittenFramework/library_wrapper_\(module).swift"
             let existingWrapper = try String(contentsOfFile: wrapperPath)
             let generatedWrapper = try libraryWrapperForModule(
-                module, loadPath: path, linuxPath: linuxPath,
+                module, loadPath: path, inProcLoadPath: inProcPath, linuxPath: linuxPath,
                 compilerArguments: sourceKittenFrameworkModule.compilerArguments
             )
             XCTAssertEqual(existingWrapper, generatedWrapper)


### PR DESCRIPTION
There are two versions of sourcekitd that come with Xcode:

- `sourcekitd.framework`, which uses XPC to connect to the sourcekit daemon and parse swift files out-of-process.
- `sourcekitdInProc.framework`, which does the parsing in-process.

SourceKitten uses the XPC version on macOS. However, there may be cases, when the in-process version might be preferred. So this PR adds the possibility to configure this using the following environment variable:

    USE_INPROC_SOURCEKIT=YES

Specifically, this will be needed to support running SourceKitten in Swift Package Manager build tool plugins. It is a new feature ([SE-0303](https://github.com/apple/swift-evolution/blob/main/proposals/0303-swiftpm-extensible-build-tools.md)) in Swift 5.6, that allows Swift packages to execute custom build commands when building. So for example, you could have [swiftlint](https://github.com/realm/SwiftLint) run during a build of your Swift package.

As of this writing, Swift 5.6 is available in the Release Candidate of Xcode 13.3. I have experimented with it and found that SPM build commands run in a sandbox that prevent the use of XPC and crash when using the regular version of sourcekitd, but it works normally with sourcekitdInProc.
