### PR TITLE
Resolve tilde when asking for absolute path

### DIFF
--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -172,7 +172,7 @@ extension NSString {
      - parameter rootDirectory: Absolute parent path if not already an absolute path.
      */
     public func absolutePathRepresentation(rootDirectory: String = FileManager.default.currentDirectoryPath) -> String {
-        if isAbsolutePath { return bridge() }
+        if isAbsolutePath { return expandingTildeInPath }
         #if os(Linux)
         return NSURL(fileURLWithPath: NSURL.fileURL(withPathComponents: [rootDirectory, bridge()])!.path).standardizingPath!.path
         #else

--- a/Tests/SourceKittenFrameworkTests/StringTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StringTests.swift
@@ -79,6 +79,13 @@ class StringTests: XCTestCase {
                        "absolutePathRepresentation() should return the caller if it's already an absolute path")
     }
 
+    func testTildeExpanded() {
+        guard ProcessInfo.processInfo.environment["TEST_WORKSPACE"] == nil else {
+            return
+        }
+        XCTAssertTrue("~/my_file".bridge().absolutePathRepresentation().starts(with: FileManager.default.homeDirectoryForCurrentUser.path))
+    }
+
     func testIsTokenDocumentable() throws {
         let source = "struct A { subscript(key: String) -> Void { return () } }"
         let file = File(contents: source)


### PR DESCRIPTION
This resolves https://github.com/realm/SwiftLint/issues/3554.