### PR TITLE
Filter out unsupported Swift 5.7 flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 
 ##### Enhancements
 
-* Adds Bazel Build Support
+* Adds Bazel Build Support.  
   [Maxwell Elliott](https://github.com/maxwellE)
+
+* Support docs generation with Xcode 14 projects.  
+  [John Fairhurst](https://github.com/johnfairh)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/Xcode.swift
+++ b/Source/SourceKittenFramework/Xcode.swift
@@ -116,6 +116,7 @@ private func filter(arguments args: [String]) -> [String] {
     return args.filter {
         ![
             "-parseable-output",
+            "-use-frontend-parseable-output",
             "-incremental",
             "-serialize-diagnostics",
             "-emit-dependencies"


### PR DESCRIPTION
Docs generation fails at cursor-info on Xcode 14 because of a new flag:

<img width="492" alt="Screenshot 2022-06-10 at 12 40 52" src="https://user-images.githubusercontent.com/26768470/173063173-8a09445e-64c2-45c9-90d6-263478ad40f6.png">

It turns out that sourcekitten is already filtering out a suspiciously-similarly named flag so I've just added this new one.  Jazzy etc. work fine with this change.
