### PR TITLE
Tests: disable Xcode tests on non-macOS platforms

### DIFF
--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -10,7 +10,7 @@ let projectRoot: String = bazelProjectRoot ?? #file.bridge()
 
 class ModuleTests: XCTestCase {
 
-#if !os(Linux)
+#if os(macOS)
 
     func testModuleNilInPathWithNoXcodeProject() {
         let pathWithNoXcodeProject = (#file as NSString).deletingLastPathComponent


### PR DESCRIPTION
Xcode is only available on the macOS platform.  Rather than enumerating all the other OSes, simply limit the test cases to that platform.