### PR TITLE
[Bazel] Remove sources from cc libraries

### DIFF
--- a/Source/BUILD
+++ b/Source/BUILD
@@ -4,10 +4,6 @@ exports_files(glob(["SourceKittenFramework/**/*.swift"]))
 
 cc_library(
     name = "Clang_CLibrary",
-    srcs = glob(
-        ["Clang_C/**/*.c"],
-        allow_empty = False,
-    ),
     hdrs = glob(
         ["Clang_C/**/*.h"],
         allow_empty = False,
@@ -25,10 +21,6 @@ swift_c_module(
 
 cc_library(
     name = "SourceKitLibrary",
-    srcs = glob(
-        ["SourceKit/**/*.c"],
-        allow_empty = False,
-    ),
     hdrs = glob(
         ["SourceKit/**/*.h"],
         allow_empty = False,


### PR DESCRIPTION
To avoid `-Wempty-translation-unit` errors such as this one:

```
Source/SourceKit/SourceKit.c:1:1: error: ISO C requires a translation unit to contain at least one declaration [-Werror,-Wempty-translation-unit]
```