### PR TITLE
Fix deprecation warning

### DIFF
--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -111,8 +111,8 @@ extension SourceKitObject: SourceKitObjectConvertible {
 extension SourceKitObject: CustomStringConvertible {
     public var description: String {
         let bytes = sourcekitd_request_description_copy(sourcekitdObject)!
-        let length = Int(strlen(bytes))
-        return String(bytesNoCopy: bytes, length: length, encoding: .utf8, freeWhenDone: true)!
+        defer { bytes.deallocate() }
+        return String(cString: bytes)
     }
 }
 


### PR DESCRIPTION
`String.init(bytesNoCopy:...)` was deprecated in macOS 13: https://developer.apple.com/documentation/swift/string/init(bytesnocopy:length:encoding:freewhendone:)

Further discussion here: https://forums.swift.org/t/does-string-bytesnocopy-copy-bytes/51643/11