### PR TITLE
build: bump SWXMLHash to 7.0.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,5 +7,5 @@ module(
 bazel_dep(name = "platforms", version = "0.0.6", dev_dependency = True)
 bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
-bazel_dep(name = "swxmlhash", version = "7.0.1", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
+bazel_dep(name = "swxmlhash", version = "7.0.2", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
 bazel_dep(name = "yams", version = "5.0.5", repo_name = "sourcekitten_com_github_jpsim_yams")

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/drmohundro/SWXMLHash.git",
       "state" : {
-        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
-        "version" : "7.0.1"
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.1")),
-        .package(url: "https://github.com/drmohundro/SWXMLHash.git", .upToNextMinor(from: "7.0.1")),
+        .package(url: "https://github.com/drmohundro/SWXMLHash.git", .upToNextMinor(from: "7.0.2")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.5"),
     ],
     targets: [


### PR DESCRIPTION
The 7.0.2 release introduces support for Windows, which is needed to
support SourceKitten on Windows.  Bump the dependency minimum version.
