### PR TITLE
gitattributes: ensure that we use Unix line endings for fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 Source/Clang_C/* linguist-vendored
-Tests/SourceKittenFrameworkTests/Fixtures/* linguist-vendored
+Tests/SourceKittenFrameworkTests/Fixtures/* linguist-vendored eol=lf


### PR DESCRIPTION
The fixture data is expected to be in Unix line endings in order to
match the test expectations.  This is important to ensure that the files
are properly checked out on Windows to support executing the tests.
