### PR TITLE
Add Swift 5.8 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ##### Enhancements
 
-* None.
+* Added new syntax, attribute and declaration kinds introduced in Swift 5.8.  
+  [JP Simard](https://github.com/jpsim)
 
 ##### Bug Fixes
 

--- a/Source/SourceKittenFramework/SwiftDeclarationAttributeKind.swift
+++ b/Source/SourceKittenFramework/SwiftDeclarationAttributeKind.swift
@@ -169,4 +169,20 @@ public enum SwiftDeclarationAttributeKind: String, CaseIterable {
     case exclusivity = "source.decl.attribute.exclusivity"
     case _unsafeInheritExecutor = "source.decl.attribute._unsafeInheritExecutor"
     case _compilerInitialized = "source.decl.attribute._compilerInitialized"
+
+    // Only available in Swift >= 5.8
+
+    case backDeployed = "source.decl.attribute.backDeployed"
+    case _noEagerMove = "source.decl.attribute._noEagerMove"
+    case typeWrapperIgnored = "source.decl.attribute.typeWrapperIgnored"
+    case _spiOnly = "source.decl.attribute._spiOnly"
+    case _moveOnly = "source.decl.attribute._moveOnly"
+    case _noMetadata = "source.decl.attribute._noMetadata"
+    case _alwaysEmitConformanceMetadata = "source.decl.attribute._alwaysEmitConformanceMetadata"
+    case runtimeMetadata = "source.decl.attribute.runtimeMetadata"
+    case _objcImplementation = "source.decl.attribute._objcImplementation"
+    case _eagerMove = "source.decl.attribute._eagerMove"
+    case typeWrapper = "source.decl.attribute.typeWrapper"
+    case _expose = "source.decl.attribute._expose"
+    case _documentation = "source.decl.attribute._documentation"
 }

--- a/Source/SourceKittenFramework/SwiftDeclarationKind.swift
+++ b/Source/SourceKittenFramework/SwiftDeclarationKind.swift
@@ -90,4 +90,6 @@ public enum SwiftDeclarationKind: String, CaseIterable {
     case varStatic = "source.lang.swift.decl.var.static"
     /// `actor`.
     case actor = "source.lang.swift.decl.actor"
+    /// `macro`
+    case macro = "source.lang.swift.decl.macro"
 }

--- a/Source/SourceKittenFramework/SyntaxKind.swift
+++ b/Source/SourceKittenFramework/SyntaxKind.swift
@@ -41,6 +41,8 @@ public enum SyntaxKind: String, CaseIterable {
     case typeidentifier = "source.lang.swift.syntaxtype.typeidentifier"
     /// `pounddirective.keyword`.
     case poundDirectiveKeyword = "source.lang.swift.syntaxtype.pounddirective.keyword"
+    /// `operator`
+    case `operator` = "source.lang.swift.syntaxtype.operator"
 
     /// Returns the valid documentation comment syntax kinds.
     internal static func docComments() -> [SyntaxKind] {

--- a/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-5.8.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/Commandant@swift-5.8.json
@@ -1,0 +1,8815 @@
+[{
+  "\/Sources\/Commandant\/Argument.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 3858,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 204
+          }
+        ],
+        "key.bodylength" : 1029,
+        "key.bodyoffset" : 231,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes an argument that can be provided on the command line.",
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.doclength" : 68,
+        "key.docoffset" : 136,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1050,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 218,
+        "key.offset" : 211,
+        "key.parsed_declaration" : "public struct Argument<T>",
+        "key.parsed_scope.end" : 36,
+        "key.parsed_scope.start" : 10,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 10,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 227,
+            "key.offset" : 227,
+            "key.parsed_declaration" : "public struct Argument<T",
+            "key.parsed_scope.end" : 10,
+            "key.parsed_scope.start" : 10,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant8ArgumentV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 443
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The default value for this argument. This is the value that will be used\nif the argument is never explicitly specified on the command line.\n\nIf this is nil, this argument is always required.",
+            "key.doc.declaration" : "public let defaultValue: T?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If this is nil, this argument is always required."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"15\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant8ArgumentV12defaultValuexSgvp<\/USR><Declaration>public let defaultValue: T?<\/Declaration><CommentParts><Abstract><Para>The default value for this argument. This is the value that will be used if the argument is never explicitly specified on the command line.<\/Para><\/Abstract><Discussion><Para>If this is nil, this argument is always required.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "defaultValue",
+            "key.doc.type" : "Other",
+            "key.doclength" : 209,
+            "key.docoffset" : 233,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "defaultValue",
+            "key.namelength" : 12,
+            "key.nameoffset" : 454,
+            "key.offset" : 450,
+            "key.parsed_declaration" : "public let defaultValue: T?",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "T?",
+            "key.typeusr" : "$sxSgD",
+            "key.usr" : "s:10Commandant8ArgumentV12defaultValuexSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 585
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this argument. This will\nbe shown in help messages.",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"19\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant8ArgumentV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this argument. This will be shown in help messages.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 19,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 111,
+            "key.docoffset" : 473,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 596,
+            "key.offset" : 592,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 19,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usageParameter: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 804
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string that describes this argument as a paramater shown\nin the list of possible parameters in help messages (e.g. for \"paths\", the\nuser would see <paths…>).",
+            "key.doc.declaration" : "public let usageParameter: String?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"24\" column=\"13\"><Name>usageParameter<\/Name><USR>s:10Commandant8ArgumentV14usageParameterSSSgvp<\/USR><Declaration>public let usageParameter: String?<\/Declaration><CommentParts><Abstract><Para>A human-readable string that describes this argument as a paramater shown in the list of possible parameters in help messages (e.g. for “paths”, the user would see &lt;paths…&gt;).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 24,
+            "key.doc.name" : "usageParameter",
+            "key.doc.type" : "Other",
+            "key.doclength" : 191,
+            "key.docoffset" : 612,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usageParameter<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 27,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameter",
+            "key.namelength" : 14,
+            "key.nameoffset" : 815,
+            "key.offset" : 811,
+            "key.parsed_declaration" : "public let usageParameter: String?",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String?",
+            "key.typeusr" : "$sSSSgD",
+            "key.usr" : "s:10Commandant8ArgumentV14usageParameterSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(defaultValue: <Type usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/Type>? = nil, usage: <Type usr=\"s:SS\">String<\/Type>, usageParameter: <Type usr=\"s:SS\">String<\/Type>? = nil)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 841
+              }
+            ],
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 924,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usageParameter<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 174,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(defaultValue:usage:usageParameter:)",
+            "key.namelength" : 74,
+            "key.nameoffset" : 848,
+            "key.offset" : 848,
+            "key.parsed_declaration" : "public init(defaultValue: T? = nil, usage: String, usageParameter: String? = nil)",
+            "key.parsed_scope.end" : 30,
+            "key.parsed_scope.start" : 26,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T> (Argument<T>.Type) -> (T?, String, String?) -> Argument<T>",
+            "key.typeusr" : "$s12defaultValue5usage0C9Parameter10Commandant8ArgumentVyxGxSg_S2SSgtcD",
+            "key.usr" : "s:10Commandant8ArgumentV12defaultValue5usage0E9ParameterACyxGxSg_S2SSgtcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate func invalidUsageError&lt;ClientError&gt;(_ value: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1025
+              }
+            ],
+            "key.bodylength" : 135,
+            "key.bodyoffset" : 1123,
+            "key.column" : 19,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>invalidUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 222,
+            "key.line" : 32,
+            "key.modulename" : "Commandant",
+            "key.name" : "invalidUsageError(_:)",
+            "key.namelength" : 47,
+            "key.nameoffset" : 1042,
+            "key.offset" : 1037,
+            "key.parsed_declaration" : "fileprivate func invalidUsageError<ClientError>(_ value: String) -> CommandantError<ClientError>",
+            "key.parsed_scope.end" : 35,
+            "key.parsed_scope.start" : 32,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 37,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 32,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1060,
+                "key.offset" : 1060,
+                "key.parsed_declaration" : "fileprivate func invalidUsageError<ClientError",
+                "key.parsed_scope.end" : 32,
+                "key.parsed_scope.start" : 32,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let description: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 83,
+                "key.line" : 33,
+                "key.modulename" : "Commandant",
+                "key.name" : "description",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1130,
+                "key.offset" : 1126,
+                "key.parsed_declaration" : "let description = \"Invalid value for '\\(self.usageParameterDescription)': \\(value)\"",
+                "key.parsed_scope.end" : 33,
+                "key.parsed_scope.start" : 33,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF11descriptionL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError> (Argument<T>) -> (String) -> CommandantError<ClientError>",
+            "key.typeusr" : "$sy10Commandant0A5ErrorOyqd__GSScluD",
+            "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 251,
+        "key.bodyoffset" : 1283,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 272,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 1273,
+        "key.offset" : 1263,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 38,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var usageParameterDescription: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1422
+              }
+            ],
+            "key.bodylength" : 62,
+            "key.bodyoffset" : 1470,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "A string describing this argument as a parameter in help messages. This falls back\nto `\"\\(self)\"` if `usageParameter` is `nil`",
+            "key.doc.declaration" : "internal var usageParameterDescription: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"41\" column=\"15\"><Name>usageParameterDescription<\/Name><USR>s:10Commandant8ArgumentV25usageParameterDescriptionSSvp<\/USR><Declaration>internal var usageParameterDescription: String { get }<\/Declaration><CommentParts><Abstract><Para>A string describing this argument as a parameter in help messages. This falls back to <codeVoice>&quot;\\(self)&quot;<\/codeVoice> if <codeVoice>usageParameter<\/codeVoice> is <codeVoice>nil<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 41,
+            "key.doc.name" : "usageParameterDescription",
+            "key.doc.type" : "Other",
+            "key.doclength" : 136,
+            "key.docoffset" : 1285,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>usageParameterDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 102,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameterDescription",
+            "key.namelength" : 25,
+            "key.nameoffset" : 1435,
+            "key.offset" : 1431,
+            "key.parsed_declaration" : "internal var usageParameterDescription: String",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 41,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp\">usageParameterDescription<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentV25usageParameterDescriptionSSvp"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 254,
+        "key.bodyoffset" : 1575,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 293,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 1547,
+        "key.offset" : 1537,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 52,
+        "key.parsed_scope.start" : 46,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var usageParameterDescription: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1714
+              }
+            ],
+            "key.bodylength" : 65,
+            "key.bodyoffset" : 1762,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "A string describing this argument as a parameter in help messages. This falls back\nto `\"\\(self)\"` if `usageParameter` is `nil`",
+            "key.doc.declaration" : "internal var usageParameterDescription: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"49\" column=\"15\"><Name>usageParameterDescription<\/Name><USR>s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp<\/USR><Declaration>internal var usageParameterDescription: String { get }<\/Declaration><CommentParts><Abstract><Para>A string describing this argument as a parameter in help messages. This falls back to <codeVoice>&quot;\\(self)&quot;<\/codeVoice> if <codeVoice>usageParameter<\/codeVoice> is <codeVoice>nil<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 49,
+            "key.doc.name" : "usageParameterDescription",
+            "key.doc.type" : "Other",
+            "key.doclength" : 136,
+            "key.docoffset" : 1577,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>usageParameterDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 105,
+            "key.line" : 49,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameterDescription",
+            "key.namelength" : 25,
+            "key.nameoffset" : 1727,
+            "key.offset" : 1723,
+            "key.parsed_declaration" : "internal var usageParameterDescription: String",
+            "key.parsed_scope.end" : 51,
+            "key.parsed_scope.start" : 49,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant8ArgumentV25usageParameterDescriptionSSvp\">usageParameterDescription<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 1835
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 1979,
+        "key.bodyoffset" : 1877,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 2003,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1864,
+        "key.offset" : 1854,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 120,
+        "key.parsed_scope.start" : 56,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2069
+              }
+            ],
+            "key.bodylength" : 518,
+            "key.bodyoffset" : 2212,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given argument in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the argument's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the argument’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"61\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, argument: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given argument in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the argument’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 61,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 189,
+            "key.docoffset" : 1879,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 655,
+            "key.line" : 61,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 79,
+            "key.nameoffset" : 2088,
+            "key.offset" : 2076,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 81,
+            "key.parsed_scope.start" : 61,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 2095
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 61,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2092,
+                "key.offset" : 2092,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 61,
+                "key.parsed_scope.start" : 61,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 61,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 2113,
+                "key.offset" : 2113,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 61,
+                "key.parsed_scope.start" : 61,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Argument<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC8ArgumentVyxGtcAC0F8ProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2929
+              }
+            ],
+            "key.bodylength" : 778,
+            "key.bodyoffset" : 3076,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given argument list in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the argument's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the argument’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"87\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, argument: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given argument list in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the argument’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 87,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 194,
+            "key.docoffset" : 2734,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 919,
+            "key.line" : 87,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 81,
+            "key.nameoffset" : 2948,
+            "key.offset" : 2936,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 119,
+            "key.parsed_scope.start" : 87,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 2955
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 87,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2952,
+                "key.offset" : 2952,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 87,
+                "key.parsed_scope.start" : 87,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 87,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 2973,
+                "key.offset" : 2973,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 87,
+                "key.parsed_scope.start" : 87,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Argument<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD8ArgumentVyACGtcAD0F8ProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/ArgumentParser.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 4637,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.private",
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:SQ\">Equatable<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.private",
+            "key.length" : 7,
+            "key.offset" : 229
+          }
+        ],
+        "key.bodylength" : 296,
+        "key.bodyoffset" : 266,
+        "key.column" : 14,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 14,
+        "key.doc.comment" : "Represents an argument passed on the command line.",
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"12\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
+        "key.doclength" : 55,
+        "key.docoffset" : 174,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 255
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 326,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "RawArgument",
+        "key.namelength" : 11,
+        "key.nameoffset" : 242,
+        "key.offset" : 237,
+        "key.parsed_declaration" : "private enum RawArgument: Equatable",
+        "key.parsed_scope.end" : 22,
+        "key.parsed_scope.start" : 12,
+        "key.substructure" : [
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 16,
+            "key.offset" : 341,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case key(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A key corresponding to an option (e.g., `verbose` for `--verbose`).",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"14\" column=\"7\"><Name>key(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A key corresponding to an option (e.g., <codeVoice>verbose<\/codeVoice> for <codeVoice>--verbose<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 14,
+                "key.doc.name" : "key(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 72,
+                "key.docoffset" : 268,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>key<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 11,
+                "key.line" : 14,
+                "key.modulename" : "Commandant",
+                "key.name" : "key(_:)",
+                "key.namelength" : 11,
+                "key.nameoffset" : 346,
+                "key.offset" : 346,
+                "key.parsed_declaration" : "case key(String)",
+                "key.parsed_scope.end" : 14,
+                "key.parsed_scope.start" : 14,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyyADSScADmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 18,
+            "key.offset" : 448,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case value(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A value, either associated with an option or passed as a positional\nargument.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"18\" column=\"7\"><Name>value(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A value, either associated with an option or passed as a positional argument.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 18,
+                "key.doc.name" : "value(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 87,
+                "key.docoffset" : 360,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>value<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 13,
+                "key.line" : 18,
+                "key.modulename" : "Commandant",
+                "key.name" : "value(_:)",
+                "key.namelength" : 13,
+                "key.nameoffset" : 453,
+                "key.offset" : 453,
+                "key.parsed_declaration" : "case value(String)",
+                "key.parsed_scope.end" : 18,
+                "key.parsed_scope.start" : 18,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueyADSScADmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 32,
+            "key.offset" : 529,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case flag(<Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>&lt;<Type usr=\"s:SJ\">Character<\/Type>&gt;)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "One or more flag arguments (e.g 'r' and 'f' for `-rf`)",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"21\" column=\"7\"><Name>flag(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagyAdA10OrderedSetVySJGcADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>One or more flag arguments (e.g ‘r’ and ‘f’ for <codeVoice>-rf<\/codeVoice>)<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 21,
+                "key.doc.name" : "flag(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 59,
+                "key.docoffset" : 469,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct>&lt;<ref.struct usr=\"s:SJ\">Character<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 27,
+                "key.line" : 21,
+                "key.modulename" : "Commandant",
+                "key.name" : "flag(_:)",
+                "key.namelength" : 27,
+                "key.nameoffset" : 534,
+                "key.offset" : 534,
+                "key.parsed_declaration" : "case flag(OrderedSet<Character>)",
+                "key.parsed_scope.end" : 21,
+                "key.parsed_scope.start" : 21,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (OrderedSet<Character>) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOAA10OrderedSetVySJGcADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagyAdA10OrderedSetVySJGcADmF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "$s10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:SQ\">Equatable<\/Type><\/Declaration>",
+        "key.bodylength" : 214,
+        "key.bodyoffset" : 613,
+        "key.column" : 14,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 14,
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"12\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 588
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 263,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "RawArgument",
+        "key.namelength" : 11,
+        "key.nameoffset" : 575,
+        "key.offset" : 565,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 37,
+        "key.parsed_scope.start" : 24,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 615
+              }
+            ],
+            "key.bodylength" : 173,
+            "key.bodyoffset" : 652,
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 199,
+            "key.line" : 25,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 631,
+            "key.offset" : 627,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "fileprivate var description: String",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "$s10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class ArgumentParser<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final",
+            "key.length" : 5,
+            "key.offset" : 896
+          },
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 889
+          }
+        ],
+        "key.bodylength" : 3711,
+        "key.bodyoffset" : 924,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Destructively parses a list of command-line arguments.",
+        "key.doc.declaration" : "public final class ArgumentParser",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"40\" column=\"20\"><Name>ArgumentParser<\/Name><USR>s:10Commandant14ArgumentParserC<\/USR><Declaration>public final class ArgumentParser<\/Declaration><CommentParts><Abstract><Para>Destructively parses a list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 40,
+        "key.doc.name" : "ArgumentParser",
+        "key.doc.type" : "Class",
+        "key.doclength" : 59,
+        "key.docoffset" : 830,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>ArgumentParser<\/decl.name><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 3734,
+        "key.line" : 40,
+        "key.modulename" : "Commandant",
+        "key.name" : "ArgumentParser",
+        "key.namelength" : 14,
+        "key.nameoffset" : 908,
+        "key.offset" : 902,
+        "key.parsed_declaration" : "public final class ArgumentParser",
+        "key.parsed_scope.end" : 175,
+        "key.parsed_scope.start" : 40,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private var rawArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 991
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "The remaining arguments to be extracted, in their raw form.",
+            "key.doc.declaration" : "private var rawArguments: [RawArgument]",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"42\" column=\"14\"><Name>rawArguments<\/Name><USR>s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGvp<\/USR><Declaration>private var rawArguments: [RawArgument]<\/Declaration><CommentParts><Abstract><Para>The remaining arguments to be extracted, in their raw form.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 42,
+            "key.doc.name" : "rawArguments",
+            "key.doc.type" : "Other",
+            "key.doclength" : 64,
+            "key.docoffset" : 926,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>rawArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 36,
+            "key.line" : 42,
+            "key.modulename" : "Commandant",
+            "key.name" : "rawArguments",
+            "key.namelength" : 12,
+            "key.nameoffset" : 1003,
+            "key.offset" : 999,
+            "key.parsed_declaration" : "private var rawArguments: [RawArgument] = []",
+            "key.parsed_scope.end" : 42,
+            "key.parsed_scope.start" : 42,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[RawArgument]",
+            "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ arguments: [<Type usr=\"s:SS\">String<\/Type>])<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1115
+              }
+            ],
+            "key.bodylength" : 741,
+            "key.bodyoffset" : 1151,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the generator from a simple list of command-line arguments.",
+            "key.doc.declaration" : "public init(_ arguments: [String])",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"45\" column=\"9\"><Name>init(_:)<\/Name><USR>s:10Commandant14ArgumentParserCyACSaySSGcfc<\/USR><Declaration>public init(_ arguments: [String])<\/Declaration><CommentParts><Abstract><Para>Initializes the generator from a simple list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 45,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 76,
+            "key.docoffset" : 1038,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>arguments<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 771,
+            "key.line" : 45,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 27,
+            "key.nameoffset" : 1122,
+            "key.offset" : 1122,
+            "key.parsed_declaration" : "public init(_ arguments: [String])",
+            "key.parsed_scope.end" : 70,
+            "key.parsed_scope.start" : 45,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let params: [<Type usr=\"s:Sa\">Array<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>&gt;.<Type usr=\"s:Sa11SubSequencea\">SubSequence<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>params<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:Sa\">Array<\/ref.struct>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>&gt;.<ref.typealias usr=\"s:Sa11SubSequencea\">SubSequence<\/ref.typealias>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 91,
+                "key.line" : 47,
+                "key.modulename" : "Commandant",
+                "key.name" : "params",
+                "key.namelength" : 6,
+                "key.nameoffset" : 1218,
+                "key.offset" : 1214,
+                "key.parsed_declaration" : "let params = arguments.split(maxSplits: 1, omittingEmptySubsequences: false) { $0 == \"--\" }",
+                "key.parsed_scope.end" : 47,
+                "key.parsed_scope.start" : 47,
+                "key.typename" : "[ArraySlice<String>]",
+                "key.typeusr" : "$sSays10ArraySliceVySSGGD",
+                "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc6paramsL_Says10ArraySliceVySSGGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let options: <Type usr=\"s:Sa\">Array<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>&gt;.<Type usr=\"s:Sa11SubSequencea\">SubSequence<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>options<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sa\">Array<\/ref.struct>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>&gt;.<ref.typealias usr=\"s:Sa11SubSequencea\">SubSequence<\/ref.typealias><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 27,
+                "key.line" : 50,
+                "key.modulename" : "Commandant",
+                "key.name" : "options",
+                "key.namelength" : 7,
+                "key.nameoffset" : 1356,
+                "key.offset" : 1352,
+                "key.parsed_declaration" : "let options = params.first!",
+                "key.parsed_scope.end" : 50,
+                "key.parsed_scope.start" : 50,
+                "key.typename" : "ArraySlice<String>",
+                "key.typeusr" : "$ss10ArraySliceVySSGD",
+                "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc7optionsL_s10ArraySliceVySSGvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser.Type) -> ([String]) -> ArgumentParser",
+            "key.typeusr" : "$sy10Commandant14ArgumentParserCSaySSGcD",
+            "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var remainingArguments: [<Type usr=\"s:SS\">String<\/Type>]? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1934
+              }
+            ],
+            "key.bodylength" : 76,
+            "key.bodyoffset" : 1978,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Returns the remaining arguments.",
+            "key.doc.declaration" : "internal var remainingArguments: [String]? { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"73\" column=\"15\"><Name>remainingArguments<\/Name><USR>s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgvp<\/USR><Declaration>internal var remainingArguments: [String]? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the remaining arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 73,
+            "key.doc.name" : "remainingArguments",
+            "key.doc.type" : "Other",
+            "key.doclength" : 37,
+            "key.docoffset" : 1896,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>remainingArguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 112,
+            "key.line" : 73,
+            "key.modulename" : "Commandant",
+            "key.name" : "remainingArguments",
+            "key.namelength" : 18,
+            "key.nameoffset" : 1947,
+            "key.offset" : 1943,
+            "key.parsed_declaration" : "internal var remainingArguments: [String]?",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 73,
+            "key.typename" : "[String]?",
+            "key.typeusr" : "$sSaySSGSgD",
+            "key.usr" : "s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 2264
+              }
+            ],
+            "key.bodylength" : 281,
+            "key.bodyoffset" : 2323,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was enabled or disabled, or nil if it\nwas not given at all.\n\nIf the key is found, it is then removed from the list of arguments\nremaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the key is found, it is then removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"82\" column=\"16\"><Name>consumeBoolean(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF<\/USR><Declaration>internal func consumeBoolean(forKey key: String) -&gt; Bool?<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was enabled or disabled, or nil if it was not given at all.<\/Para><\/Abstract><Discussion><Para>If the key is found, it is then removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 82,
+            "key.doc.name" : "consumeBoolean(forKey:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 205,
+            "key.docoffset" : 2058,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 332,
+            "key.line" : 82,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeBoolean(forKey:)",
+            "key.namelength" : 34,
+            "key.nameoffset" : 2278,
+            "key.offset" : 2273,
+            "key.parsed_declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.parsed_scope.end" : 98,
+            "key.parsed_scope.start" : 82,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF\">consumeBoolean(flag:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 83,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 2330,
+                "key.offset" : 2326,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 83,
+                "key.parsed_scope.start" : 83,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var result: <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>result<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 17,
+                "key.line" : 86,
+                "key.modulename" : "Commandant",
+                "key.name" : "result",
+                "key.namelength" : 6,
+                "key.nameoffset" : 2392,
+                "key.offset" : 2388,
+                "key.parsed_declaration" : "var result: Bool?",
+                "key.parsed_scope.end" : 86,
+                "key.parsed_scope.start" : 86,
+                "key.typename" : "Bool?",
+                "key.typeusr" : "$sSbSgD",
+                "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF6resultL_AFvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool?",
+            "key.typeusr" : "$s6forKeySbSgSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeValue(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:s5NeverO\">Never<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 2908
+              }
+            ],
+            "key.bodylength" : 503,
+            "key.bodyoffset" : 2999,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the value associated with the given flag, or nil if the flag was\nnot specified. If the key is presented, but no value was given, an error\nis returned.\n\nIf a value is found, the key and the value are both removed from the\nlist of arguments remaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<Never>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"106\" column=\"16\"><Name>consumeValue(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF<\/USR><Declaration>internal func consumeValue(forKey key: String) -&gt; Result&lt;String?, CommandantError&lt;Never&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the value associated with the given flag, or nil if the flag was not specified. If the key is presented, but no value was given, an error is returned.<\/Para><\/Abstract><Discussion><Para>If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 106,
+            "key.doc.name" : "consumeValue(forKey:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 299,
+            "key.docoffset" : 2608,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeValue<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 586,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeValue(forKey:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 2922,
+            "key.offset" : 2917,
+            "key.parsed_declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<Never>>",
+            "key.parsed_scope.end" : 131,
+            "key.parsed_scope.start" : 106,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 107,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 3006,
+                "key.offset" : 3002,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 107,
+                "key.parsed_scope.start" : 107,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var foundValue: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>foundValue<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 23,
+                "key.line" : 110,
+                "key.modulename" : "Commandant",
+                "key.name" : "foundValue",
+                "key.namelength" : 10,
+                "key.nameoffset" : 3068,
+                "key.offset" : 3064,
+                "key.parsed_declaration" : "var foundValue: String?",
+                "key.parsed_scope.end" : 110,
+                "key.parsed_scope.start" : 110,
+                "key.typename" : "String?",
+                "key.typeusr" : "$sSSSgD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF05foundE0L_AHvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var index: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>index<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 13,
+                "key.line" : 111,
+                "key.modulename" : "Commandant",
+                "key.name" : "index",
+                "key.namelength" : 5,
+                "key.nameoffset" : 3094,
+                "key.offset" : 3090,
+                "key.parsed_declaration" : "var index = 0",
+                "key.parsed_scope.end" : 111,
+                "key.parsed_scope.start" : 111,
+                "key.related_decls" : [
+                  {
+                    "key.annotated_decl" : "<RelatedName usr=\"c:@F@index\">index(_:_:)<\/RelatedName>"
+                  }
+                ],
+                "key.typename" : "Int",
+                "key.typeusr" : "$sSiD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF5indexL_Sivp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Result<String?, CommandantError<Never>>",
+            "key.typeusr" : "$s6forKeys6ResultOySSSg10Commandant0D5ErrorOys5NeverOGGSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumePositionalArgument() -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 3634
+              }
+            ],
+            "key.bodylength" : 164,
+            "key.bodyoffset" : 3688,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the next positional argument that hasn't yet been returned, or\nnil if there are no more positional arguments.",
+            "key.doc.declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"135\" column=\"16\"><Name>consumePositionalArgument()<\/Name><USR>s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF<\/USR><Declaration>internal func consumePositionalArgument() -&gt; String?<\/Declaration><CommentParts><Abstract><Para>Returns the next positional argument that hasn’t yet been returned, or nil if there are no more positional arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 135,
+            "key.doc.name" : "consumePositionalArgument()",
+            "key.doc.type" : "Function",
+            "key.doclength" : 127,
+            "key.docoffset" : 3506,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumePositionalArgument<\/decl.name>() -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 210,
+            "key.line" : 135,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumePositionalArgument()",
+            "key.namelength" : 27,
+            "key.nameoffset" : 3648,
+            "key.offset" : 3643,
+            "key.parsed_declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 135,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> () -> String?",
+            "key.typeusr" : "$sSSSgycD",
+            "key.usr" : "s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consume(key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 3963
+              }
+            ],
+            "key.bodylength" : 143,
+            "key.bodyoffset" : 4007,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consume(key: String) -> Bool",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"148\" column=\"16\"><Name>consume(key:)<\/Name><USR>s:10Commandant14ArgumentParserC7consume3keySbSS_tF<\/USR><Declaration>internal func consume(key: String) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 148,
+            "key.doc.name" : "consume(key:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 106,
+            "key.docoffset" : 3856,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consume<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 179,
+            "key.line" : 148,
+            "key.modulename" : "Commandant",
+            "key.name" : "consume(key:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 3977,
+            "key.offset" : 3972,
+            "key.parsed_declaration" : "internal func consume(key: String) -> Bool",
+            "key.parsed_scope.end" : 153,
+            "key.parsed_scope.start" : 148,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 149,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 4014,
+                "key.offset" : 4010,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 149,
+                "key.parsed_scope.start" : 149,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC7consume3keySbSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool",
+            "key.typeusr" : "$s3keySbSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC7consume3keySbSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(flag: <Type usr=\"s:SJ\">Character<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 4262
+              }
+            ],
+            "key.bodylength" : 316,
+            "key.bodyoffset" : 4317,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given flag was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"157\" column=\"16\"><Name>consumeBoolean(flag:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF<\/USR><Declaration>internal func consumeBoolean(flag: Character) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given flag was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 157,
+            "key.doc.name" : "consumeBoolean(flag:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 107,
+            "key.docoffset" : 4154,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 363,
+            "key.line" : 157,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeBoolean(flag:)",
+            "key.namelength" : 31,
+            "key.nameoffset" : 4276,
+            "key.offset" : 4271,
+            "key.parsed_declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.parsed_scope.end" : 174,
+            "key.parsed_scope.start" : 157,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF\">consumeBoolean(forKey:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (Character) -> Bool",
+            "key.typeusr" : "$s4flagSbSJ_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF"
+          }
+        ],
+        "key.typename" : "ArgumentParser.Type",
+        "key.typeusr" : "$s10Commandant14ArgumentParserCmD",
+        "key.usr" : "s:10Commandant14ArgumentParserC"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/ArgumentProtocol.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 1141,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol ArgumentProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 219
+          }
+        ],
+        "key.bodylength" : 189,
+        "key.bodyoffset" : 253,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a value that can be converted from a command-line argument.",
+        "key.doc.declaration" : "public protocol ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"10\" column=\"17\"><Name>ArgumentProtocol<\/Name><USR>s:10Commandant16ArgumentProtocolP<\/USR><Declaration>public protocol ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a value that can be converted from a command-line argument.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "ArgumentProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 75,
+        "key.docoffset" : 144,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>ArgumentProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 217,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "ArgumentProtocol",
+        "key.namelength" : 16,
+        "key.nameoffset" : 235,
+        "key.offset" : 226,
+        "key.parsed_declaration" : "public protocol ArgumentProtocol",
+        "key.parsed_scope.end" : 16,
+        "key.parsed_scope.start" : 10,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static var name: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 322,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable name for this type.",
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.doclength" : 41,
+            "key.docoffset" : 255,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 31,
+            "key.line" : 12,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 308,
+            "key.offset" : 297,
+            "key.parsed_declaration" : "static var name: String",
+            "key.parsed_scope.end" : 12,
+            "key.parsed_scope.start" : 12,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant16ArgumentProtocolP4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Attempts to parse a value from the given command-line argument.",
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 68,
+            "key.docoffset" : 331,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant16ArgumentProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 41,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 412,
+            "key.offset" : 400,
+            "key.parsed_declaration" : "static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "ArgumentProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant16ArgumentProtocol_pmD",
+        "key.usr" : "s:10Commandant16ArgumentProtocolP"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>@frozen struct Int : <Type usr=\"s:s17FixedWidthIntegerP\">FixedWidthInteger<\/Type>, <Type usr=\"s:SZ\">SignedInteger<\/Type>, <Type usr=\"s:s35_ExpressibleByBuiltinIntegerLiteralP\">_ExpressibleByBuiltinIntegerLiteral<\/Type><\/Declaration>",
+        "key.bodylength" : 113,
+        "key.bodyoffset" : 478,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen struct Int : FixedWidthInteger, SignedInteger, _ExpressibleByBuiltinIntegerLiteral",
+        "key.doc.discussion" : [
+          {
+            "Para" : "On 32-bit platforms, `Int` is the same size as `Int32`, and on 64-bit platforms, `Int` is the same size as `Int64`."
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>Int<\/Name><USR>s:Si<\/USR><Declaration>@frozen struct Int : FixedWidthInteger, SignedInteger, _ExpressibleByBuiltinIntegerLiteral<\/Declaration><CommentParts><Abstract><Para>A signed integer value type.<\/Para><\/Abstract><Discussion><Para>On 32-bit platforms, <codeVoice>Int<\/codeVoice> is the same size as <codeVoice>Int32<\/codeVoice>, and on 64-bit platforms, <codeVoice>Int<\/codeVoice> is the same size as <codeVoice>Int64<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "Int",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 460
+          }
+        ],
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Int<\/decl.name> : <ref.protocol usr=\"s:s17FixedWidthIntegerP\">FixedWidthInteger<\/ref.protocol>, <ref.protocol usr=\"s:SZ\">SignedInteger<\/ref.protocol>, <ref.protocol usr=\"s:s35_ExpressibleByBuiltinIntegerLiteralP\">_ExpressibleByBuiltinIntegerLiteral<\/ref.protocol><\/decl.struct>",
+        "key.groupname" : "Math\/Integers",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ArgumentProtocol"
+          }
+        ],
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 147,
+        "key.modulename" : "Swift",
+        "key.name" : "Int",
+        "key.namelength" : 3,
+        "key.nameoffset" : 455,
+        "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static let name: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 480
+              }
+            ],
+            "key.column" : 20,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 27,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 498,
+            "key.offset" : 487,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static let name = \"integer\"",
+            "key.parsed_scope.end" : 19,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 517
+              }
+            ],
+            "key.bodylength" : 23,
+            "key.bodyoffset" : 566,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 66,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 536,
+            "key.offset" : 524,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func from(string: String) -> Int?",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 21,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(Int.Type) -> (String) -> Int?",
+            "key.typeusr" : "$s6stringSiSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "Int.Type",
+        "key.typeusr" : "$sSimD",
+        "key.usr" : "s:Si"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>@frozen struct String<\/Declaration>",
+        "key.bodylength" : 110,
+        "key.bodyoffset" : 630,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen struct String",
+        "key.doc.discussion" : [
+          {
+            "Para" : "A string is a series of characters, such as `\"Swift\"`, that forms a collection. Strings in Swift are Unicode correct and locale insensitive, and are designed to be efficient. The `String` type bridges with the Objective-C class `NSString` and offers interoperability with C functions that works with strings."
+          },
+          {
+            "Para" : "You can create new strings using string literals or string interpolations. A  is a series of characters enclosed in quotes."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : " are string literals that evaluate any included expressions and convert the results to string form. String interpolations give you an easy way to build a string from multiple pieces. Wrap each expression in a string interpolation in parentheses, prefixed by a backslash."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Combine strings using the concatenation operator (`+`)."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Multiline string literals are enclosed in three double quotation marks (`\"\"\"`), with each delimiter on its own line. Indentation is stripped from each line of a multiline string literal to match the indentation of the closing delimiter."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Strings always have value semantics. Modifying a copy of a string leaves the original unaffected."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Comparing strings for equality using the equal-to operator (`==`) or a relational operator (like `<` or `>=`) is always performed using Unicode canonical representation. As a result, different representations of a string compare as being equal."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The Unicode scalar value `\"\\u{301}\"` modifies the preceding character to include an accent, so `\"e\\u{301}\"` has the same canonical representation as the single Unicode scalar value `\"é\"`."
+          },
+          {
+            "Para" : "Basic string operations are not sensitive to locale settings, ensuring that string comparisons and other operations always have a single, stable result, allowing strings to be used as keys in `Dictionary` instances and for other purposes."
+          },
+          {
+            "Para" : "A string is a collection of , which approximate human-readable characters. Many individual characters, such as “é”, “김”, and “🇮🇳”, can be made up of multiple Unicode scalar values. These scalar values are combined by Unicode’s boundary algorithms into extended grapheme clusters, represented by the Swift `Character` type. Each element of a string is represented by a `Character` instance."
+          },
+          {
+            "Para" : "For example, to retrieve the first word of a longer string, you can search for a space and then create a substring from a prefix of the string up to that point:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `firstName` constant is an instance of the `Substring` type—a type that represents substrings of a string while sharing the original string’s storage. Substrings present the same interface as strings."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "If you need to access the contents of a string as encoded in different Unicode encodings, use one of the string’s `unicodeScalars`, `utf16`, or `utf8` properties. Each property provides access to a view of the string as a series of code units, each encoded in a different Unicode encoding."
+          },
+          {
+            "Para" : "To demonstrate the different views available for every string, the following examples use this `String` instance:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `cafe` string is a collection of the nine characters that are visible when the string is displayed."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "A string’s `unicodeScalars` property is a collection of Unicode scalar values, the 21-bit codes that are the basic unit of Unicode. Each scalar value is represented by a `Unicode.Scalar` instance and is equivalent to a UTF-32 code unit."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `unicodeScalars` view’s elements comprise each Unicode scalar value in the `cafe` string. In particular, because `cafe` was declared using the decomposed form of the `\"é\"` character, `unicodeScalars` contains the scalar values for both the letter `\"e\"` (101) and the accent character `\"´\"` (769)."
+          },
+          {
+            "Para" : "A string’s `utf16` property is a collection of UTF-16 code units, the 16-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a `UInt16` instance."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The elements of the `utf16` view are the code units for the string when encoded in UTF-16. These elements match those accessed through indexed `NSString` APIs."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "A string’s `utf8` property is a collection of UTF-8 code units, the 8-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a `UInt8` instance."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The elements of the `utf8` view are the code units for the string when encoded in UTF-8. This representation matches the one used when `String` instances are passed to C APIs."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "When you need to know the length of a string, you must first consider what you’ll use the length for. Are you measuring the number of characters that will be displayed on the screen, or are you measuring the amount of storage needed for the string in a particular encoding? A single string can have greatly differing lengths when measured by its different views."
+          },
+          {
+            "Para" : "For example, an ASCII character like the capital letter  is represented by a single element in each of its four views. The Unicode scalar value of  is `65`, which is small enough to fit in a single code unit in both UTF-16 and UTF-8."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "On the other hand, an emoji flag character is constructed from a pair of Unicode scalar values, like `\"\\u{1F1F5}\"` and `\"\\u{1F1F7}\"`. Each of these scalar values, in turn, is too large to fit into a single UTF-16 or UTF-8 code unit. As a result, each view of the string `\"🇵🇷\"` reports a different length."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "To check whether a string is empty, use its `isEmpty` property instead of comparing the length of one of the views to `0`. Unlike with `isEmpty`, calculating a view’s `count` property requires iterating through the elements of the string."
+          },
+          {
+            "Para" : "To find individual elements of a string, use the appropriate view for your task. For example, to retrieve the first word of a longer string, you can search the string for a space and then create a new string from a prefix of the string up to that point."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Strings and their views share indices, so you can access the UTF-8 view of the `name` string using the same `firstSpace` index."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Note that an index into one view may not have an exact corresponding position in another view. For example, the `flag` string declared above comprises a single character, but is composed of eight code units when encoded as UTF-8. The following code creates constants for the first and second positions in the `flag.utf8` view. Accessing the `utf8` view with these indices yields the first and second code UTF-8 units."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "When used to access the elements of the `flag` string itself, however, the `secondCodeUnit` index does not correspond to the position of a specific character. Instead of only accessing the specific UTF-8 code unit, that index is treated as the position of the character at the index’s encoded offset. In the case of `secondCodeUnit`, that character is still the flag itself."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "If you need to validate that an index from one string’s view corresponds with an exact position in another view, use the index’s `samePosition(in:)` method or the `init(_:within:)` initializer."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Although strings in Swift have value semantics, strings use a copy-on-write strategy to store their data in a buffer. This buffer can then be shared by different copies of a string. A string’s data is only copied lazily, upon mutation, when more than one string instance is using the same buffer. Therefore, the first in any sequence of mutating operations may cost O() time and space."
+          },
+          {
+            "Para" : "When a string’s contiguous storage fills up, a new buffer must be allocated and data must be moved to the new storage. String buffers use an exponential growth strategy that makes appending to a string a constant time operation when averaged over many append operations."
+          },
+          {
+            "Para" : "Any `String` instance can be bridged to `NSString` using the type-cast operator (`as`), and any `String` instance that originates in Objective-C may use an `NSString` instance as its storage. Because any arbitrary subclass of `NSString` can become a `String` instance, there are no guarantees about representation or efficiency when a `String` instance is backed by `NSString` storage. Because `NSString` is immutable, it is just as though the storage was shared by a copy. The first in any sequence of mutating operations causes elements to be copied into unique, contiguous storage which may cost O() time and space, where  is the length of the string’s encoded representation (or more, if the underlying `NSString` has unusual performance characteristics)."
+          },
+          {
+            "Para" : "For more information about the Unicode terms used in this discussion, see the . In particular, this discussion mentions , , and ."
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>String<\/Name><USR>s:SS<\/USR><Declaration>@frozen struct String<\/Declaration><CommentParts><Abstract><Para>A Unicode string value that is a collection of characters.<\/Para><\/Abstract><Discussion><Para>A string is a series of characters, such as <codeVoice>&quot;Swift&quot;<\/codeVoice>, that forms a collection. Strings in Swift are Unicode correct and locale insensitive, and are designed to be efficient. The <codeVoice>String<\/codeVoice> type bridges with the Objective-C class <codeVoice>NSString<\/codeVoice> and offers interoperability with C functions that works with strings.<\/Para><Para>You can create new strings using string literals or string interpolations. A <emphasis>string literal<\/emphasis> is a series of characters enclosed in quotes.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para><emphasis>String interpolations<\/emphasis> are string literals that evaluate any included expressions and convert the results to string form. String interpolations give you an easy way to build a string from multiple pieces. Wrap each expression in a string interpolation in parentheses, prefixed by a backslash.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Rosa\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let personalizedGreeting = \"Welcome, \\(name)!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ personalizedGreeting == \"Welcome, Rosa!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let price = 2]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let number = 3]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let cookiePrice = \"\\(number) cookies: $\\(price * number).\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ cookiePrice == \"3 cookies: $6.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Combine strings using the concatenation operator (<codeVoice>+<\/codeVoice>).<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let longerGreeting = greeting + \" We're glad you're here!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ longerGreeting == \"Welcome! We're glad you're here!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Multiline string literals are enclosed in three double quotation marks (<codeVoice>&quot;&quot;&quot;<\/codeVoice>), with each delimiter on its own line. Indentation is stripped from each line of a multiline string literal to match the indentation of the closing delimiter.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let banner = \"\"\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[          __,]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[         (           o  \/) _\/_]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[          `.  , , , ,  \/\/  \/]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        (___)(_(_\/_(_ \/\/_ (__]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[                     \/)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[                    (\/]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        \"\"\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Modifying and Comparing Strings<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Strings always have value semantics. Modifying a copy of a string leaves the original unaffected.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var otherGreeting = greeting]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[otherGreeting += \" Have a nice time!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ otherGreeting == \"Welcome! Have a nice time!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(greeting)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Welcome!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Comparing strings for equality using the equal-to operator (<codeVoice>==<\/codeVoice>) or a relational operator (like <codeVoice>&lt;<\/codeVoice> or <codeVoice>&gt;=<\/codeVoice>) is always performed using Unicode canonical representation. As a result, different representations of a string compare as being equal.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cafe1 = \"Cafe\\u{301}\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let cafe2 = \"Café\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe1 == cafe2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"true\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The Unicode scalar value <codeVoice>&quot;\\u{301}&quot;<\/codeVoice> modifies the preceding character to include an accent, so <codeVoice>&quot;e\\u{301}&quot;<\/codeVoice> has the same canonical representation as the single Unicode scalar value <codeVoice>&quot;é&quot;<\/codeVoice>.<\/Para><Para>Basic string operations are not sensitive to locale settings, ensuring that string comparisons and other operations always have a single, stable result, allowing strings to be used as keys in <codeVoice>Dictionary<\/codeVoice> instances and for other purposes.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing String Elements<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>A string is a collection of <emphasis>extended grapheme clusters<\/emphasis>, which approximate human-readable characters. Many individual characters, such as “é”, “김”, and “🇮🇳”, can be made up of multiple Unicode scalar values. These scalar values are combined by Unicode’s boundary algorithms into extended grapheme clusters, represented by the Swift <codeVoice>Character<\/codeVoice> type. Each element of a string is represented by a <codeVoice>Character<\/codeVoice> instance.<\/Para><Para>For example, to retrieve the first word of a longer string, you can search for a space and then create a substring from a prefix of the string up to that point:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Marie Curie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstSpace = name.firstIndex(of: \" \") ?? name.endIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstName = name[..<firstSpace]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ firstName == \"Marie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>firstName<\/codeVoice> constant is an instance of the <codeVoice>Substring<\/codeVoice> type—a type that represents substrings of a string while sharing the original string’s storage. Substrings present the same interface as strings.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(\"\\(name)'s first name has \\(firstName.count) letters.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Marie Curie's first name has 5 letters.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing a String’s Unicode Representation<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>If you need to access the contents of a string as encoded in different Unicode encodings, use one of the string’s <codeVoice>unicodeScalars<\/codeVoice>, <codeVoice>utf16<\/codeVoice>, or <codeVoice>utf8<\/codeVoice> properties. Each property provides access to a view of the string as a series of code units, each encoded in a different Unicode encoding.<\/Para><Para>To demonstrate the different views available for every string, the following examples use this <codeVoice>String<\/codeVoice> instance:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cafe = \"Cafe\\u{301} du 🌍\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Café du 🌍\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>cafe<\/codeVoice> string is a collection of the nine characters that are visible when the string is displayed.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"9\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[\"C\", \"a\", \"f\", \"é\", \" \", \"d\", \"u\", \" \", \"🌍\"]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h2>]]><\/rawHTML>Unicode Scalar View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>unicodeScalars<\/codeVoice> property is a collection of Unicode scalar values, the 21-bit codes that are the basic unit of Unicode. Each scalar value is represented by a <codeVoice>Unicode.Scalar<\/codeVoice> instance and is equivalent to a UTF-32 code unit.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"10\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.unicodeScalars))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[\"C\", \"a\", \"f\", \"e\", \"\\u{0301}\", \" \", \"d\", \"u\", \" \", \"\\u{0001F30D}\"]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe.unicodeScalars.map { $0.value })]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 769, 32, 100, 117, 32, 127757]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>unicodeScalars<\/codeVoice> view’s elements comprise each Unicode scalar value in the <codeVoice>cafe<\/codeVoice> string. In particular, because <codeVoice>cafe<\/codeVoice> was declared using the decomposed form of the <codeVoice>&quot;é&quot;<\/codeVoice> character, <codeVoice>unicodeScalars<\/codeVoice> contains the scalar values for both the letter <codeVoice>&quot;e&quot;<\/codeVoice> (101) and the accent character <codeVoice>&quot;´&quot;<\/codeVoice> (769).<\/Para><rawHTML><![CDATA[<h2>]]><\/rawHTML>UTF-16 View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>utf16<\/codeVoice> property is a collection of UTF-16 code units, the 16-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a <codeVoice>UInt16<\/codeVoice> instance.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"11\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.utf16))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 769, 32, 100, 117, 32, 55356, 57101]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The elements of the <codeVoice>utf16<\/codeVoice> view are the code units for the string when encoded in UTF-16. These elements match those accessed through indexed <codeVoice>NSString<\/codeVoice> APIs.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let nscafe = cafe as NSString]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nscafe.length)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"11\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nscafe.character(at: 3))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"101\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h2>]]><\/rawHTML>UTF-8 View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>utf8<\/codeVoice> property is a collection of UTF-8 code units, the 8-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a <codeVoice>UInt8<\/codeVoice> instance.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"14\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.utf8))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 204, 129, 32, 100, 117, 32, 240, 159, 140, 141]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The elements of the <codeVoice>utf8<\/codeVoice> view are the code units for the string when encoded in UTF-8. This representation matches the one used when <codeVoice>String<\/codeVoice> instances are passed to C APIs.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cLength = strlen(cafe)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cLength)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"14\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Measuring the Length of a String<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>When you need to know the length of a string, you must first consider what you’ll use the length for. Are you measuring the number of characters that will be displayed on the screen, or are you measuring the amount of storage needed for the string in a particular encoding? A single string can have greatly differing lengths when measured by its different views.<\/Para><Para>For example, an ASCII character like the capital letter <emphasis>A<\/emphasis> is represented by a single element in each of its four views. The Unicode scalar value of <emphasis>A<\/emphasis> is <codeVoice>65<\/codeVoice>, which is small enough to fit in a single code unit in both UTF-16 and UTF-8.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let capitalA = \"A\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>On the other hand, an emoji flag character is constructed from a pair of Unicode scalar values, like <codeVoice>&quot;\\u{1F1F5}&quot;<\/codeVoice> and <codeVoice>&quot;\\u{1F1F7}&quot;<\/codeVoice>. Each of these scalar values, in turn, is too large to fit into a single UTF-16 or UTF-8 code unit. As a result, each view of the string <codeVoice>&quot;🇵🇷&quot;<\/codeVoice> reports a different length.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let flag = \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"2\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"4\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"8\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>To check whether a string is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing the length of one of the views to <codeVoice>0<\/codeVoice>. Unlike with <codeVoice>isEmpty<\/codeVoice>, calculating a view’s <codeVoice>count<\/codeVoice> property requires iterating through the elements of the string.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing String View Elements<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>To find individual elements of a string, use the appropriate view for your task. For example, to retrieve the first word of a longer string, you can search the string for a space and then create a new string from a prefix of the string up to that point.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Marie Curie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstSpace = name.firstIndex(of: \" \") ?? name.endIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstName = name[..<firstSpace]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(firstName)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Marie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Strings and their views share indices, so you can access the UTF-8 view of the <codeVoice>name<\/codeVoice> string using the same <codeVoice>firstSpace<\/codeVoice> index.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(Array(name.utf8[..<firstSpace]))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[77, 97, 114, 105, 101]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Note that an index into one view may not have an exact corresponding position in another view. For example, the <codeVoice>flag<\/codeVoice> string declared above comprises a single character, but is composed of eight code units when encoded as UTF-8. The following code creates constants for the first and second positions in the <codeVoice>flag.utf8<\/codeVoice> view. Accessing the <codeVoice>utf8<\/codeVoice> view with these indices yields the first and second code UTF-8 units.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let firstCodeUnit = flag.startIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let secondCodeUnit = flag.utf8.index(after: firstCodeUnit)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag.utf8[firstCodeUnit] == 240]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag.utf8[secondCodeUnit] == 159]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>When used to access the elements of the <codeVoice>flag<\/codeVoice> string itself, however, the <codeVoice>secondCodeUnit<\/codeVoice> index does not correspond to the position of a specific character. Instead of only accessing the specific UTF-8 code unit, that index is treated as the position of the character at the index’s encoded offset. In the case of <codeVoice>secondCodeUnit<\/codeVoice>, that character is still the flag itself.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[\/\/ flag[firstCodeUnit] == \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag[secondCodeUnit] == \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If you need to validate that an index from one string’s view corresponds with an exact position in another view, use the index’s <codeVoice>samePosition(in:)<\/codeVoice> method or the <codeVoice>init(_:within:)<\/codeVoice> initializer.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[if let exactIndex = secondCodeUnit.samePosition(in: flag) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(flag[exactIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"No exact match for this position.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"No exact match for this position.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Performance Optimizations<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Although strings in Swift have value semantics, strings use a copy-on-write strategy to store their data in a buffer. This buffer can then be shared by different copies of a string. A string’s data is only copied lazily, upon mutation, when more than one string instance is using the same buffer. Therefore, the first in any sequence of mutating operations may cost O(<emphasis>n<\/emphasis>) time and space.<\/Para><Para>When a string’s contiguous storage fills up, a new buffer must be allocated and data must be moved to the new storage. String buffers use an exponential growth strategy that makes appending to a string a constant time operation when averaged over many append operations.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Bridging Between String and NSString<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Any <codeVoice>String<\/codeVoice> instance can be bridged to <codeVoice>NSString<\/codeVoice> using the type-cast operator (<codeVoice>as<\/codeVoice>), and any <codeVoice>String<\/codeVoice> instance that originates in Objective-C may use an <codeVoice>NSString<\/codeVoice> instance as its storage. Because any arbitrary subclass of <codeVoice>NSString<\/codeVoice> can become a <codeVoice>String<\/codeVoice> instance, there are no guarantees about representation or efficiency when a <codeVoice>String<\/codeVoice> instance is backed by <codeVoice>NSString<\/codeVoice> storage. Because <codeVoice>NSString<\/codeVoice> is immutable, it is just as though the storage was shared by a copy. The first in any sequence of mutating operations causes elements to be copied into unique, contiguous storage which may cost O(<emphasis>n<\/emphasis>) time and space, where <emphasis>n<\/emphasis> is the length of the string’s encoded representation (or more, if the underlying <codeVoice>NSString<\/codeVoice> has unusual performance characteristics).<\/Para><Para>For more information about the Unicode terms used in this discussion, see the <Link href=\"http:\/\/www.unicode.org\/glossary\/\">Unicode.org glossary<\/Link>. In particular, this discussion mentions <Link href=\"http:\/\/www.unicode.org\/glossary\/#extended_grapheme_cluster\">extended grapheme clusters<\/Link>, <Link href=\"http:\/\/www.unicode.org\/glossary\/#unicode_scalar_value\">Unicode scalar values<\/Link>, and <Link href=\"http:\/\/www.unicode.org\/glossary\/#canonical_equivalent\">canonical equivalence<\/Link>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "String",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 612
+          }
+        ],
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>String<\/decl.name><\/decl.struct>",
+        "key.groupname" : "String",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ArgumentProtocol"
+          }
+        ],
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 147,
+        "key.modulename" : "Swift",
+        "key.name" : "String",
+        "key.namelength" : 6,
+        "key.nameoffset" : 604,
+        "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static let name: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 632
+              }
+            ],
+            "key.column" : 20,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 26,
+            "key.line" : 27,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 650,
+            "key.offset" : 639,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static let name = \"string\"",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 27,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 668
+              }
+            ],
+            "key.bodylength" : 18,
+            "key.bodyoffset" : 720,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 64,
+            "key.line" : 29,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 687,
+            "key.offset" : 675,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func from(string: String) -> String?",
+            "key.parsed_scope.end" : 31,
+            "key.parsed_scope.start" : 29,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(String.Type) -> (String) -> String?",
+            "key.typeusr" : "$s6stringSSSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "String.Type",
+        "key.typeusr" : "$sSSmD",
+        "key.usr" : "s:SS"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>protocol RawRepresentable&lt;<Type usr=\"s:SY8RawValueQa\">RawValue<\/Type>&gt;<\/Declaration>",
+        "key.bodylength" : 112,
+        "key.bodyoffset" : 826,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "protocol RawRepresentable<RawValue>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "With a `RawRepresentable` type, you can switch back and forth between a custom type and an associated `RawValue` type without losing the value of the original `RawRepresentable` type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as `Equatable`, `Comparable`, and `Hashable`."
+          },
+          {
+            "Para" : "The `RawRepresentable` protocol is seen mainly in two categories of types: enumerations with raw value types and option sets."
+          },
+          {
+            "Para" : "For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds `RawRepresentable` conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases."
+          },
+          {
+            "Para" : "For example, the `Counter` enumeration defined here has an `Int` raw value type and gives the first case a raw value of `1`:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "You can create a `Counter` instance from an integer value between 1 and 5 by using the `init?(rawValue:)` initializer declared in the `RawRepresentable` protocol. This initializer is failable because although every case of the `Counter` type has a corresponding `Int` value, there are many `Int` values that  correspond to a case of `Counter`."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets all conform to `RawRepresentable` by inheritance using the `OptionSet` protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the `FixedWidthInteger` protocol, such as `UInt8` or `Int`. For example, the `Direction` type defines an option set for the four directions you can move in a game."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Unlike enumerations, option sets provide a nonfailable `init(rawValue:)` initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values."
+          },
+          {
+            "Para" : "In the case of the `Directions` option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the `allowedMoves` instance is the result of the bitwise OR of its three members’ raw values:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the `contains()` method on `allowedMoves` performs a bitwise AND operation to check whether the option set contains an element."
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>RawRepresentable<\/Name><USR>s:SY<\/USR><Declaration>protocol RawRepresentable&lt;RawValue&gt;<\/Declaration><CommentParts><Abstract><Para>A type that can be converted to and from an associated raw value.<\/Para><\/Abstract><Discussion><Para>With a <codeVoice>RawRepresentable<\/codeVoice> type, you can switch back and forth between a custom type and an associated <codeVoice>RawValue<\/codeVoice> type without losing the value of the original <codeVoice>RawRepresentable<\/codeVoice> type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as <codeVoice>Equatable<\/codeVoice>, <codeVoice>Comparable<\/codeVoice>, and <codeVoice>Hashable<\/codeVoice>.<\/Para><Para>The <codeVoice>RawRepresentable<\/codeVoice> protocol is seen mainly in two categories of types: enumerations with raw value types and option sets.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Enumerations with Raw Values<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds <codeVoice>RawRepresentable<\/codeVoice> conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases.<\/Para><Para>For example, the <codeVoice>Counter<\/codeVoice> enumeration defined here has an <codeVoice>Int<\/codeVoice> raw value type and gives the first case a raw value of <codeVoice>1<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[enum Counter: Int {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    case one = 1, two, three, four, five]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can create a <codeVoice>Counter<\/codeVoice> instance from an integer value between 1 and 5 by using the <codeVoice>init?(rawValue:)<\/codeVoice> initializer declared in the <codeVoice>RawRepresentable<\/codeVoice> protocol. This initializer is failable because although every case of the <codeVoice>Counter<\/codeVoice> type has a corresponding <codeVoice>Int<\/codeVoice> value, there are many <codeVoice>Int<\/codeVoice> values that <emphasis>don’t<\/emphasis> correspond to a case of <codeVoice>Counter<\/codeVoice>.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[for i in 3...6 {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(Counter(rawValue: i))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.three)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.four)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.five)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"nil\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Option Sets<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Option sets all conform to <codeVoice>RawRepresentable<\/codeVoice> by inheritance using the <codeVoice>OptionSet<\/codeVoice> protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the <codeVoice>FixedWidthInteger<\/codeVoice> protocol, such as <codeVoice>UInt8<\/codeVoice> or <codeVoice>Int<\/codeVoice>. For example, the <codeVoice>Direction<\/codeVoice> type defines an option set for the four directions you can move in a game.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Directions: OptionSet {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let rawValue: UInt8]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let up    = Directions(rawValue: 1 << 0)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let down  = Directions(rawValue: 1 << 1)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let left  = Directions(rawValue: 1 << 2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let right = Directions(rawValue: 1 << 3)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Unlike enumerations, option sets provide a nonfailable <codeVoice>init(rawValue:)<\/codeVoice> initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values.<\/Para><Para>In the case of the <codeVoice>Directions<\/codeVoice> option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the <codeVoice>allowedMoves<\/codeVoice> instance is the result of the bitwise OR of its three members’ raw values:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let allowedMoves: Directions = [.up, .down, .left]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"7\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the <codeVoice>contains()<\/codeVoice> method on <codeVoice>allowedMoves<\/codeVoice> performs a bitwise AND operation to check whether the option set contains an element.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(allowedMoves.contains(.right))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"false\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue & Directions.right.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"0\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "RawRepresentable",
+        "key.doc.type" : "Class",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>RawRepresentable<\/decl.name>&lt;<decl.generic_type_param usr=\"s:SY8RawValueQa\"><ref.associatedtype usr=\"s:SY8RawValueQa\">RawValue<\/ref.associatedtype><\/decl.generic_type_param>&gt;<\/decl.protocol>",
+        "key.groupname" : "Protocols",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 196,
+        "key.modulename" : "Swift",
+        "key.name" : "RawRepresentable",
+        "key.namelength" : 16,
+        "key.nameoffset" : 753,
+        "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 828
+              }
+            ],
+            "key.bodylength" : 58,
+            "key.bodyoffset" : 878,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 102,
+            "key.line" : 35,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 847,
+            "key.offset" : 835,
+            "key.parsed_declaration" : "public static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 35,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4from6stringxSgSS_tFZ\">from(string: String) -&gt; Self?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol, Self : RawRepresentable, Self.RawValue : StringProtocol> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "RawRepresentable.Protocol",
+        "key.typeusr" : "$sSY_pmD",
+        "key.usr" : "s:SY"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>protocol RawRepresentable&lt;<Type usr=\"s:SY8RawValueQa\">RawValue<\/Type>&gt;<\/Declaration>",
+        "key.bodylength" : 112,
+        "key.bodyoffset" : 1027,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "protocol RawRepresentable<RawValue>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "With a `RawRepresentable` type, you can switch back and forth between a custom type and an associated `RawValue` type without losing the value of the original `RawRepresentable` type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as `Equatable`, `Comparable`, and `Hashable`."
+          },
+          {
+            "Para" : "The `RawRepresentable` protocol is seen mainly in two categories of types: enumerations with raw value types and option sets."
+          },
+          {
+            "Para" : "For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds `RawRepresentable` conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases."
+          },
+          {
+            "Para" : "For example, the `Counter` enumeration defined here has an `Int` raw value type and gives the first case a raw value of `1`:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "You can create a `Counter` instance from an integer value between 1 and 5 by using the `init?(rawValue:)` initializer declared in the `RawRepresentable` protocol. This initializer is failable because although every case of the `Counter` type has a corresponding `Int` value, there are many `Int` values that  correspond to a case of `Counter`."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets all conform to `RawRepresentable` by inheritance using the `OptionSet` protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the `FixedWidthInteger` protocol, such as `UInt8` or `Int`. For example, the `Direction` type defines an option set for the four directions you can move in a game."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Unlike enumerations, option sets provide a nonfailable `init(rawValue:)` initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values."
+          },
+          {
+            "Para" : "In the case of the `Directions` option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the `allowedMoves` instance is the result of the bitwise OR of its three members’ raw values:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the `contains()` method on `allowedMoves` performs a bitwise AND operation to check whether the option set contains an element."
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>RawRepresentable<\/Name><USR>s:SY<\/USR><Declaration>protocol RawRepresentable&lt;RawValue&gt;<\/Declaration><CommentParts><Abstract><Para>A type that can be converted to and from an associated raw value.<\/Para><\/Abstract><Discussion><Para>With a <codeVoice>RawRepresentable<\/codeVoice> type, you can switch back and forth between a custom type and an associated <codeVoice>RawValue<\/codeVoice> type without losing the value of the original <codeVoice>RawRepresentable<\/codeVoice> type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as <codeVoice>Equatable<\/codeVoice>, <codeVoice>Comparable<\/codeVoice>, and <codeVoice>Hashable<\/codeVoice>.<\/Para><Para>The <codeVoice>RawRepresentable<\/codeVoice> protocol is seen mainly in two categories of types: enumerations with raw value types and option sets.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Enumerations with Raw Values<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds <codeVoice>RawRepresentable<\/codeVoice> conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases.<\/Para><Para>For example, the <codeVoice>Counter<\/codeVoice> enumeration defined here has an <codeVoice>Int<\/codeVoice> raw value type and gives the first case a raw value of <codeVoice>1<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[enum Counter: Int {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    case one = 1, two, three, four, five]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can create a <codeVoice>Counter<\/codeVoice> instance from an integer value between 1 and 5 by using the <codeVoice>init?(rawValue:)<\/codeVoice> initializer declared in the <codeVoice>RawRepresentable<\/codeVoice> protocol. This initializer is failable because although every case of the <codeVoice>Counter<\/codeVoice> type has a corresponding <codeVoice>Int<\/codeVoice> value, there are many <codeVoice>Int<\/codeVoice> values that <emphasis>don’t<\/emphasis> correspond to a case of <codeVoice>Counter<\/codeVoice>.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[for i in 3...6 {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(Counter(rawValue: i))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.three)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.four)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.five)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"nil\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Option Sets<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Option sets all conform to <codeVoice>RawRepresentable<\/codeVoice> by inheritance using the <codeVoice>OptionSet<\/codeVoice> protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the <codeVoice>FixedWidthInteger<\/codeVoice> protocol, such as <codeVoice>UInt8<\/codeVoice> or <codeVoice>Int<\/codeVoice>. For example, the <codeVoice>Direction<\/codeVoice> type defines an option set for the four directions you can move in a game.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Directions: OptionSet {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let rawValue: UInt8]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let up    = Directions(rawValue: 1 << 0)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let down  = Directions(rawValue: 1 << 1)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let left  = Directions(rawValue: 1 << 2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let right = Directions(rawValue: 1 << 3)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Unlike enumerations, option sets provide a nonfailable <codeVoice>init(rawValue:)<\/codeVoice> initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values.<\/Para><Para>In the case of the <codeVoice>Directions<\/codeVoice> option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the <codeVoice>allowedMoves<\/codeVoice> instance is the result of the bitwise OR of its three members’ raw values:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let allowedMoves: Directions = [.up, .down, .left]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"7\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the <codeVoice>contains()<\/codeVoice> method on <codeVoice>allowedMoves<\/codeVoice> performs a bitwise AND operation to check whether the option set contains an element.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(allowedMoves.contains(.right))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"false\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue & Directions.right.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"0\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "RawRepresentable",
+        "key.doc.type" : "Class",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>RawRepresentable<\/decl.name>&lt;<decl.generic_type_param usr=\"s:SY8RawValueQa\"><ref.associatedtype usr=\"s:SY8RawValueQa\">RawValue<\/ref.associatedtype><\/decl.generic_type_param>&gt;<\/decl.protocol>",
+        "key.groupname" : "Protocols",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 199,
+        "key.modulename" : "Swift",
+        "key.name" : "RawRepresentable",
+        "key.namelength" : 16,
+        "key.nameoffset" : 951,
+        "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1029
+              }
+            ],
+            "key.bodylength" : 58,
+            "key.bodyoffset" : 1079,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 102,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 1048,
+            "key.offset" : 1036,
+            "key.parsed_declaration" : "public static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 41,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4from6stringxSgSS_tFZ\">from(string: String) -&gt; Self?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol, Self : RawRepresentable, Self.RawValue : FixedWidthInteger> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "RawRepresentable.Protocol",
+        "key.typeusr" : "$sSY_pmD",
+        "key.usr" : "s:SY"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Command.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 7522,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol CommandProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 247
+          }
+        ],
+        "key.bodylength" : 483,
+        "key.bodyoffset" : 280,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a subcommand that can be executed with its own set of arguments.",
+        "key.doc.declaration" : "public protocol CommandProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"12\" column=\"17\"><Name>CommandProtocol<\/Name><USR>s:10Commandant15CommandProtocolP<\/USR><Declaration>public protocol CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a subcommand that can be executed with its own set of arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "CommandProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 80,
+        "key.docoffset" : 167,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>CommandProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 510,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandProtocol",
+        "key.namelength" : 15,
+        "key.nameoffset" : 263,
+        "key.offset" : 254,
+        "key.parsed_declaration" : "public protocol CommandProtocol",
+        "key.parsed_scope.end" : 29,
+        "key.parsed_scope.start" : 12,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype Options : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 17,
+            "key.doc.comment" : "The command's options type.",
+            "key.doc.declaration" : "associatedtype Options : Commandant.OptionsProtocol",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"15\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7OptionsQa<\/USR><Declaration>associatedtype Options : Commandant.OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "Options",
+            "key.doc.type" : "Other",
+            "key.doclength" : 32,
+            "key.docoffset" : 283,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Options<\/decl.name> : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 39,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "Options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 331,
+            "key.offset" : 316,
+            "key.parsed_declaration" : "associatedtype Options: OptionsProtocol",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "Self.Options.Type",
+            "key.typeusr" : "$s7OptionsQzmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype ClientError where <Type usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type> == <Type usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/Type>.<Type usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>ClientError<\/decl.name> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype> == <ref.generic_type_param usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/ref.associatedtype>.<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 67,
+            "key.line" : 17,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 373,
+            "key.offset" : 358,
+            "key.parsed_declaration" : "associatedtype ClientError where ClientError == Options.ClientError",
+            "key.parsed_scope.end" : 17,
+            "key.parsed_scope.start" : 17,
+            "key.typename" : "Self.ClientError.Type",
+            "key.typeusr" : "$s11ClientErrorQzmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP11ClientErrorQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 532,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.comment" : "The action that users should specify to use this subcommand (e.g.,\n`help`).",
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"21\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSvp<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 21,
+            "key.doc.name" : "verb",
+            "key.doc.type" : "Other",
+            "key.doclength" : 85,
+            "key.docoffset" : 428,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 24,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 518,
+            "key.offset" : 514,
+            "key.parsed_declaration" : "var verb: String",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 21,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>var function: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 648,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.comment" : "A human-readable, high-level description of what this command is used\nfor.",
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"25\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSvp<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 25,
+            "key.doc.name" : "function",
+            "key.doc.type" : "Other",
+            "key.doclength" : 84,
+            "key.docoffset" : 541,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 28,
+            "key.line" : 25,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 630,
+            "key.offset" : 626,
+            "key.parsed_declaration" : "var function: String",
+            "key.parsed_scope.end" : 25,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>func run(_ options: <Type usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 7,
+            "key.doc.comment" : "Runs this subcommand with the given options.",
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"28\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 28,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 49,
+            "key.docoffset" : 657,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 55,
+            "key.line" : 28,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 712,
+            "key.offset" : 707,
+            "key.parsed_declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 28,
+            "key.parsed_scope.start" : 28,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : CommandProtocol> (Self) -> (Self.Options) -> Result<(), Self.ClientError>",
+            "key.typeusr" : "$sys6ResultOyyt11ClientErrorQzG7OptionsQzcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "CommandProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant15CommandProtocol_pmD",
+        "key.usr" : "s:10Commandant15CommandProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct CommandWrapper&lt;ClientError&gt; where <Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 793
+          }
+        ],
+        "key.bodylength" : 957,
+        "key.bodyoffset" : 843,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A type-erased command.",
+        "key.doc.declaration" : "public struct CommandWrapper<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"32\" column=\"15\"><Name>CommandWrapper<\/Name><USR>s:10Commandant14CommandWrapperV<\/USR><Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A type-erased command.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 32,
+        "key.doc.name" : "CommandWrapper",
+        "key.doc.type" : "Class",
+        "key.doclength" : 27,
+        "key.docoffset" : 766,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>CommandWrapper<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1001,
+        "key.line" : 32,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandWrapper",
+        "key.namelength" : 14,
+        "key.nameoffset" : 807,
+        "key.offset" : 800,
+        "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error>",
+        "key.parsed_scope.end" : 65,
+        "key.parsed_scope.start" : 32,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 30,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 835
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 32,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 822,
+            "key.offset" : 822,
+            "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 32,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant14CommandWrapperV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 845
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 16,
+            "key.line" : 33,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 856,
+            "key.offset" : 852,
+            "key.parsed_declaration" : "public let verb: String",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 33,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 870
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 34,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 881,
+            "key.offset" : 877,
+            "key.parsed_declaration" : "public let function: String",
+            "key.parsed_scope.end" : 34,
+            "key.parsed_scope.start" : 34,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let run: (<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 900
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>run<\/decl.name>: <decl.var.type>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 69,
+            "key.line" : 36,
+            "key.modulename" : "Commandant",
+            "key.name" : "run",
+            "key.namelength" : 3,
+            "key.nameoffset" : 911,
+            "key.offset" : 907,
+            "key.parsed_declaration" : "public let run: (ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 36,
+            "key.typename" : "(ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyyt10Commandant0B5ErrorOyxGGAC14ArgumentParserCcD",
+            "key.usr" : "s:10Commandant14CommandWrapperV3runys6ResultOyytAA0A5ErrorOyxGGAA14ArgumentParserCcvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: () -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 979
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type>() -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 990,
+            "key.offset" : 986,
+            "key.parsed_declaration" : "public let usage: () -> CommandantError<ClientError>?",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "() -> CommandantError<ClientError>?",
+            "key.typeusr" : "$s10Commandant0A5ErrorOyxGSgycD",
+            "key.usr" : "s:10Commandant14CommandWrapperV5usageAA0A5ErrorOyxGSgycvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate init&lt;C&gt;(_ command: <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>) where <Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type> == <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>, <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type> : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1078
+              }
+            ],
+            "key.bodylength" : 633,
+            "key.bodyoffset" : 1165,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Creates a command that wraps another.",
+            "key.doc.declaration" : "fileprivate init<C>(_ command: C) where ClientError == C.ClientError, C : Commandant.CommandProtocol",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"41\" column=\"14\"><Name>init(_:)<\/Name><USR>s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc<\/USR><Declaration>fileprivate init&lt;C&gt;(_ command: C) where ClientError == C.ClientError, C : Commandant.CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Creates a command that wraps another.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 41,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 42,
+            "key.docoffset" : 1035,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>command<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 709,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 38,
+            "key.nameoffset" : 1090,
+            "key.offset" : 1090,
+            "key.parsed_declaration" : "fileprivate init<C: CommandProtocol>(_ command: C) where C.ClientError == ClientError",
+            "key.parsed_scope.end" : 64,
+            "key.parsed_scope.start" : 41,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+                "key.column" : 19,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 15,
+                    "key.offset" : 1098
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>C<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "CommandProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 18,
+                "key.line" : 41,
+                "key.modulename" : "Commandant",
+                "key.name" : "C",
+                "key.namelength" : 1,
+                "key.nameoffset" : 1095,
+                "key.offset" : 1095,
+                "key.parsed_declaration" : "fileprivate init<C: CommandProtocol",
+                "key.parsed_scope.end" : 41,
+                "key.parsed_scope.start" : 41,
+                "key.typename" : "C.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol> (CommandWrapper<ClientError>.Type) -> (C) -> CommandWrapper<ClientError>",
+            "key.typeusr" : "$sy10Commandant14CommandWrapperVyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__luD",
+            "key.usr" : "s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc"
+          }
+        ],
+        "key.typename" : "CommandWrapper<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant14CommandWrapperVyxGmD",
+        "key.usr" : "s:10Commandant14CommandWrapperV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1859
+          }
+        ],
+        "key.bodylength" : 216,
+        "key.bodyoffset" : 1884,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Describes the \"mode\" in which a command should run.",
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.doclength" : 56,
+        "key.docoffset" : 1803,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 235,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1871,
+        "key.offset" : 1866,
+        "key.parsed_declaration" : "public enum CommandMode",
+        "key.parsed_scope.end" : 75,
+        "key.parsed_scope.start" : 68,
+        "key.substructure" : [
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 30,
+            "key.offset" : 1955,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case arguments(<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Options should be parsed from the given command-line arguments.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"70\" column=\"7\"><Name>arguments(_:)<\/Name><USR>s:10Commandant11CommandModeO9argumentsyAcA14ArgumentParserCcACmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Options should be parsed from the given command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 70,
+                "key.doc.name" : "arguments(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 68,
+                "key.docoffset" : 1886,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 25,
+                "key.line" : 70,
+                "key.modulename" : "Commandant",
+                "key.name" : "arguments(_:)",
+                "key.namelength" : 25,
+                "key.nameoffset" : 1960,
+                "key.offset" : 1960,
+                "key.parsed_declaration" : "case arguments(ArgumentParser)",
+                "key.parsed_scope.end" : 70,
+                "key.parsed_scope.start" : 70,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(CommandMode.Type) -> (ArgumentParser) -> CommandMode",
+                "key.typeusr" : "$sy10Commandant11CommandModeOAA14ArgumentParserCcACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO9argumentsyAcA14ArgumentParserCcACmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 10,
+            "key.offset" : 2089,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case usage<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Each option should record its usage information in an error, for\npresentation to the user.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"74\" column=\"7\"><Name>usage<\/Name><USR>s:10Commandant11CommandModeO5usageyA2CmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Each option should record its usage information in an error, for presentation to the user.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 74,
+                "key.doc.name" : "usage",
+                "key.doc.type" : "Other",
+                "key.doclength" : 100,
+                "key.docoffset" : 1988,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usage<\/decl.name><\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 5,
+                "key.line" : 74,
+                "key.modulename" : "Commandant",
+                "key.name" : "usage",
+                "key.namelength" : 5,
+                "key.nameoffset" : 2094,
+                "key.offset" : 2094,
+                "key.parsed_declaration" : "case usage",
+                "key.parsed_scope.end" : 74,
+                "key.parsed_scope.start" : 74,
+                "key.typename" : "(CommandMode.Type) -> CommandMode",
+                "key.typeusr" : "$sy10Commandant11CommandModeOACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO5usageyA2CmF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final",
+            "key.length" : 5,
+            "key.offset" : 2163
+          },
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 2156
+          }
+        ],
+        "key.bodylength" : 1204,
+        "key.bodyoffset" : 2212,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Maintains the list of commands available to run.",
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"78\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 78,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.doclength" : 53,
+        "key.docoffset" : 2103,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 1248,
+        "key.line" : 78,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 2175,
+        "key.offset" : 2169,
+        "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error>",
+        "key.parsed_scope.end" : 116,
+        "key.parsed_scope.start" : 78,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 36,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 2204
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 78,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2191,
+            "key.offset" : 2191,
+            "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error",
+            "key.parsed_scope.end" : 78,
+            "key.parsed_scope.start" : 78,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant15CommandRegistryC11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private var commandsByVerb: [<Type usr=\"s:SS\">String<\/Type> : <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 2214
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commandsByVerb<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct> : <ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 63,
+            "key.line" : 79,
+            "key.modulename" : "Commandant",
+            "key.name" : "commandsByVerb",
+            "key.namelength" : 14,
+            "key.nameoffset" : 2226,
+            "key.offset" : 2222,
+            "key.parsed_declaration" : "private var commandsByVerb: [String: CommandWrapper<ClientError>] = [:]",
+            "key.parsed_scope.end" : 79,
+            "key.parsed_scope.start" : 79,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[String : CommandWrapper<ClientError>]",
+            "key.typeusr" : "$sSDySS10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC14commandsByVerb33_1DD6990CD6DFDE28F713A55F8EE2B70ELLSDySSAA0B7WrapperVyxGGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var commands: [<Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;] { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2317
+              }
+            ],
+            "key.bodylength" : 69,
+            "key.bodyoffset" : 2369,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "All available commands.",
+            "key.doc.declaration" : "public var commands: [CommandWrapper<ClientError>] { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"82\" column=\"13\"><Name>commands<\/Name><USR>s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGvp<\/USR><Declaration>public var commands: [CommandWrapper&lt;ClientError&gt;] { get }<\/Declaration><CommentParts><Abstract><Para>All available commands.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 82,
+            "key.doc.name" : "commands",
+            "key.doc.type" : "Other",
+            "key.doclength" : 28,
+            "key.docoffset" : 2288,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commands<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 115,
+            "key.line" : 82,
+            "key.modulename" : "Commandant",
+            "key.name" : "commands",
+            "key.namelength" : 8,
+            "key.nameoffset" : 2328,
+            "key.offset" : 2324,
+            "key.parsed_declaration" : "public var commands: [CommandWrapper<ClientError>]",
+            "key.parsed_scope.end" : 84,
+            "key.parsed_scope.start" : 82,
+            "key.typename" : "[CommandWrapper<ClientError>]",
+            "key.typeusr" : "$sSay10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2442
+              }
+            ],
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 2457,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 2449,
+            "key.offset" : 2449,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>.Type) -> () -> CommandRegistry<ClientError>",
+            "key.typeusr" : "$s10Commandant15CommandRegistryCyxGycD",
+            "key.usr" : "s:10Commandant15CommandRegistryCACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>@discardableResult public func register&lt;C&gt;(_ commands: <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type>...) -&gt; <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type> where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> == <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>, <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type> : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2656
+              },
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult",
+                "key.length" : 18,
+                "key.offset" : 2636
+              }
+            ],
+            "key.bodylength" : 106,
+            "key.bodyoffset" : 2775,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Registers the given commands, making those available to run.\n\nIf another commands were already registered with the same `verb`s, those\nwill be overwritten.",
+            "key.doc.declaration" : "@discardableResult\npublic func register<C>(_ commands: C...) -> CommandRegistry where ClientError == C.ClientError, C : Commandant.CommandProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If another commands were already registered with the same `verb`s, those will be overwritten."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"93\" column=\"14\"><Name>register(_:)<\/Name><USR>s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF<\/USR><Declaration>@discardableResult\npublic func register&lt;C&gt;(_ commands: C...) -&gt; CommandRegistry where ClientError == C.ClientError, C : Commandant.CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Registers the given commands, making those available to run.<\/Para><\/Abstract><Discussion><Para>If another commands were already registered with the same <codeVoice>verb<\/codeVoice>s, those will be overwritten.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 93,
+            "key.doc.name" : "register(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 174,
+            "key.docoffset" : 2461,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>register<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>commands<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param>...<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class><\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 219,
+            "key.line" : 93,
+            "key.modulename" : "Commandant",
+            "key.name" : "register(_:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 2668,
+            "key.offset" : 2663,
+            "key.parsed_declaration" : "public func register<C: CommandProtocol>(_ commands: C...)\n\t-> CommandRegistry\n\twhere C.ClientError == ClientError",
+            "key.parsed_scope.end" : 101,
+            "key.parsed_scope.start" : 93,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+                "key.column" : 23,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 15,
+                    "key.offset" : 2680
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>C<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "CommandProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 18,
+                "key.line" : 93,
+                "key.modulename" : "Commandant",
+                "key.name" : "C",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2677,
+                "key.offset" : 2677,
+                "key.parsed_declaration" : "public func register<C: CommandProtocol",
+                "key.parsed_scope.end" : 93,
+                "key.parsed_scope.start" : 93,
+                "key.typename" : "C.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol> (CommandRegistry<ClientError>) -> (C...) -> CommandRegistry<ClientError>",
+            "key.typeusr" : "$sy10Commandant15CommandRegistryCyxGqd__d_tc11ClientErrorQyd__RszAA0B8ProtocolRd__luD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(command verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3059
+              }
+            ],
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 3164,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Runs the command corresponding to the given verb, passing it the given\narguments.\n\nReturns the results of the execution, or nil if no such command exists.",
+            "key.doc.declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the results of the execution, or nil if no such command exists."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"107\" column=\"14\"><Name>run(command:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC3run7command9argumentss6ResultOyytAA0A5ErrorOyxGGSgSS_SaySSGtF<\/USR><Declaration>public func run(command verb: String, arguments: [String]) -&gt; Result&lt;(), CommandantError&lt;ClientError&gt;&gt;?<\/Declaration><CommentParts><Abstract><Para>Runs the command corresponding to the given verb, passing it the given arguments.<\/Para><\/Abstract><Discussion><Para>Returns the results of the execution, or nil if no such command exists.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 107,
+            "key.doc.name" : "run(command:arguments:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 173,
+            "key.docoffset" : 2885,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>command<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 153,
+            "key.line" : 107,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(command:arguments:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 3071,
+            "key.offset" : 3066,
+            "key.parsed_declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.parsed_scope.end" : 109,
+            "key.parsed_scope.start" : 107,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.typeusr" : "$s7command9argumentss6ResultOyyt10Commandant0D5ErrorOyxGGSgSS_SaySSGtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC3run7command9argumentss6ResultOyytAA0A5ErrorOyxGGSgSS_SaySSGtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public subscript(verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3318
+              }
+            ],
+            "key.bodylength" : 32,
+            "key.bodyoffset" : 3382,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Returns the command matching the given verb, or nil if no such command\nis registered.",
+            "key.doc.declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>? { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"113\" column=\"9\"><Name>subscript(_:)<\/Name><USR>s:10Commandant15CommandRegistryCyAA0B7WrapperVyxGSgSScip<\/USR><Declaration>public subscript(verb: String) -&gt; CommandWrapper&lt;ClientError&gt;? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the command matching the given verb, or nil if no such command is registered.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 113,
+            "key.doc.name" : "subscript(_:)",
+            "key.doc.type" : "Other",
+            "key.doclength" : 95,
+            "key.docoffset" : 3222,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
+            "key.kind" : "source.lang.swift.decl.function.subscript",
+            "key.length" : 90,
+            "key.line" : 113,
+            "key.modulename" : "Commandant",
+            "key.name" : "subscript(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 3325,
+            "key.offset" : 3325,
+            "key.parsed_declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>?",
+            "key.parsed_scope.end" : 115,
+            "key.parsed_scope.start" : 113,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (String) -> CommandWrapper<ClientError>?",
+            "key.typeusr" : "$sy10Commandant14CommandWrapperVyxGSgSScD",
+            "key.usr" : "s:10Commandant15CommandRegistryCyAA0B7WrapperVyxGSgSScip"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 4074,
+        "key.bodyoffset" : 3446,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"78\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 78,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 4102,
+        "key.line" : 78,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 3429,
+        "key.offset" : 3419,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 241,
+        "key.parsed_scope.start" : 118,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; <Type usr=\"s:s4Voida\">Void<\/Type>) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 4246
+              }
+            ],
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 4332,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing CommandLine.arguments\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"136\" column=\"14\"><Name>main(defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF<\/USR><Declaration>public func main(defaultVerb: String, errorHandler: (ClientError) -&gt; Void) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing CommandLine.arguments and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 136,
+            "key.doc.name" : "main(defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 797,
+            "key.docoffset" : 3448,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void<\/ref.typealias><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 177,
+            "key.line" : 136,
+            "key.modulename" : "Commandant",
+            "key.name" : "main(defaultVerb:errorHandler:)",
+            "key.namelength" : 62,
+            "key.nameoffset" : 4258,
+            "key.offset" : 4253,
+            "key.parsed_declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.parsed_scope.end" : 138,
+            "key.parsed_scope.start" : 136,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF\">main(arguments:defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "$s11defaultVerb12errorHandlers5NeverOSS_yxXEtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(arguments: [<Type usr=\"s:SS\">String<\/Type>], defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; <Type usr=\"s:s4Voida\">Void<\/Type>) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 5221
+              }
+            ],
+            "key.bodylength" : 945,
+            "key.bodyoffset" : 5328,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing `arguments`\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"157\" column=\"14\"><Name>main(arguments:defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF<\/USR><Declaration>public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -&gt; Void) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing <codeVoice>arguments<\/codeVoice> and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 157,
+            "key.doc.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 787,
+            "key.docoffset" : 4433,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void<\/ref.typealias><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 1046,
+            "key.line" : 157,
+            "key.modulename" : "Commandant",
+            "key.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.namelength" : 83,
+            "key.nameoffset" : 5233,
+            "key.offset" : 5228,
+            "key.parsed_declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.parsed_scope.end" : 196,
+            "key.parsed_scope.start" : 157,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF\">main(defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>var arguments: [<Type usr=\"s:SS\">String<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 25,
+                "key.line" : 160,
+                "key.modulename" : "Commandant",
+                "key.name" : "arguments",
+                "key.namelength" : 9,
+                "key.nameoffset" : 5367,
+                "key.offset" : 5363,
+                "key.parsed_declaration" : "var arguments = arguments",
+                "key.parsed_scope.end" : 160,
+                "key.parsed_scope.start" : 160,
+                "key.typename" : "[String]",
+                "key.typeusr" : "$sSaySSGD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtFAEL0_AJvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let executableName: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>executableName<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 44,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "executableName",
+                "key.namelength" : 14,
+                "key.nameoffset" : 5430,
+                "key.offset" : 5426,
+                "key.parsed_declaration" : "let executableName = arguments.remove(at: 0)",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF14executableNameL_SSvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 22,
+                "key.line" : 166,
+                "key.modulename" : "Commandant",
+                "key.name" : "verb",
+                "key.namelength" : 4,
+                "key.nameoffset" : 5536,
+                "key.offset" : 5532,
+                "key.parsed_declaration" : "var verb = defaultVerb",
+                "key.parsed_scope.end" : 166,
+                "key.parsed_scope.start" : 166,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF4verbL_SSvp"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> ([String], String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "$s9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private func executeSubcommandIfExists(_ executableName: <Type usr=\"s:SS\">String<\/Type>, verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 6474
+              }
+            ],
+            "key.bodylength" : 933,
+            "key.bodyoffset" : 6585,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Finds and executes a subcommand which exists in your $PATH. The executable\nname must be in the form of `executable-verb`.\n\n- Returns: The exit status of found subcommand or nil.",
+            "key.doc.declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"202\" column=\"15\"><Name>executeSubcommandIfExists(_:verb:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF<\/USR><Declaration>private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -&gt; Int32?<\/Declaration><CommentParts><Abstract><Para>Finds and executes a subcommand which exists in your $PATH. The executable name must be in the form of <codeVoice>executable-verb<\/codeVoice>.<\/Para><\/Abstract><ResultDiscussion><Para>The exit status of found subcommand or nil.<\/Para><\/ResultDiscussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 202,
+            "key.doc.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The exit status of found subcommand or nil."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.doclength" : 196,
+            "key.docoffset" : 6277,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>executeSubcommandIfExists<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>executableName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 1037,
+            "key.line" : 202,
+            "key.modulename" : "Commandant",
+            "key.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.namelength" : 86,
+            "key.nameoffset" : 6487,
+            "key.offset" : 6482,
+            "key.parsed_declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.parsed_scope.end" : 240,
+            "key.parsed_scope.start" : 202,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let subcommand: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>subcommand<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 80,
+                "key.line" : 203,
+                "key.modulename" : "Commandant",
+                "key.name" : "subcommand",
+                "key.namelength" : 10,
+                "key.nameoffset" : 6592,
+                "key.offset" : 6588,
+                "key.parsed_declaration" : "let subcommand = \"\\(NSString(string: executableName).lastPathComponent)-\\(verb)\"",
+                "key.parsed_scope.end" : 203,
+                "key.parsed_scope.start" : 203,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10subcommandL_SSvp"
+              },
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>func launchTask(_ path: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type><\/Declaration>",
+                "key.bodylength" : 603,
+                "key.bodyoffset" : 6735,
+                "key.column" : 8,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>launchTask<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>path<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct><\/decl.function.returntype><\/decl.function.free>",
+                "key.kind" : "source.lang.swift.decl.function.free",
+                "key.length" : 667,
+                "key.line" : 205,
+                "key.modulename" : "Commandant",
+                "key.name" : "launchTask(_:arguments:)",
+                "key.namelength" : 47,
+                "key.nameoffset" : 6677,
+                "key.offset" : 6672,
+                "key.parsed_declaration" : "func launchTask(_ path: String, arguments: [String]) -> Int32",
+                "key.parsed_scope.end" : 233,
+                "key.parsed_scope.start" : 205,
+                "key.substructure" : [
+                  {
+                    "key.annotated_decl" : "<Declaration>let task: <Type usr=\"c:objc(cs)NSTask\">Process<\/Type><\/Declaration>",
+                    "key.column" : 8,
+                    "key.decl_lang" : "source.lang.swift",
+                    "key.filepath" : "",
+                    "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>task<\/decl.name>: <decl.var.type><ref.class usr=\"c:objc(cs)NSTask\">Process<\/ref.class><\/decl.var.type><\/decl.var.local>",
+                    "key.kind" : "source.lang.swift.decl.var.local",
+                    "key.length" : 20,
+                    "key.line" : 206,
+                    "key.modulename" : "Commandant",
+                    "key.name" : "task",
+                    "key.namelength" : 4,
+                    "key.nameoffset" : 6743,
+                    "key.offset" : 6739,
+                    "key.parsed_declaration" : "let task = Process()",
+                    "key.parsed_scope.end" : 206,
+                    "key.parsed_scope.start" : 206,
+                    "key.typename" : "Process",
+                    "key.typeusr" : "$sSo6NSTaskCD",
+                    "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10launchTaskL__AgISS_AKts5ErrorRzlF4taskL_So6NSTaskCvp"
+                  }
+                ],
+                "key.typename" : "<ClientError where ClientError : Error> (String, arguments: [String]) -> Int32",
+                "key.typeusr" : "$s_9argumentss5Int32VSS_SaySSGtcs5ErrorRzluD",
+                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10launchTaskL__AgISS_AKts5ErrorRzlF"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, String, [String]) -> Int32?",
+            "key.typeusr" : "$s_4verb9argumentss5Int32VSgSS_SSSaySSGtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Errors.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 5739,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum CommandantError&lt;ClientError&gt; : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 323
+          }
+        ],
+        "key.bodylength" : 157,
+        "key.bodyoffset" : 372,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Possible errors that can originate from Commandant.\n\n`ClientError` should be the type of error (if any) that can occur when\nrunning commands.",
+        "key.doc.declaration" : "public enum CommandantError<ClientError> : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "`ClientError` should be the type of error (if any) that can occur when running commands."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"15\" column=\"13\"><Name>CommandantError<\/Name><USR>s:10Commandant0A5ErrorO<\/USR><Declaration>public enum CommandantError&lt;ClientError&gt; : Error<\/Declaration><CommentParts><Abstract><Para>Possible errors that can originate from Commandant.<\/Para><\/Abstract><Discussion><Para><codeVoice>ClientError<\/codeVoice> should be the type of error (if any) that can occur when running commands.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+        "key.doc.line" : 15,
+        "key.doc.name" : "CommandantError",
+        "key.doc.type" : "Other",
+        "key.doclength" : 157,
+        "key.docoffset" : 166,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 5,
+            "key.offset" : 365
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandantError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Error"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 200,
+        "key.line" : 15,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandantError",
+        "key.namelength" : 15,
+        "key.nameoffset" : 335,
+        "key.offset" : 330,
+        "key.parsed_declaration" : "public enum CommandantError<ClientError>: Error",
+        "key.parsed_scope.end" : 21,
+        "key.parsed_scope.start" : 15,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 29,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 351,
+            "key.offset" : 351,
+            "key.parsed_declaration" : "public enum CommandantError<ClientError",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant0A5ErrorO06ClientB0xmfp"
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 36,
+            "key.offset" : 411,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case usageError(description: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "An option was used incorrectly.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"17\" column=\"7\"><Name>usageError(description:)<\/Name><USR>s:10Commandant0A5ErrorO05usageB0yACyxGSS_tcAEmlF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>An option was used incorrectly.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 17,
+                "key.doc.name" : "usageError(description:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 36,
+                "key.docoffset" : 374,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usageError<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>description<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 31,
+                "key.line" : 17,
+                "key.modulename" : "Commandant",
+                "key.name" : "usageError(description:)",
+                "key.namelength" : 31,
+                "key.nameoffset" : 416,
+                "key.offset" : 416,
+                "key.parsed_declaration" : "case usageError(description: String)",
+                "key.parsed_scope.end" : 17,
+                "key.parsed_scope.start" : 17,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "<ClientError> (CommandantError<ClientError>.Type) -> (String) -> CommandantError<ClientError>",
+                "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSS_tcADmcluD",
+                "key.usr" : "s:10Commandant0A5ErrorO05usageB0yACyxGSS_tcAEmlF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 30,
+            "key.offset" : 498,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case commandError(<Type usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\">ClientError<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "An error occurred while running a command.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"20\" column=\"7\"><Name>commandError(_:)<\/Name><USR>s:10Commandant0A5ErrorO07commandB0yACyxGxcAEmlF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>An error occurred while running a command.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 20,
+                "key.doc.name" : "commandError(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 47,
+                "key.docoffset" : 450,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>commandError<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 25,
+                "key.line" : 20,
+                "key.modulename" : "Commandant",
+                "key.name" : "commandError(_:)",
+                "key.namelength" : 25,
+                "key.nameoffset" : 503,
+                "key.offset" : 503,
+                "key.parsed_declaration" : "case commandError(ClientError)",
+                "key.parsed_scope.end" : 20,
+                "key.parsed_scope.start" : 20,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "<ClientError> (CommandantError<ClientError>.Type) -> (ClientError) -> CommandantError<ClientError>",
+                "key.typeusr" : "$sy10Commandant0A5ErrorOyxGxcADmcluD",
+                "key.usr" : "s:10Commandant0A5ErrorO07commandB0yACyxGxcAEmlF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "CommandantError<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant0A5ErrorOyxGmD",
+        "key.usr" : "s:10Commandant0A5ErrorO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandantError&lt;ClientError&gt; : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 187,
+        "key.bodyoffset" : 584,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandantError<ClientError> : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "`ClientError` should be the type of error (if any) that can occur when running commands."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"15\" column=\"13\"><Name>CommandantError<\/Name><USR>s:10Commandant0A5ErrorO<\/USR><Declaration>public enum CommandantError&lt;ClientError&gt; : Error<\/Declaration><CommentParts><Abstract><Para>Possible errors that can originate from Commandant.<\/Para><\/Abstract><Discussion><Para><codeVoice>ClientError<\/codeVoice> should be the type of error (if any) that can occur when running commands.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+        "key.doc.line" : 15,
+        "key.doc.name" : "CommandantError",
+        "key.doc.type" : "Other",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 559
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandantError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 240,
+        "key.line" : 15,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandantError",
+        "key.namelength" : 15,
+        "key.nameoffset" : 542,
+        "key.offset" : 532,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 33,
+        "key.parsed_scope.start" : 23,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 586
+              }
+            ],
+            "key.bodylength" : 151,
+            "key.bodyoffset" : 618,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 177,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 597,
+            "key.offset" : 593,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "CommandantError<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant0A5ErrorOyxGmD",
+        "key.usr" : "s:10Commandant0A5ErrorO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func missingArgumentError&lt;ClientError&gt;(_ argumentName: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 887
+          }
+        ],
+        "key.bodylength" : 105,
+        "key.bodyoffset" : 992,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an `InvalidArgument` error that indicates a missing value for\nthe argument by the given name.",
+        "key.doc.declaration" : "internal func missingArgumentError<ClientError>(_ argumentName: String) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"37\" column=\"15\"><Name>missingArgumentError(_:)<\/Name><USR>s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF<\/USR><Declaration>internal func missingArgumentError&lt;ClientError&gt;(_ argumentName: String) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an <codeVoice>InvalidArgument<\/codeVoice> error that indicates a missing value for the argument by the given name.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 37,
+        "key.doc.name" : "missingArgumentError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 113,
+        "key.docoffset" : 774,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>missingArgumentError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argumentName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 202,
+        "key.line" : 37,
+        "key.modulename" : "Commandant",
+        "key.name" : "missingArgumentError(_:)",
+        "key.namelength" : 57,
+        "key.nameoffset" : 901,
+        "key.offset" : 896,
+        "key.parsed_declaration" : "internal func missingArgumentError<ClientError>(_ argumentName: String) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 40,
+        "key.parsed_scope.start" : 37,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 36,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 37,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 922,
+            "key.offset" : 922,
+            "key.parsed_declaration" : "internal func missingArgumentError<ClientError",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 37,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let description: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 56,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 998,
+            "key.offset" : 994,
+            "key.parsed_declaration" : "let description = \"Missing argument for \\(argumentName)\"",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF11descriptionL_SSvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (String) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSScluD",
+        "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ keyValueExample: <Type usr=\"s:SS\">String<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 1215
+          }
+        ],
+        "key.bodylength" : 179,
+        "key.bodyoffset" : 1339,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error by combining the example of key (and value, if applicable)\nwith the usage description.",
+        "key.doc.declaration" : "internal func informativeUsageError<ClientError>(_ keyValueExample: String, usage: String) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"44\" column=\"15\"><Name>informativeUsageError(_:usage:)<\/Name><USR>s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF<\/USR><Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ keyValueExample: String, usage: String) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error by combining the example of key (and value, if applicable) with the usage description.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 44,
+        "key.doc.name" : "informativeUsageError(_:usage:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 115,
+        "key.docoffset" : 1100,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>keyValueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 295,
+        "key.line" : 44,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:usage:)",
+        "key.namelength" : 76,
+        "key.nameoffset" : 1229,
+        "key.offset" : 1224,
+        "key.parsed_declaration" : "internal func informativeUsageError<ClientError>(_ keyValueExample: String, usage: String) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 50,
+        "key.parsed_scope.start" : 44,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 44,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1251,
+            "key.offset" : 1251,
+            "key.parsed_declaration" : "internal func informativeUsageError<ClientError",
+            "key.parsed_scope.end" : 44,
+            "key.parsed_scope.start" : 44,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let lines: [<Type usr=\"s:SS\">String<\/Type>]<\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>lines<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 52,
+            "key.line" : 45,
+            "key.modulename" : "Commandant",
+            "key.name" : "lines",
+            "key.namelength" : 5,
+            "key.nameoffset" : 1345,
+            "key.offset" : 1341,
+            "key.parsed_declaration" : "let lines = usage.components(separatedBy: .newlines)",
+            "key.parsed_scope.end" : 45,
+            "key.parsed_scope.start" : 45,
+            "key.typename" : "[String]",
+            "key.typeusr" : "$sSaySSGD",
+            "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF5linesL_SaySSGvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (String, usage: String) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_5usage10Commandant0B5ErrorOyxGSS_SStcluD",
+        "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func combineUsageErrors&lt;ClientError&gt;(_ lhs: <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;, _ rhs: <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 1660
+          }
+        ],
+        "key.bodylength" : 265,
+        "key.bodyoffset" : 1813,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Combines the text of the two errors, if they're both `UsageError`s.\nOtherwise, uses whichever one is not (biased toward the left).",
+        "key.doc.declaration" : "internal func combineUsageErrors<ClientError>(_ lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"54\" column=\"15\"><Name>combineUsageErrors(_:_:)<\/Name><USR>s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF<\/USR><Declaration>internal func combineUsageErrors&lt;ClientError&gt;(_ lhs: CommandantError&lt;ClientError&gt;, _ rhs: CommandantError&lt;ClientError&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Combines the text of the two errors, if they’re both <codeVoice>UsageError<\/codeVoice>s. Otherwise, uses whichever one is not (biased toward the left).<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 54,
+        "key.doc.name" : "combineUsageErrors(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 139,
+        "key.docoffset" : 1521,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>combineUsageErrors<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 410,
+        "key.line" : 54,
+        "key.modulename" : "Commandant",
+        "key.name" : "combineUsageErrors(_:_:)",
+        "key.namelength" : 105,
+        "key.nameoffset" : 1674,
+        "key.offset" : 1669,
+        "key.parsed_declaration" : "internal func combineUsageErrors<ClientError>(_ lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 66,
+        "key.parsed_scope.start" : 54,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 34,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 54,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1693,
+            "key.offset" : 1693,
+            "key.parsed_declaration" : "internal func combineUsageErrors<ClientError",
+            "key.parsed_scope.end" : 54,
+            "key.parsed_scope.start" : 54,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp"
+          }
+        ],
+        "key.typename" : "<ClientError> (CommandantError<ClientError>, CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGAD_ADtcluD",
+        "key.usr" : "s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func unrecognizedArgumentsError&lt;ClientError&gt;(_ options: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2152
+          }
+        ],
+        "key.bodylength" : 96,
+        "key.bodyoffset" : 2260,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that indicates unrecognized arguments remains.",
+        "key.doc.declaration" : "internal func unrecognizedArgumentsError<ClientError>(_ options: [String]) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"69\" column=\"15\"><Name>unrecognizedArgumentsError(_:)<\/Name><USR>s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF<\/USR><Declaration>internal func unrecognizedArgumentsError&lt;ClientError&gt;(_ options: [String]) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that indicates unrecognized arguments remains.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 69,
+        "key.doc.name" : "unrecognizedArgumentsError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 71,
+        "key.docoffset" : 2081,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>unrecognizedArgumentsError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 196,
+        "key.line" : 69,
+        "key.modulename" : "Commandant",
+        "key.name" : "unrecognizedArgumentsError(_:)",
+        "key.namelength" : 60,
+        "key.nameoffset" : 2166,
+        "key.offset" : 2161,
+        "key.parsed_declaration" : "internal func unrecognizedArgumentsError<ClientError>(_ options: [String]) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 71,
+        "key.parsed_scope.start" : 69,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 42,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 69,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2193,
+            "key.offset" : 2193,
+            "key.parsed_declaration" : "internal func unrecognizedArgumentsError<ClientError",
+            "key.parsed_scope.end" : 69,
+            "key.parsed_scope.start" : 69,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp"
+          }
+        ],
+        "key.typename" : "<ClientError> ([String]) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSaySSGcluD",
+        "key.usr" : "s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 14,
+        "key.name" : "MARK: Argument",
+        "key.offset" : 2362
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ valueExample: <Type usr=\"s:SS\">String<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2499
+          }
+        ],
+        "key.bodylength" : 192,
+        "key.bodyoffset" : 2631,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument, with the given\nexample of value usage if applicable.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ valueExample: String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"77\" column=\"15\"><Name>informativeUsageError(_:argument:)<\/Name><USR>s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ valueExample: String, argument: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument, with the given example of value usage if applicable.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 77,
+        "key.doc.name" : "informativeUsageError(_:argument:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 121,
+        "key.docoffset" : 2378,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>valueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>argument<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 316,
+        "key.line" : 77,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:argument:)",
+        "key.namelength" : 84,
+        "key.nameoffset" : 2513,
+        "key.offset" : 2508,
+        "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError>(_ valueExample: String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 83,
+        "key.parsed_scope.start" : 77,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 77,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2535,
+            "key.offset" : 2535,
+            "key.parsed_declaration" : "internal func informativeUsageError<T",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 77,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 40,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 77,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2538,
+            "key.offset" : 2538,
+            "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 77,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError> (String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_8argument10Commandant0B5ErrorOyq_GSS_AB8ArgumentVyxGtcr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2890
+          }
+        ],
+        "key.bodylength" : 378,
+        "key.bodyoffset" : 3018,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ argument: Argument<T>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"86\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 86,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 64,
+        "key.docoffset" : 2826,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 498,
+        "key.line" : 86,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 80,
+        "key.nameoffset" : 2904,
+        "key.offset" : 2899,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 103,
+        "key.parsed_scope.start" : 86,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 2929
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2926,
+            "key.offset" : 2926,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2947,
+            "key.offset" : 2947,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var example: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>example<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 16,
+            "key.line" : 87,
+            "key.modulename" : "Commandant",
+            "key.name" : "example",
+            "key.namelength" : 7,
+            "key.nameoffset" : 3024,
+            "key.offset" : 3020,
+            "key.parsed_declaration" : "var example = \"\"",
+            "key.parsed_scope.end" : 87,
+            "key.parsed_scope.start" : 87,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF7exampleL_SSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var valueExample: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>valueExample<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 21,
+            "key.line" : 89,
+            "key.modulename" : "Commandant",
+            "key.name" : "valueExample",
+            "key.namelength" : 12,
+            "key.nameoffset" : 3043,
+            "key.offset" : 3039,
+            "key.parsed_declaration" : "var valueExample = \"\"",
+            "key.parsed_scope.end" : 89,
+            "key.parsed_scope.start" : 89,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF12valueExampleL_SSvp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Argument<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA8ArgumentVyxGcAA0C8ProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 3468
+          }
+        ],
+        "key.bodylength" : 378,
+        "key.bodyoffset" : 3598,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument list.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ argument: Argument<[T]>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"106\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument list.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 106,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 69,
+        "key.docoffset" : 3399,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 500,
+        "key.line" : 106,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 82,
+        "key.nameoffset" : 3482,
+        "key.offset" : 3477,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ argument: Argument<[T]>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 123,
+        "key.parsed_scope.start" : 106,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 3507
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 3504,
+            "key.offset" : 3504,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 106,
+            "key.parsed_scope.start" : 106,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 3525,
+            "key.offset" : 3525,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 106,
+            "key.parsed_scope.start" : 106,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var example: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>example<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 16,
+            "key.line" : 107,
+            "key.modulename" : "Commandant",
+            "key.name" : "example",
+            "key.namelength" : 7,
+            "key.nameoffset" : 3604,
+            "key.offset" : 3600,
+            "key.parsed_declaration" : "var example = \"\"",
+            "key.parsed_scope.end" : 107,
+            "key.parsed_scope.start" : 107,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF7exampleL_SSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var valueExample: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>valueExample<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 21,
+            "key.line" : 109,
+            "key.modulename" : "Commandant",
+            "key.name" : "valueExample",
+            "key.namelength" : 12,
+            "key.nameoffset" : 3623,
+            "key.offset" : 3619,
+            "key.parsed_declaration" : "var valueExample = \"\"",
+            "key.parsed_scope.end" : 109,
+            "key.parsed_scope.start" : 109,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF12valueExampleL_SSvp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Argument<[T]>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA8ArgumentVySayxGGcAA0C8ProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 12,
+        "key.name" : "MARK: Option",
+        "key.offset" : 3982
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ keyValueExample: <Type usr=\"s:SS\">String<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4126
+          }
+        ],
+        "key.bodylength" : 76,
+        "key.bodyoffset" : 4257,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option, with the given\nexample of key (and value, if applicable) usage.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ keyValueExample: String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"129\" column=\"15\"><Name>informativeUsageError(_:option:)<\/Name><USR>s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ keyValueExample: String, option: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option, with the given example of key (and value, if applicable) usage.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 129,
+        "key.doc.name" : "informativeUsageError(_:option:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 130,
+        "key.docoffset" : 3996,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>keyValueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>option<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 199,
+        "key.line" : 129,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:option:)",
+        "key.namelength" : 83,
+        "key.nameoffset" : 4140,
+        "key.offset" : 4135,
+        "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError>(_ keyValueExample: String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 131,
+        "key.parsed_scope.start" : 129,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 129,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4162,
+            "key.offset" : 4162,
+            "key.parsed_declaration" : "internal func informativeUsageError<T",
+            "key.parsed_scope.end" : 129,
+            "key.parsed_scope.start" : 129,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 40,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 129,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4165,
+            "key.offset" : 4165,
+            "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError",
+            "key.parsed_scope.end" : 129,
+            "key.parsed_scope.start" : 129,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError> (String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_6option10Commandant0B5ErrorOyq_GSS_AB6OptionVyxGtcr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4398
+          }
+        ],
+        "key.bodylength" : 89,
+        "key.bodyoffset" : 4522,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<T>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"134\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 134,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4336,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 205,
+        "key.line" : 134,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 76,
+        "key.nameoffset" : 4412,
+        "key.offset" : 4407,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 136,
+        "key.parsed_scope.start" : 134,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4437
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 134,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4434,
+            "key.offset" : 4434,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 134,
+            "key.parsed_scope.start" : 134,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 134,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4455,
+            "key.offset" : 4455,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 134,
+            "key.parsed_scope.start" : 134,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVyxGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4676
+          }
+        ],
+        "key.bodylength" : 78,
+        "key.bodyoffset" : 4801,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<T?>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"139\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 139,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4614,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 195,
+        "key.line" : 139,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 77,
+        "key.nameoffset" : 4690,
+        "key.offset" : 4685,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<T?>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 141,
+        "key.parsed_scope.start" : 139,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4715
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 139,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4712,
+            "key.offset" : 4712,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 139,
+            "key.parsed_scope.start" : 139,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 139,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4733,
+            "key.offset" : 4733,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 139,
+            "key.parsed_scope.start" : 139,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<T?>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVyxSgGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4944
+          }
+        ],
+        "key.bodylength" : 91,
+        "key.bodyoffset" : 5070,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<[T]>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"144\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 144,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4882,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 209,
+        "key.line" : 144,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 78,
+        "key.nameoffset" : 4958,
+        "key.offset" : 4953,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<[T]>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 146,
+        "key.parsed_scope.start" : 144,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4983
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 144,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4980,
+            "key.offset" : 4980,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 144,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 144,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5001,
+            "key.offset" : 5001,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 144,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<[T]>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVySayxGGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 5226
+          }
+        ],
+        "key.bodylength" : 78,
+        "key.bodyoffset" : 5353,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<[T]?>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"149\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 149,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 5164,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 197,
+        "key.line" : 149,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 79,
+        "key.nameoffset" : 5240,
+        "key.offset" : 5235,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<[T]?>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 151,
+        "key.parsed_scope.start" : 149,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 5265
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 149,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 5262,
+            "key.offset" : 5262,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 149,
+            "key.parsed_scope.start" : 149,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 149,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5283,
+            "key.offset" : 5283,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 149,
+            "key.parsed_scope.start" : 149,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<[T]?>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVySayxGSgGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 5510
+          }
+        ],
+        "key.bodylength" : 121,
+        "key.bodyoffset" : 5616,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the given boolean option.",
+        "key.doc.declaration" : "internal func informativeUsageError<ClientError>(_ option: Option<Bool>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"154\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF<\/USR><Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ option: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the given boolean option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 154,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 76,
+        "key.docoffset" : 5434,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 219,
+        "key.line" : 154,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 58,
+        "key.nameoffset" : 5524,
+        "key.offset" : 5519,
+        "key.parsed_declaration" : "internal func informativeUsageError<ClientError>(_ option: Option<Bool>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 157,
+        "key.parsed_scope.start" : 154,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 154,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5546,
+            "key.offset" : 5546,
+            "key.parsed_declaration" : "internal func informativeUsageError<ClientError",
+            "key.parsed_scope.end" : 154,
+            "key.parsed_scope.start" : 154,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 20,
+            "key.line" : 155,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 5622,
+            "key.offset" : 5618,
+            "key.parsed_declaration" : "let key = option.key",
+            "key.parsed_scope.end" : 155,
+            "key.parsed_scope.start" : 155,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF3keyL_SSvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (Option<Bool>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGAA6OptionVySbGcluD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/HelpCommand.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 2203,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpCommand&lt;ClientError&gt; : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type> where <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 537
+          }
+        ],
+        "key.bodylength" : 1127,
+        "key.bodyoffset" : 601,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A basic implementation of a `help` command, using information available in a\n`CommandRegistry`.\n\nIf you want to use this command, initialize it with the registry, then add\nit to that same registry:\n\n\tlet commands: CommandRegistry<MyErrorType> = …\n\tlet helpCommand = HelpCommand(registry: commands)\n\tcommands.register(helpCommand)",
+        "key.doc.declaration" : "public struct HelpCommand<ClientError> : CommandProtocol where ClientError : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "If you want to use this command, initialize it with the registry, then add it to that same registry:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/HelpCommand.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/HelpCommand.swift\" line=\"20\" column=\"15\"><Name>HelpCommand<\/Name><USR>s:10Commandant11HelpCommandV<\/USR><Declaration>public struct HelpCommand&lt;ClientError&gt; : CommandProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A basic implementation of a <codeVoice>help<\/codeVoice> command, using information available in a <codeVoice>CommandRegistry<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>If you want to use this command, initialize it with the registry, then add it to that same registry:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let commands: CommandRegistry<MyErrorType> = …]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let helpCommand = HelpCommand(registry: commands)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[commands.register(helpCommand)]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 20,
+        "key.doc.name" : "HelpCommand",
+        "key.doc.type" : "Class",
+        "key.doclength" : 366,
+        "key.docoffset" : 171,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 584
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpCommand<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CommandProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1185,
+        "key.line" : 20,
+        "key.modulename" : "Commandant",
+        "key.name" : "HelpCommand",
+        "key.namelength" : 11,
+        "key.nameoffset" : 551,
+        "key.offset" : 544,
+        "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error>: CommandProtocol",
+        "key.parsed_scope.end" : 59,
+        "key.parsed_scope.start" : 20,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 27,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 576
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 20,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 563,
+            "key.offset" : 563,
+            "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error",
+            "key.parsed_scope.end" : 20,
+            "key.parsed_scope.start" : 20,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11HelpCommandV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant11HelpCommandV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public typealias <Type usr=\"s:10Commandant11HelpCommandV\">HelpCommand<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;.Options = <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 603
+              }
+            ],
+            "key.column" : 19,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 17,
+            "key.doc.declaration" : "associatedtype Options : Commandant.OptionsProtocol",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"15\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7OptionsQa<\/USR><Declaration>associatedtype Options : Commandant.OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "Options",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.typealias><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>typealias<\/syntaxtype.keyword> <ref.struct usr=\"s:10Commandant11HelpCommandV\">HelpCommand<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;.<decl.name>Options<\/decl.name> = <ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.typealias>",
+            "key.kind" : "source.lang.swift.decl.typealias",
+            "key.length" : 44,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "Options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 620,
+            "key.offset" : 610,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+              }
+            ],
+            "key.parsed_declaration" : "public typealias Options = HelpOptions<ClientError>",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 21,
+            "key.typename" : "HelpOptions<ClientError>.Type",
+            "key.typeusr" : "$s10Commandant11HelpOptionsVyxGmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 657
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"21\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSvp<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 21,
+            "key.doc.name" : "verb",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 23,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 668,
+            "key.offset" : 664,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public let verb = \"help\"",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 23,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 683
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"25\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSvp<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 25,
+            "key.doc.name" : "function",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 694,
+            "key.offset" : 690,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public let function: String",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private let registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 713
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>registry<\/decl.name>: <decl.var.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 42,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "registry",
+            "key.namelength" : 8,
+            "key.nameoffset" : 725,
+            "key.offset" : 721,
+            "key.parsed_declaration" : "private let registry: CommandRegistry<ClientError>",
+            "key.parsed_scope.end" : 26,
+            "key.parsed_scope.start" : 26,
+            "key.typename" : "CommandRegistry<ClientError>",
+            "key.typeusr" : "$s10Commandant15CommandRegistryCyxGD",
+            "key.usr" : "s:10Commandant11HelpCommandV8registry33_38F61CE0DF9D73793CEDF5D1C3140331LLAA0C8RegistryCyxGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;, function: <Type usr=\"s:SS\">String<\/Type>? = nil)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 853
+              }
+            ],
+            "key.bodylength" : 102,
+            "key.bodyoffset" : 931,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the command to provide help from the given registry of\ncommands.",
+            "key.doc.declaration" : "public init(registry: CommandRegistry<ClientError>, function: String? = nil)",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/HelpCommand.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/HelpCommand.swift\" line=\"30\" column=\"9\"><Name>init(registry:function:)<\/Name><USR>s:10Commandant11HelpCommandV8registry8functionACyxGAA0C8RegistryCyxG_SSSgtcfc<\/USR><Declaration>public init(registry: CommandRegistry&lt;ClientError&gt;, function: String? = nil)<\/Declaration><CommentParts><Abstract><Para>Initializes the command to provide help from the given registry of commands.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 30,
+            "key.doc.name" : "init(registry:function:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 86,
+            "key.docoffset" : 766,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>registry<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>function<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 174,
+            "key.line" : 30,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(registry:function:)",
+            "key.namelength" : 69,
+            "key.nameoffset" : 860,
+            "key.offset" : 860,
+            "key.parsed_declaration" : "public init(registry: CommandRegistry<ClientError>, function: String? = nil)",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 30,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>.Type) -> (CommandRegistry<ClientError>, String?) -> HelpCommand<ClientError>",
+            "key.typeusr" : "$s8registry8function10Commandant11HelpCommandVyxGAC0E8RegistryCyxG_SSSgtcD",
+            "key.usr" : "s:10Commandant11HelpCommandV8registry8functionACyxGAA0C8RegistryCyxG_SSSgtcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(_ options: <Type usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1037
+              }
+            ],
+            "key.bodylength" : 625,
+            "key.bodyoffset" : 1101,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 7,
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"28\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 28,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 683,
+            "key.line" : 35,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 1049,
+            "key.offset" : 1044,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+              }
+            ],
+            "key.parsed_declaration" : "public func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 58,
+            "key.parsed_scope.start" : 35,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let maxVerbLength: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>maxVerbLength<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 75,
+                "key.line" : 50,
+                "key.modulename" : "Commandant",
+                "key.name" : "maxVerbLength",
+                "key.namelength" : 13,
+                "key.nameoffset" : 1422,
+                "key.offset" : 1418,
+                "key.parsed_declaration" : "let maxVerbLength = self.registry.commands.map { $0.verb.count }.max() ?? 0",
+                "key.parsed_scope.end" : 50,
+                "key.parsed_scope.start" : 50,
+                "key.typename" : "Int",
+                "key.typeusr" : "$sSiD",
+                "key.usr" : "s:10Commandant11HelpCommandV3runys6ResultOyytxGAA0B7OptionsVyxGF13maxVerbLengthL_Sivp"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>) -> (HelpOptions<ClientError>) -> Result<(), ClientError>",
+            "key.typeusr" : "$sys6ResultOyytxG10Commandant11HelpOptionsVyxGcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "HelpCommand<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant11HelpCommandVyxGmD",
+        "key.usr" : "s:10Commandant11HelpCommandV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where <Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1731
+          }
+        ],
+        "key.bodylength" : 406,
+        "key.bodyoffset" : 1795,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1778
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 464,
+        "key.line" : 61,
+        "key.modulename" : "Commandant",
+        "key.name" : "HelpOptions",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1745,
+        "key.offset" : 1738,
+        "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 76,
+        "key.parsed_scope.start" : 61,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 27,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 1770
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 61,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1757,
+            "key.offset" : 1757,
+            "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error",
+            "key.parsed_scope.end" : 61,
+            "key.parsed_scope.start" : 61,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11HelpOptionsV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant11HelpOptionsV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate let verb: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1797
+              }
+            ],
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 62,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 1813,
+            "key.offset" : 1809,
+            "key.parsed_declaration" : "fileprivate let verb: String?",
+            "key.parsed_scope.end" : 62,
+            "key.parsed_scope.start" : 62,
+            "key.typename" : "String?",
+            "key.typeusr" : "$sSSSgD",
+            "key.usr" : "s:10Commandant11HelpOptionsV4verb33_38F61CE0DF9D73793CEDF5D1C3140331LLSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private init(verb: <Type usr=\"s:SS\">String<\/Type>?)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 1829
+              }
+            ],
+            "key.bodylength" : 21,
+            "key.bodyoffset" : 1858,
+            "key.column" : 10,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 43,
+            "key.line" : 64,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(verb:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 1837,
+            "key.offset" : 1837,
+            "key.parsed_declaration" : "private init(verb: String?)",
+            "key.parsed_scope.end" : 66,
+            "key.parsed_scope.start" : 64,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String?) -> HelpOptions<ClientError>",
+            "key.typeusr" : "$s4verb10Commandant11HelpOptionsVyxGSSSg_tcD",
+            "key.usr" : "s:10Commandant11HelpOptionsV4verbACyxGSSSg_tc33_38F61CE0DF9D73793CEDF5D1C3140331Llfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private static func create(_ verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 1883
+              }
+            ],
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 1942,
+            "key.column" : 22,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>create<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 106,
+            "key.line" : 68,
+            "key.modulename" : "Commandant",
+            "key.name" : "create(_:)",
+            "key.namelength" : 22,
+            "key.nameoffset" : 1903,
+            "key.offset" : 1891,
+            "key.parsed_declaration" : "private static func create(_ verb: String) -> HelpOptions",
+            "key.parsed_scope.end" : 70,
+            "key.parsed_scope.start" : 68,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String) -> HelpOptions<ClientError>",
+            "key.typeusr" : "$sy10Commandant11HelpOptionsVyxGSScD",
+            "key.usr" : "s:10Commandant11HelpOptionsV6create33_38F61CE0DF9D73793CEDF5D1C3140331LLyACyxGSSFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2000
+              }
+            ],
+            "key.bodylength" : 99,
+            "key.bodyoffset" : 2100,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>OptionsProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 193,
+            "key.line" : 72,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 2019,
+            "key.offset" : 2007,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 72,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (CommandMode) -> Result<HelpOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOy10Commandant11HelpOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "HelpOptions<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant11HelpOptionsVyxGmD",
+        "key.usr" : "s:10Commandant11HelpOptionsV"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Option.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 9661,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol OptionsProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1388
+          }
+        ],
+        "key.bodylength" : 233,
+        "key.bodyoffset" : 1421,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a record of options for a command, which can be parsed from\na list of command-line arguments.\n\nThis is most helpful when used in conjunction with the `Option` and `Switch`\ntypes, and `<*>` and `<|` combinators.\n\nExample:\n\n\tstruct LogOptions: OptionsProtocol {\n\t\tlet verbosity: Int\n\t\tlet outputFilename: String\n\t\tlet shouldDelete: Bool\n\t\tlet logName: String\n\n\t\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {\n\t\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }\n\t\t}\n\n\t\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {\n\t\t\treturn create\n\t\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")\n\t\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")\n\t\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")\n\t\t\t\t<*> m <| Argument(usage: \"the log to read\")\n\t\t}\n\t}",
+        "key.doc.declaration" : "public protocol OptionsProtocol",
+        "key.doc.discussion" : [
+          {
+            "Para" : "This is most helpful when used in conjunction with the `Option` and `Switch` types, and `<*>` and `<|` combinators."
+          },
+          {
+            "Para" : "Example:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"37\" column=\"17\"><Name>OptionsProtocol<\/Name><USR>s:10Commandant15OptionsProtocolP<\/USR><Declaration>public protocol OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a record of options for a command, which can be parsed from a list of command-line arguments.<\/Para><\/Abstract><Discussion><Para>This is most helpful when used in conjunction with the <codeVoice>Option<\/codeVoice> and <codeVoice>Switch<\/codeVoice> types, and <codeVoice>&lt;*&gt;<\/codeVoice> and <codeVoice>&lt;|<\/codeVoice> combinators.<\/Para><Para>Example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct LogOptions: OptionsProtocol {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet verbosity: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet outputFilename: String]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet shouldDelete: Bool]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet logName: String]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn create]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Argument(usage: \"the log to read\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 37,
+        "key.doc.name" : "OptionsProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 1222,
+        "key.docoffset" : 166,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>OptionsProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 260,
+        "key.line" : 37,
+        "key.modulename" : "Commandant",
+        "key.name" : "OptionsProtocol",
+        "key.namelength" : 15,
+        "key.nameoffset" : 1404,
+        "key.offset" : 1395,
+        "key.parsed_declaration" : "public protocol OptionsProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 37,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>ClientError<\/decl.name> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 33,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1438,
+            "key.offset" : 1423,
+            "key.parsed_declaration" : "associatedtype ClientError: Error",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "Self.ClientError.Type",
+            "key.typeusr" : "$s11ClientErrorQzmD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP11ClientErrorQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Evaluates this set of options in the given mode.\n\nReturns the parsed options or a `UsageError`.",
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 109,
+            "key.docoffset" : 1459,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 84,
+            "key.line" : 43,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1581,
+            "key.offset" : 1569,
+            "key.parsed_declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 43,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : OptionsProtocol> (Self.Type) -> (CommandMode) -> Result<Self, CommandantError<Self.ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOy06ClientC0QzGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "OptionsProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant15OptionsProtocol_pmD",
+        "key.usr" : "s:10Commandant15OptionsProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct NoOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where <Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1703
+          }
+        ],
+        "key.bodylength" : 154,
+        "key.bodyoffset" : 1765,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "An `OptionsProtocol` that has no options.",
+        "key.doc.declaration" : "public struct NoOptions<ClientError> : OptionsProtocol where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"47\" column=\"15\"><Name>NoOptions<\/Name><USR>s:10Commandant9NoOptionsV<\/USR><Declaration>public struct NoOptions&lt;ClientError&gt; : OptionsProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>An <codeVoice>OptionsProtocol<\/codeVoice> that has no options.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 47,
+        "key.doc.name" : "NoOptions",
+        "key.doc.type" : "Class",
+        "key.doclength" : 46,
+        "key.docoffset" : 1657,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1748
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>NoOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 210,
+        "key.line" : 47,
+        "key.modulename" : "Commandant",
+        "key.name" : "NoOptions",
+        "key.namelength" : 9,
+        "key.nameoffset" : 1717,
+        "key.offset" : 1710,
+        "key.parsed_declaration" : "public struct NoOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 53,
+        "key.parsed_scope.start" : 47,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 25,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 1740
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 47,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1727,
+            "key.offset" : 1727,
+            "key.parsed_declaration" : "public struct NoOptions<ClientError: Error",
+            "key.parsed_scope.end" : 47,
+            "key.parsed_scope.start" : 47,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant9NoOptionsV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant9NoOptionsV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1767
+              }
+            ],
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 1782,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.line" : 48,
+            "key.modulename" : "Commandant",
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 1774,
+            "key.offset" : 1774,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 48,
+            "key.parsed_scope.start" : 48,
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> () -> NoOptions<ClientError>",
+            "key.typeusr" : "$s10Commandant9NoOptionsVyxGycD",
+            "key.usr" : "s:10Commandant9NoOptionsVACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1786
+              }
+            ],
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 1884,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>OptionsProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 125,
+            "key.line" : 50,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1805,
+            "key.offset" : 1793,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 52,
+            "key.parsed_scope.start" : 50,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> (CommandMode) -> Result<NoOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOy10Commandant9NoOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "NoOptions<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant9NoOptionsVyxGmD",
+        "key.usr" : "s:10Commandant9NoOptionsV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1988
+          }
+        ],
+        "key.bodylength" : 786,
+        "key.bodyoffset" : 2013,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes an option that can be provided on the command line.",
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"56\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 56,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.doclength" : 66,
+        "key.docoffset" : 1922,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 805,
+        "key.line" : 56,
+        "key.modulename" : "Commandant",
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2002,
+        "key.offset" : 1995,
+        "key.parsed_declaration" : "public struct Option<T>",
+        "key.parsed_scope.end" : 78,
+        "key.parsed_scope.start" : 56,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 22,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 56,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2009,
+            "key.offset" : 2009,
+            "key.parsed_declaration" : "public struct Option<T",
+            "key.parsed_scope.end" : 56,
+            "key.parsed_scope.start" : 56,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant6OptionV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2132
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The key that controls this option. For example, a key of `verbose` would\nbe used for a `--verbose` option.",
+            "key.doc.declaration" : "public let key: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"59\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6OptionV3keySSvp<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that controls this option. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 59,
+            "key.doc.name" : "key",
+            "key.doc.type" : "Other",
+            "key.doclength" : 116,
+            "key.docoffset" : 2015,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 15,
+            "key.line" : 59,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 2143,
+            "key.offset" : 2139,
+            "key.parsed_declaration" : "public let key: String",
+            "key.parsed_scope.end" : 59,
+            "key.parsed_scope.start" : 59,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6OptionV3keySSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2303
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The default value for this option. This is the value that will be used\nif the option is never explicitly specified on the command line.",
+            "key.doc.declaration" : "public let defaultValue: T",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"63\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant6OptionV12defaultValuexvp<\/USR><Declaration>public let defaultValue: T<\/Declaration><CommentParts><Abstract><Para>The default value for this option. This is the value that will be used if the option is never explicitly specified on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 63,
+            "key.doc.name" : "defaultValue",
+            "key.doc.type" : "Other",
+            "key.doclength" : 145,
+            "key.docoffset" : 2157,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 19,
+            "key.line" : 63,
+            "key.modulename" : "Commandant",
+            "key.name" : "defaultValue",
+            "key.namelength" : 12,
+            "key.nameoffset" : 2314,
+            "key.offset" : 2310,
+            "key.parsed_declaration" : "public let defaultValue: T",
+            "key.parsed_scope.end" : 63,
+            "key.parsed_scope.start" : 63,
+            "key.typename" : "T",
+            "key.typeusr" : "$sxD",
+            "key.usr" : "s:10Commandant6OptionV12defaultValuexvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2637
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.\n\nFor boolean operations, this should describe the effect of _not_ using\nthe default value (i.e., what will happen if you disable\/enable the flag\ndifferently from the default).",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.discussion" : [
+              {
+                "Para" : "For boolean operations, this should describe the effect of  using the default value (i.e., what will happen if you disable\/enable the flag differently from the default)."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"71\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6OptionV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><Discussion><Para>For boolean operations, this should describe the effect of <emphasis>not<\/emphasis> using the default value (i.e., what will happen if you disable\/enable the flag differently from the default).<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 71,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 304,
+            "key.docoffset" : 2332,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 71,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 2648,
+            "key.offset" : 2644,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 71,
+            "key.parsed_scope.start" : 71,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6OptionV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(key: <Type usr=\"s:SS\">String<\/Type>, defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2664
+              }
+            ],
+            "key.bodylength" : 75,
+            "key.bodyoffset" : 2722,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 127,
+            "key.line" : 73,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(key:defaultValue:usage:)",
+            "key.namelength" : 49,
+            "key.nameoffset" : 2671,
+            "key.offset" : 2671,
+            "key.parsed_declaration" : "public init(key: String, defaultValue: T, usage: String)",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 73,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T> (Option<T>.Type) -> (String, T, String) -> Option<T>",
+            "key.typeusr" : "$s3key12defaultValue5usage10Commandant6OptionVyxGSS_xSStcD",
+            "key.usr" : "s:10Commandant6OptionV3key12defaultValue5usageACyxGSS_xSStcfc"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "$s10Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 58,
+        "key.bodyoffset" : 2845,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"56\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 56,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 2820
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 102,
+        "key.line" : 56,
+        "key.modulename" : "Commandant",
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2812,
+        "key.offset" : 2802,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 84,
+        "key.parsed_scope.start" : 80,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2847
+              }
+            ],
+            "key.bodylength" : 22,
+            "key.bodyoffset" : 2879,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 48,
+            "key.line" : 81,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2858,
+            "key.offset" : 2854,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 83,
+            "key.parsed_scope.start" : 81,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "$s10Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 2909
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: (<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, value: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4404
+          }
+        ],
+        "key.bodylength" : 22,
+        "key.bodyoffset" : 4545,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"122\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: (T) -&gt; U, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 122,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 211,
+        "key.docoffset" : 4193,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt; <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 157,
+        "key.line" : 122,
+        "key.modulename" : "Commandant",
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 84,
+        "key.nameoffset" : 4416,
+        "key.offset" : 4411,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 124,
+        "key.parsed_scope.start" : 122,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF\">&lt;*&gt; &lt;T, U, ClientError&gt;(_: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4421,
+            "key.offset" : 4421,
+            "key.parsed_declaration" : "public func <*> <T",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "U",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4424,
+            "key.offset" : 4424,
+            "key.parsed_declaration" : "public func <*> <T, U",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "U.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4427,
+            "key.offset" : 4427,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq0_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> ((T) -> U, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "$sys6ResultOyq_10Commandant0B5ErrorOyq0_GGq_xXE_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;((<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;, value: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4797
+          }
+        ],
+        "key.bodylength" : 346,
+        "key.bodyoffset" : 4978,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies the function in `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"130\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies the function in <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 130,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 227,
+        "key.docoffset" : 4570,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt; <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>(<tuple.element><tuple.element.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/tuple.element.type><\/tuple.element>)<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 521,
+        "key.line" : 130,
+        "key.modulename" : "Commandant",
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 124,
+        "key.nameoffset" : 4809,
+        "key.offset" : 4804,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 145,
+        "key.parsed_scope.start" : 130,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF\">&lt;*&gt; &lt;T, U, ClientError&gt;(_: (T) -&gt; U, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4814,
+            "key.offset" : 4814,
+            "key.parsed_declaration" : "public func <*> <T",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "U",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4817,
+            "key.offset" : 4817,
+            "key.parsed_declaration" : "public func <*> <T, U",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "U.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4820,
+            "key.offset" : 4820,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq0_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> (Result<((T) -> U), CommandantError<ClientError>>, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "$sys6ResultOyq_10Commandant0B5ErrorOyq0_GGAByq_xcAFG_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 4309,
+        "key.bodyoffset" : 5350,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 4333,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 5337,
+        "key.offset" : 5327,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 273,
+        "key.parsed_scope.start" : 147,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 5538
+              }
+            ],
+            "key.bodylength" : 230,
+            "key.bodyoffset" : 5677,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"152\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 152,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 185,
+            "key.docoffset" : 5352,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 363,
+            "key.line" : 152,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 75,
+            "key.nameoffset" : 5557,
+            "key.offset" : 5545,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 157,
+            "key.parsed_scope.start" : 152,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 5564
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 152,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 5561,
+                "key.offset" : 5561,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 152,
+                "key.parsed_scope.start" : 152,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 152,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 5582,
+                "key.offset" : 5582,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 152,
+                "key.parsed_scope.start" : 152,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let wrapped: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>wrapped<\/decl.name>: <decl.var.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 97,
+                "key.line" : 153,
+                "key.modulename" : "Commandant",
+                "key.name" : "wrapped",
+                "key.namelength" : 7,
+                "key.nameoffset" : 5684,
+                "key.offset" : 5680,
+                "key.parsed_declaration" : "let wrapped = Option<T?>(key: option.key, defaultValue: option.defaultValue, usage: option.usage)",
+                "key.parsed_scope.end" : 153,
+                "key.parsed_scope.start" : 153,
+                "key.typename" : "Option<T?>",
+                "key.typeusr" : "$s10Commandant6OptionVyxSgGD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ7wrappedL_ALyxSgGvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC6OptionVyxGtcAC16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 6075
+              }
+            ],
+            "key.bodylength" : 852,
+            "key.bodyoffset" : 6216,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"163\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 163,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 163,
+            "key.docoffset" : 5911,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 987,
+            "key.line" : 163,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 76,
+            "key.nameoffset" : 6094,
+            "key.offset" : 6082,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 196,
+            "key.parsed_scope.start" : 163,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 6101
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 6098,
+                "key.offset" : 6098,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 6119,
+                "key.offset" : 6119,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 20,
+                "key.line" : 164,
+                "key.modulename" : "Commandant",
+                "key.name" : "key",
+                "key.namelength" : 3,
+                "key.nameoffset" : 6223,
+                "key.offset" : 6219,
+                "key.parsed_declaration" : "let key = option.key",
+                "key.parsed_scope.end" : 164,
+                "key.parsed_scope.start" : 164,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ3keyL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyxSg10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 7258
+              }
+            ],
+            "key.bodylength" : 232,
+            "key.bodyoffset" : 7401,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"202\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 202,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 185,
+            "key.docoffset" : 7072,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 369,
+            "key.line" : 202,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 77,
+            "key.nameoffset" : 7277,
+            "key.offset" : 7265,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 207,
+            "key.parsed_scope.start" : 202,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 7284
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 202,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 7281,
+                "key.offset" : 7281,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 202,
+                "key.parsed_scope.start" : 202,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 202,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 7302,
+                "key.offset" : 7302,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 202,
+                "key.parsed_scope.start" : 202,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let wrapped: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>wrapped<\/decl.name>: <decl.var.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 99,
+                "key.line" : 203,
+                "key.modulename" : "Commandant",
+                "key.name" : "wrapped",
+                "key.namelength" : 7,
+                "key.nameoffset" : 7408,
+                "key.offset" : 7404,
+                "key.parsed_declaration" : "let wrapped = Option<[T]?>(key: option.key, defaultValue: option.defaultValue, usage: option.usage)",
+                "key.parsed_scope.end" : 203,
+                "key.parsed_scope.start" : 203,
+                "key.typename" : "Option<[T]?>",
+                "key.typeusr" : "$s10Commandant6OptionVySayxGSgGD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ7wrappedL_AMyAGSgGvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 7801
+              }
+            ],
+            "key.bodylength" : 1117,
+            "key.bodyoffset" : 7946,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"213\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 213,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 163,
+            "key.docoffset" : 7637,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 1256,
+            "key.line" : 213,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 78,
+            "key.nameoffset" : 7820,
+            "key.offset" : 7808,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 254,
+            "key.parsed_scope.start" : 213,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 7827
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 213,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 7824,
+                "key.offset" : 7824,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 213,
+                "key.parsed_scope.start" : 213,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 213,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 7845,
+                "key.offset" : 7845,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 213,
+                "key.parsed_scope.start" : 213,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 20,
+                "key.line" : 214,
+                "key.modulename" : "Commandant",
+                "key.name" : "key",
+                "key.namelength" : 3,
+                "key.nameoffset" : 7953,
+                "key.offset" : 7949,
+                "key.parsed_declaration" : "let key = option.key",
+                "key.parsed_scope.end" : 214,
+                "key.parsed_scope.start" : 214,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ3keyL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxGSg10Commandant0B5ErrorOyq_GGAE11CommandModeO_AE6OptionVyADGtcAE16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 9261
+              }
+            ],
+            "key.bodylength" : 272,
+            "key.bodyoffset" : 9385,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given boolean option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"260\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ<\/USR><Declaration>public static func &lt;| &lt;ClientError&gt;(mode: CommandMode, option: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 260,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 193,
+            "key.docoffset" : 9067,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 390,
+            "key.line" : 260,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 57,
+            "key.nameoffset" : 9280,
+            "key.offset" : 9268,
+            "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 272,
+            "key.parsed_scope.start" : 260,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 260,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 9284,
+                "key.offset" : 9284,
+                "key.parsed_declaration" : "public static func <| <ClientError",
+                "key.parsed_scope.end" : 260,
+                "key.parsed_scope.start" : 260,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp"
+              }
+            ],
+            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6OptionVySbGtcluD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/OrderedSet.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 800,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; : <Type usr=\"s:SQ\">Equatable<\/Type> where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 30
+          }
+        ],
+        "key.bodylength" : 348,
+        "key.bodyoffset" : 82,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "A poor man's ordered set.",
+        "key.doc.declaration" : "internal struct OrderedSet<T> : Equatable where T : Hashable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; : Equatable where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.doclength" : 30,
+        "key.docoffset" : 0,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 71
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 392,
+        "key.line" : 2,
+        "key.modulename" : "Commandant",
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 46,
+        "key.offset" : 39,
+        "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable>: Equatable",
+        "key.parsed_scope.end" : 19,
+        "key.parsed_scope.start" : 2,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+            "key.column" : 28,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 8,
+                "key.offset" : 60
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Hashable"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 2,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 57,
+            "key.offset" : 57,
+            "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable",
+            "key.parsed_scope.end" : 2,
+            "key.parsed_scope.start" : 2,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant10OrderedSetV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate var values: [<Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 84
+              }
+            ],
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>values<\/decl.name>: <decl.var.type>[<ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 3,
+            "key.modulename" : "Commandant",
+            "key.name" : "values",
+            "key.namelength" : 6,
+            "key.nameoffset" : 100,
+            "key.offset" : 96,
+            "key.parsed_declaration" : "fileprivate var values: [T] = []",
+            "key.parsed_scope.end" : 3,
+            "key.parsed_scope.start" : 3,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.typename" : "[T]",
+            "key.typeusr" : "$sSayxGD",
+            "key.usr" : "s:10Commandant10OrderedSetV6values33_E700A43BE27995F7283A44882E2B4A42LLSayxGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>init&lt;S&gt;(_ sequence: <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type>) where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> == <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type>.<Type usr=\"s:ST7ElementQa\">Element<\/Type>, <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type> : <Type usr=\"s:ST\">Sequence<\/Type><\/Declaration>",
+            "key.bodylength" : 74,
+            "key.bodyoffset" : 174,
+            "key.column" : 2,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\"><decl.generic_type_param.name>S<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>sequence<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:ST7ElementQa\">Element<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param> : <ref.protocol usr=\"s:ST\">Sequence<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 130,
+            "key.line" : 5,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 119,
+            "key.offset" : 119,
+            "key.parsed_declaration" : "init<S: Sequence>(_ sequence: S) where S.Element == T",
+            "key.parsed_scope.end" : 9,
+            "key.parsed_scope.start" : 5,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>S : <Type usr=\"s:ST\">Sequence<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 8,
+                    "key.offset" : 127
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>S<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:ST\">Sequence<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "Sequence"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 5,
+                "key.modulename" : "Commandant",
+                "key.name" : "S",
+                "key.namelength" : 1,
+                "key.nameoffset" : 124,
+                "key.offset" : 124,
+                "key.parsed_declaration" : "init<S: Sequence",
+                "key.parsed_scope.end" : 5,
+                "key.parsed_scope.start" : 5,
+                "key.typename" : "S.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<T, S where T : Hashable, T == S.Element, S : Sequence> (OrderedSet<T>.Type) -> (S) -> OrderedSet<T>",
+            "key.typeusr" : "$sy10Commandant10OrderedSetVyxGqd__c7ElementQyd__RszSTRd__luD",
+            "key.usr" : "s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>@discardableResult mutating func remove(_ member: <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.mutating",
+                "key.length" : 8,
+                "key.offset" : 272
+              },
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult",
+                "key.length" : 18,
+                "key.offset" : 252
+              }
+            ],
+            "key.bodylength" : 115,
+            "key.bodyoffset" : 313,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>remove<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>member<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 148,
+            "key.line" : 12,
+            "key.modulename" : "Commandant",
+            "key.name" : "remove(_:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 286,
+            "key.offset" : 281,
+            "key.parsed_declaration" : "mutating func remove(_ member: T) -> T?",
+            "key.parsed_scope.end" : 18,
+            "key.parsed_scope.start" : 12,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (inout OrderedSet<T>) -> (T) -> T?",
+            "key.typeusr" : "$syxSgxcD",
+            "key.usr" : "s:10Commandant10OrderedSetV6removeyxSgxF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "$s10Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; : <Type usr=\"s:SQ\">Equatable<\/Type> where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+        "key.bodylength" : 331,
+        "key.bodyoffset" : 467,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.declaration" : "internal struct OrderedSet<T> : Equatable where T : Hashable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; : Equatable where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 10,
+            "key.offset" : 455
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Collection"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 366,
+        "key.line" : 2,
+        "key.modulename" : "Commandant",
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 443,
+        "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>subscript(position: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 28,
+            "key.bodyoffset" : 500,
+            "key.column" : 2,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "subscript(position: Self.Index) -> Self.Element { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "The following example accesses an element of an array through its subscript to print its value:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "You can subscript a collection with any valid index other than the collection’s end index. The end index refers to the position one past the last element of a collection, so it doesn’t correspond with an element."
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>subscript(_:)<\/Name><USR>s:Sly7ElementQz5IndexQzcip<\/USR><Declaration>subscript(position: Self.Index) -&gt; Self.Element { get }<\/Declaration><CommentParts><Abstract><Para>Accesses the element at the specified position.<\/Para><\/Abstract><Parameters><Parameter><Name>position<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>The position of the element to access. <codeVoice>position<\/codeVoice> must be a valid index of the collection that is not equal to the <codeVoice>endIndex<\/codeVoice> property.<\/Para><\/Discussion><\/Parameter><\/Parameters><Discussion><Para>The following example accesses an element of an array through its subscript to print its value:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var streets = [\"Adams\", \"Bryant\", \"Channing\", \"Douglas\", \"Evarts\"]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(streets[1])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Bryant\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can subscript a collection with any valid index other than the collection’s end index. The end index refers to the position one past the last element of a collection, so it doesn’t correspond with an element.<\/Para><Complexity><Para>O(1)<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "subscript(_:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "The position of the element to access. `position` must be a valid index of the collection that is not equal to the `endIndex` property."
+                  }
+                ],
+                "name" : "position"
+              }
+            ],
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>position<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
+            "key.kind" : "source.lang.swift.decl.function.subscript",
+            "key.length" : 60,
+            "key.line" : 22,
+            "key.modulename" : "Commandant",
+            "key.name" : "subscript(_:)",
+            "key.namelength" : 24,
+            "key.nameoffset" : 469,
+            "key.offset" : 469,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sly7ElementQz5IndexQzcip"
+              }
+            ],
+            "key.parsed_declaration" : "subscript(position: Int) -> T",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 22,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (Int) -> T",
+            "key.typeusr" : "$syxSicD",
+            "key.usr" : "s:Sly7ElementQz5IndexQzcip"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var count: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 24,
+            "key.bodyoffset" : 548,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var count: Int { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "To check whether a collection is empty, use its `isEmpty` property instead of comparing `count` to zero. Unless the collection guarantees random-access performance, calculating `count` can be an O() operation."
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>count<\/Name><USR>s:Sl5countSivp<\/USR><Declaration>var count: Int { get }<\/Declaration><CommentParts><Abstract><Para>The number of elements in the collection.<\/Para><\/Abstract><Discussion><Para>To check whether a collection is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing <codeVoice>count<\/codeVoice> to zero. Unless the collection guarantees random-access performance, calculating <codeVoice>count<\/codeVoice> can be an O(<emphasis>n<\/emphasis>) operation.<\/Para><Complexity><Para>O(1) if the collection conforms to <codeVoice>RandomAccessCollection<\/codeVoice>; otherwise, O(<emphasis>n<\/emphasis>), where <emphasis>n<\/emphasis> is the length of the collection.<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "count",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>count<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 41,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "count",
+            "key.namelength" : 5,
+            "key.nameoffset" : 536,
+            "key.offset" : 532,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl5countSivp"
+              }
+            ],
+            "key.parsed_declaration" : "var count: Int",
+            "key.parsed_scope.end" : 28,
+            "key.parsed_scope.start" : 26,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl5countSivp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var isEmpty: <Type usr=\"s:Sb\">Bool<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 26,
+            "key.bodyoffset" : 595,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var isEmpty: Bool { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need to check whether your collection is empty, use the `isEmpty` property instead of checking that the `count` property is equal to zero. For collections that don’t conform to `RandomAccessCollection`, accessing the `count` property iterates through the elements of the collection."
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>isEmpty<\/Name><USR>s:Sl7isEmptySbvp<\/USR><Declaration>var isEmpty: Bool { get }<\/Declaration><CommentParts><Abstract><Para>A Boolean value indicating whether the collection is empty.<\/Para><\/Abstract><Discussion><Para>When you need to check whether your collection is empty, use the <codeVoice>isEmpty<\/codeVoice> property instead of checking that the <codeVoice>count<\/codeVoice> property is equal to zero. For collections that don’t conform to <codeVoice>RandomAccessCollection<\/codeVoice>, accessing the <codeVoice>count<\/codeVoice> property iterates through the elements of the collection.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let horseName = \"Silver\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if horseName.isEmpty {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"My horse has no name.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Hi ho, \\(horseName)!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Hi ho, Silver!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Complexity><Para>O(1)<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "isEmpty",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>isEmpty<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
+            "key.line" : 30,
+            "key.modulename" : "Commandant",
+            "key.name" : "isEmpty",
+            "key.namelength" : 7,
+            "key.nameoffset" : 580,
+            "key.offset" : 576,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl7isEmptySbvp"
+              }
+            ],
+            "key.parsed_declaration" : "var isEmpty: Bool",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 30,
+            "key.typename" : "Bool",
+            "key.typeusr" : "$sSbD",
+            "key.usr" : "s:Sl7isEmptySbvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var startIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 29,
+            "key.bodyoffset" : 646,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var startIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the collection is empty, `startIndex` is equal to `endIndex`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>startIndex<\/Name><USR>s:Sl10startIndex0B0Qzvp<\/USR><Declaration>var startIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The position of the first element in a nonempty collection.<\/Para><\/Abstract><Discussion><Para>If the collection is empty, <codeVoice>startIndex<\/codeVoice> is equal to <codeVoice>endIndex<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "startIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>startIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 51,
+            "key.line" : 34,
+            "key.modulename" : "Commandant",
+            "key.name" : "startIndex",
+            "key.namelength" : 10,
+            "key.nameoffset" : 629,
+            "key.offset" : 625,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl10startIndex0B0Qzvp"
+              }
+            ],
+            "key.parsed_declaration" : "var startIndex: Int",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 34,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl10startIndex0B0Qzvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var endIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 698,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var endIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need a range that includes the last element of a collection, use the half-open range operator (`..<`) with `endIndex`. The `..<` operator creates a range that doesn’t include the upper bound, so it’s always safe to use with `endIndex`. For example:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "If the collection is empty, `endIndex` is equal to `startIndex`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>endIndex<\/Name><USR>s:Sl8endIndex0B0Qzvp<\/USR><Declaration>var endIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The collection’s “past the end” position—that is, the position one greater than the last valid subscript argument.<\/Para><\/Abstract><Discussion><Para>When you need a range that includes the last element of a collection, use the half-open range operator (<codeVoice>..&lt;<\/codeVoice>) with <codeVoice>endIndex<\/codeVoice>. The <codeVoice>..&lt;<\/codeVoice> operator creates a range that doesn’t include the upper bound, so it’s always safe to use with <codeVoice>endIndex<\/codeVoice>. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let numbers = [10, 20, 30, 40, 50]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if let index = numbers.firstIndex(of: 30) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(numbers[index ..< numbers.endIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[30, 40, 50]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If the collection is empty, <codeVoice>endIndex<\/codeVoice> is equal to <codeVoice>startIndex<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "endIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>endIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 47,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "endIndex",
+            "key.namelength" : 8,
+            "key.nameoffset" : 683,
+            "key.offset" : 679,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl8endIndex0B0Qzvp"
+              }
+            ],
+            "key.parsed_declaration" : "var endIndex: Int",
+            "key.parsed_scope.end" : 40,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl8endIndex0B0Qzvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>func index(after i: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.bodylength" : 34,
+            "key.bodyoffset" : 762,
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "func index(after i: Self.Index) -> Self.Index",
+            "key.doc.discussion" : [
+              {
+                "Para" : "The successor of an index must be well defined. For an index `i` into a collection `c`, calling `c.index(after: i)` returns the same index every time."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Function><Name>index(after:)<\/Name><USR>s:Sl5index5after5IndexQzAD_tF<\/USR><Declaration>func index(after i: Self.Index) -&gt; Self.Index<\/Declaration><CommentParts><Abstract><Para>Returns the position immediately after the given index.<\/Para><\/Abstract><Parameters><Parameter><Name>i<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A valid index of the collection. <codeVoice>i<\/codeVoice> must be less than <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/Parameter><\/Parameters><ResultDiscussion><Para>The index value immediately after <codeVoice>i<\/codeVoice>.<\/Para><\/ResultDiscussion><Discussion><Para>The successor of an index must be well defined. For an index <codeVoice>i<\/codeVoice> into a collection <codeVoice>c<\/codeVoice>, calling <codeVoice>c.index(after: i)<\/codeVoice> returns the same index every time.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.name" : "index(after:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "A valid index of the collection. `i` must be less than `endIndex`."
+                  }
+                ],
+                "name" : "i"
+              }
+            ],
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The index value immediately after `i`."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>index<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>after<\/decl.var.parameter.argument_label> <decl.var.parameter.name>i<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 68,
+            "key.line" : 42,
+            "key.modulename" : "Commandant",
+            "key.name" : "index(after:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 734,
+            "key.offset" : 729,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl5index5after5IndexQzAD_tF"
+              }
+            ],
+            "key.parsed_declaration" : "func index(after i: Int) -> Int",
+            "key.parsed_scope.end" : 44,
+            "key.parsed_scope.start" : 42,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (OrderedSet<T>) -> (Int) -> Int",
+            "key.typeusr" : "$s5afterS2i_tcD",
+            "key.usr" : "s:Sl5index5after5IndexQzAD_tF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "$s10Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Result+Additions.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 421,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>@frozen enum Result&lt;Success, Failure&gt; where <Type usr=\"s:s6ResultO7Failureq_mfp\">Failure<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 148
+          }
+        ],
+        "key.bodylength" : 244,
+        "key.bodyoffset" : 175,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen enum Result<Success, Failure> where Failure : Error",
+        "key.doc.full_as_xml" : "<Other><Name>Result<\/Name><USR>s:s6ResultO<\/USR><Declaration>@frozen enum Result&lt;Success, Failure&gt; where Failure : Error<\/Declaration><CommentParts><Abstract><Para>A value that represents either a success or a failure, including an associated value in each case.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:s6ResultO7Successxmfp\"><decl.generic_type_param.name>Success<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:s6ResultO7Failureq_mfp\"><decl.generic_type_param.name>Failure<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:s6ResultO7Failureq_mfp\">Failure<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.groupname" : "Result",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 263,
+        "key.modulename" : "Swift",
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 167,
+        "key.offset" : 157,
+        "key.parsed_declaration" : "internal extension Result",
+        "key.parsed_scope.end" : 27,
+        "key.parsed_scope.start" : 9,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var value: <Type usr=\"s:s6ResultO10CommandantE7Successxmfp\">Success<\/Type>? { get }<\/Declaration>",
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 198,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>value<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:s6ResultO10CommandantE7Successxmfp\">Success<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 119,
+            "key.line" : 10,
+            "key.modulename" : "Commandant",
+            "key.name" : "value",
+            "key.namelength" : 5,
+            "key.nameoffset" : 181,
+            "key.offset" : 177,
+            "key.parsed_declaration" : "var value: Success?",
+            "key.parsed_scope.end" : 17,
+            "key.parsed_scope.start" : 10,
+            "key.typename" : "Success?",
+            "key.typeusr" : "$sxSgD",
+            "key.usr" : "s:s6ResultO10CommandantE5valuexSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var error: <Type usr=\"s:s6ResultO10CommandantE7Failureq_mfp\">Failure<\/Type>? { get }<\/Declaration>",
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 320,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>error<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:s6ResultO10CommandantE7Failureq_mfp\">Failure<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 119,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 303,
+            "key.offset" : 299,
+            "key.parsed_declaration" : "var error: Failure?",
+            "key.parsed_scope.end" : 26,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "Failure?",
+            "key.typeusr" : "$sq_SgD",
+            "key.usr" : "s:s6ResultO10CommandantE5errorq_Sgvp"
+          }
+        ],
+        "key.typename" : "Result<Success, Failure>.Type",
+        "key.typeusr" : "$ss6ResultOyxq_GmD",
+        "key.usr" : "s:s6ResultO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Switch.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 2007,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Switch<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 375
+          }
+        ],
+        "key.bodylength" : 724,
+        "key.bodyoffset" : 397,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes a parameterless command line flag that defaults to false and can only\nbe switched on. Canonical examples include `--force` and `--recurse`.\n\nFor a boolean toggle that can be enabled and disabled use `Option<Bool>`.",
+        "key.doc.declaration" : "public struct Switch",
+        "key.doc.discussion" : [
+          {
+            "Para" : "For a boolean toggle that can be enabled and disabled use `Option<Bool>`."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"13\" column=\"15\"><Name>Switch<\/Name><USR>s:10Commandant6SwitchV<\/USR><Declaration>public struct Switch<\/Declaration><CommentParts><Abstract><Para>Describes a parameterless command line flag that defaults to false and can only be switched on. Canonical examples include <codeVoice>--force<\/codeVoice> and <codeVoice>--recurse<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>For a boolean toggle that can be enabled and disabled use <codeVoice>Option&lt;Bool&gt;<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "Switch",
+        "key.doc.type" : "Class",
+        "key.doclength" : 240,
+        "key.docoffset" : 135,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Switch<\/decl.name><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 740,
+        "key.line" : 13,
+        "key.modulename" : "Commandant",
+        "key.name" : "Switch",
+        "key.namelength" : 6,
+        "key.nameoffset" : 389,
+        "key.offset" : 382,
+        "key.parsed_declaration" : "public struct Switch",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 13,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 515
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The key that enables this switch. For example, a key of `verbose` would be\nused for a `--verbose` option.",
+            "key.doc.declaration" : "public let key: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"16\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6SwitchV3keySSvp<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that enables this switch. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 16,
+            "key.doc.name" : "key",
+            "key.doc.type" : "Other",
+            "key.doclength" : 115,
+            "key.docoffset" : 399,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 15,
+            "key.line" : 16,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 526,
+            "key.offset" : 522,
+            "key.parsed_declaration" : "public let key: String",
+            "key.parsed_scope.end" : 16,
+            "key.parsed_scope.start" : 16,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV3keySSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let flag: <Type usr=\"s:SJ\">Character<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 828
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "Optional single letter flag that enables this switch. For example, `-v` would\nbe used as a shorthand for `--verbose`.\n\nMultiple flags can be grouped together as a single argument and will split\nwhen parsing (e.g. `rm -rf` treats 'r' and 'f' as inidividual flags).",
+            "key.doc.declaration" : "public let flag: Character?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Multiple flags can be grouped together as a single argument and will split when parsing (e.g. `rm -rf` treats ‘r’ and ‘f’ as inidividual flags)."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"23\" column=\"13\"><Name>flag<\/Name><USR>s:10Commandant6SwitchV4flagSJSgvp<\/USR><Declaration>public let flag: Character?<\/Declaration><CommentParts><Abstract><Para>Optional single letter flag that enables this switch. For example, <codeVoice>-v<\/codeVoice> would be used as a shorthand for <codeVoice>--verbose<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>Multiple flags can be grouped together as a single argument and will split when parsing (e.g. <codeVoice>rm -rf<\/codeVoice> treats ‘r’ and ‘f’ as inidividual flags).<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 23,
+            "key.doc.name" : "flag",
+            "key.doc.type" : "Other",
+            "key.doclength" : 287,
+            "key.docoffset" : 540,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 23,
+            "key.modulename" : "Commandant",
+            "key.name" : "flag",
+            "key.namelength" : 4,
+            "key.nameoffset" : 839,
+            "key.offset" : 835,
+            "key.parsed_declaration" : "public let flag: Character?",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 23,
+            "key.typename" : "Character?",
+            "key.typeusr" : "$sSJSgD",
+            "key.usr" : "s:10Commandant6SwitchV4flagSJSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 968
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"27\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6SwitchV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 27,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 109,
+            "key.docoffset" : 858,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 27,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 979,
+            "key.offset" : 975,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 27,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(flag: <Type usr=\"s:SJ\">Character<\/Type>? = nil, key: <Type usr=\"s:SS\">String<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 995
+              }
+            ],
+            "key.bodylength" : 59,
+            "key.bodyoffset" : 1060,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 118,
+            "key.line" : 29,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(flag:key:usage:)",
+            "key.namelength" : 56,
+            "key.nameoffset" : 1002,
+            "key.offset" : 1002,
+            "key.parsed_declaration" : "public init(flag: Character? = nil, key: String, usage: String)",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 29,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(Switch.Type) -> (Character?, String, String) -> Switch",
+            "key.typeusr" : "$s4flag3key5usage10Commandant6SwitchVSJSg_S2StcD",
+            "key.usr" : "s:10Commandant6SwitchV4flag3key5usageACSJSg_S2Stcfc"
+          }
+        ],
+        "key.typename" : "Switch.Type",
+        "key.typeusr" : "$s10Commandant6SwitchVmD",
+        "key.usr" : "s:10Commandant6SwitchV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Switch<\/Declaration>",
+        "key.bodylength" : 140,
+        "key.bodyoffset" : 1167,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Switch",
+        "key.doc.discussion" : [
+          {
+            "Para" : "For a boolean toggle that can be enabled and disabled use `Option<Bool>`."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"13\" column=\"15\"><Name>Switch<\/Name><USR>s:10Commandant6SwitchV<\/USR><Declaration>public struct Switch<\/Declaration><CommentParts><Abstract><Para>Describes a parameterless command line flag that defaults to false and can only be switched on. Canonical examples include <codeVoice>--force<\/codeVoice> and <codeVoice>--recurse<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>For a boolean toggle that can be enabled and disabled use <codeVoice>Option&lt;Bool&gt;<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "Switch",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 1142
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Switch<\/decl.name><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 184,
+        "key.line" : 13,
+        "key.modulename" : "Commandant",
+        "key.name" : "Switch",
+        "key.namelength" : 6,
+        "key.nameoffset" : 1134,
+        "key.offset" : 1124,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 36,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1169
+              }
+            ],
+            "key.bodylength" : 104,
+            "key.bodyoffset" : 1201,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 130,
+            "key.line" : 37,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1180,
+            "key.offset" : 1176,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 37,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var options: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>options<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 24,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 1208,
+            "key.offset" : 1204,
+            "key.parsed_declaration" : "var options = \"--\\(key)\"",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV11descriptionSSvg7optionsL_SSvp"
+          }
+        ],
+        "key.typename" : "Switch.Type",
+        "key.typeusr" : "$s10Commandant6SwitchVmD",
+        "key.usr" : "s:10Commandant6SwitchV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 1313
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 650,
+        "key.bodyoffset" : 1355,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 674,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1342,
+        "key.offset" : 1332,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 67,
+        "key.parsed_scope.start" : 48,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6SwitchV\">Switch<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1551
+              }
+            ],
+            "key.bodylength" : 333,
+            "key.bodyoffset" : 1670,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given boolean switch in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"53\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ<\/USR><Declaration>public static func &lt;| &lt;ClientError&gt;(mode: CommandMode, option: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean switch in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 53,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 193,
+            "key.docoffset" : 1357,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6SwitchV\">Switch<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 446,
+            "key.line" : 53,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 52,
+            "key.nameoffset" : 1570,
+            "key.offset" : 1558,
+            "key.parsed_declaration" : "public static func <| <ClientError> (mode: CommandMode, option: Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 66,
+            "key.parsed_scope.start" : 53,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 53,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1574,
+                "key.offset" : 1574,
+                "key.parsed_declaration" : "public static func <| <ClientError",
+                "key.parsed_scope.end" : 53,
+                "key.parsed_scope.start" : 53,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp"
+              }
+            ],
+            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6SwitchVtcluD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}]

--- a/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-5.8.json
+++ b/Tests/SourceKittenFrameworkTests/Fixtures/CommandantSPM@swift-5.8.json
@@ -1,0 +1,8815 @@
+[{
+  "\/Sources\/Commandant\/Argument.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 3858,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 204
+          }
+        ],
+        "key.bodylength" : 1029,
+        "key.bodyoffset" : 231,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes an argument that can be provided on the command line.",
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.doclength" : 68,
+        "key.docoffset" : 136,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1050,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 218,
+        "key.offset" : 211,
+        "key.parsed_declaration" : "public struct Argument<T>",
+        "key.parsed_scope.end" : 36,
+        "key.parsed_scope.start" : 10,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 10,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 227,
+            "key.offset" : 227,
+            "key.parsed_declaration" : "public struct Argument<T",
+            "key.parsed_scope.end" : 10,
+            "key.parsed_scope.start" : 10,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant8ArgumentV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 443
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The default value for this argument. This is the value that will be used\nif the argument is never explicitly specified on the command line.\n\nIf this is nil, this argument is always required.",
+            "key.doc.declaration" : "public let defaultValue: T?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If this is nil, this argument is always required."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"15\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant8ArgumentV12defaultValuexSgvp<\/USR><Declaration>public let defaultValue: T?<\/Declaration><CommentParts><Abstract><Para>The default value for this argument. This is the value that will be used if the argument is never explicitly specified on the command line.<\/Para><\/Abstract><Discussion><Para>If this is nil, this argument is always required.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "defaultValue",
+            "key.doc.type" : "Other",
+            "key.doclength" : 209,
+            "key.docoffset" : 233,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "defaultValue",
+            "key.namelength" : 12,
+            "key.nameoffset" : 454,
+            "key.offset" : 450,
+            "key.parsed_declaration" : "public let defaultValue: T?",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "T?",
+            "key.typeusr" : "$sxSgD",
+            "key.usr" : "s:10Commandant8ArgumentV12defaultValuexSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 585
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this argument. This will\nbe shown in help messages.",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"19\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant8ArgumentV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this argument. This will be shown in help messages.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 19,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 111,
+            "key.docoffset" : 473,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 596,
+            "key.offset" : 592,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 19,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usageParameter: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 804
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string that describes this argument as a paramater shown\nin the list of possible parameters in help messages (e.g. for \"paths\", the\nuser would see <paths…>).",
+            "key.doc.declaration" : "public let usageParameter: String?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"24\" column=\"13\"><Name>usageParameter<\/Name><USR>s:10Commandant8ArgumentV14usageParameterSSSgvp<\/USR><Declaration>public let usageParameter: String?<\/Declaration><CommentParts><Abstract><Para>A human-readable string that describes this argument as a paramater shown in the list of possible parameters in help messages (e.g. for “paths”, the user would see &lt;paths…&gt;).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 24,
+            "key.doc.name" : "usageParameter",
+            "key.doc.type" : "Other",
+            "key.doclength" : 191,
+            "key.docoffset" : 612,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usageParameter<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 27,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameter",
+            "key.namelength" : 14,
+            "key.nameoffset" : 815,
+            "key.offset" : 811,
+            "key.parsed_declaration" : "public let usageParameter: String?",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String?",
+            "key.typeusr" : "$sSSSgD",
+            "key.usr" : "s:10Commandant8ArgumentV14usageParameterSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(defaultValue: <Type usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/Type>? = nil, usage: <Type usr=\"s:SS\">String<\/Type>, usageParameter: <Type usr=\"s:SS\">String<\/Type>? = nil)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 841
+              }
+            ],
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 924,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usageParameter<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 174,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(defaultValue:usage:usageParameter:)",
+            "key.namelength" : 74,
+            "key.nameoffset" : 848,
+            "key.offset" : 848,
+            "key.parsed_declaration" : "public init(defaultValue: T? = nil, usage: String, usageParameter: String? = nil)",
+            "key.parsed_scope.end" : 30,
+            "key.parsed_scope.start" : 26,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T> (Argument<T>.Type) -> (T?, String, String?) -> Argument<T>",
+            "key.typeusr" : "$s12defaultValue5usage0C9Parameter10Commandant8ArgumentVyxGxSg_S2SSgtcD",
+            "key.usr" : "s:10Commandant8ArgumentV12defaultValue5usage0E9ParameterACyxGxSg_S2SSgtcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate func invalidUsageError&lt;ClientError&gt;(_ value: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1025
+              }
+            ],
+            "key.bodylength" : 135,
+            "key.bodyoffset" : 1123,
+            "key.column" : 19,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>invalidUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 222,
+            "key.line" : 32,
+            "key.modulename" : "Commandant",
+            "key.name" : "invalidUsageError(_:)",
+            "key.namelength" : 47,
+            "key.nameoffset" : 1042,
+            "key.offset" : 1037,
+            "key.parsed_declaration" : "fileprivate func invalidUsageError<ClientError>(_ value: String) -> CommandantError<ClientError>",
+            "key.parsed_scope.end" : 35,
+            "key.parsed_scope.start" : 32,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 37,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 32,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1060,
+                "key.offset" : 1060,
+                "key.parsed_declaration" : "fileprivate func invalidUsageError<ClientError",
+                "key.parsed_scope.end" : 32,
+                "key.parsed_scope.start" : 32,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF06ClientE0L_qd__mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let description: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 83,
+                "key.line" : 33,
+                "key.modulename" : "Commandant",
+                "key.name" : "description",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1130,
+                "key.offset" : 1126,
+                "key.parsed_declaration" : "let description = \"Invalid value for '\\(self.usageParameterDescription)': \\(value)\"",
+                "key.parsed_scope.end" : 33,
+                "key.parsed_scope.start" : 33,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF11descriptionL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError> (Argument<T>) -> (String) -> CommandantError<ClientError>",
+            "key.typeusr" : "$sy10Commandant0A5ErrorOyqd__GSScluD",
+            "key.usr" : "s:10Commandant8ArgumentV17invalidUsageError33_8CAE711C2CD19D07FEBBE5F857AB09FDLLyAA0aE0Oyqd__GSSlF"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 251,
+        "key.bodyoffset" : 1283,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 272,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 1273,
+        "key.offset" : 1263,
+        "key.parsed_declaration" : "extension Argument",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 38,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var usageParameterDescription: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1422
+              }
+            ],
+            "key.bodylength" : 62,
+            "key.bodyoffset" : 1470,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "A string describing this argument as a parameter in help messages. This falls back\nto `\"\\(self)\"` if `usageParameter` is `nil`",
+            "key.doc.declaration" : "internal var usageParameterDescription: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"41\" column=\"15\"><Name>usageParameterDescription<\/Name><USR>s:10Commandant8ArgumentV25usageParameterDescriptionSSvp<\/USR><Declaration>internal var usageParameterDescription: String { get }<\/Declaration><CommentParts><Abstract><Para>A string describing this argument as a parameter in help messages. This falls back to <codeVoice>&quot;\\(self)&quot;<\/codeVoice> if <codeVoice>usageParameter<\/codeVoice> is <codeVoice>nil<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 41,
+            "key.doc.name" : "usageParameterDescription",
+            "key.doc.type" : "Other",
+            "key.doclength" : 136,
+            "key.docoffset" : 1285,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>usageParameterDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 102,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameterDescription",
+            "key.namelength" : 25,
+            "key.nameoffset" : 1435,
+            "key.offset" : 1431,
+            "key.parsed_declaration" : "internal var usageParameterDescription: String",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 41,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp\">usageParameterDescription<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentV25usageParameterDescriptionSSvp"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Argument&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 254,
+        "key.bodyoffset" : 1575,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Argument<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"10\" column=\"15\"><Name>Argument<\/Name><USR>s:10Commandant8ArgumentV<\/USR><Declaration>public struct Argument&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an argument that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "Argument",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Argument<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant8ArgumentV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 293,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "Argument",
+        "key.namelength" : 8,
+        "key.nameoffset" : 1547,
+        "key.offset" : 1537,
+        "key.parsed_declaration" : "extension Argument where T: Sequence",
+        "key.parsed_scope.end" : 52,
+        "key.parsed_scope.start" : 46,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var usageParameterDescription: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1714
+              }
+            ],
+            "key.bodylength" : 65,
+            "key.bodyoffset" : 1762,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "A string describing this argument as a parameter in help messages. This falls back\nto `\"\\(self)\"` if `usageParameter` is `nil`",
+            "key.doc.declaration" : "internal var usageParameterDescription: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"49\" column=\"15\"><Name>usageParameterDescription<\/Name><USR>s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp<\/USR><Declaration>internal var usageParameterDescription: String { get }<\/Declaration><CommentParts><Abstract><Para>A string describing this argument as a parameter in help messages. This falls back to <codeVoice>&quot;\\(self)&quot;<\/codeVoice> if <codeVoice>usageParameter<\/codeVoice> is <codeVoice>nil<\/codeVoice><\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 49,
+            "key.doc.name" : "usageParameterDescription",
+            "key.doc.type" : "Other",
+            "key.doclength" : 136,
+            "key.docoffset" : 1577,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>usageParameterDescription<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 105,
+            "key.line" : 49,
+            "key.modulename" : "Commandant",
+            "key.name" : "usageParameterDescription",
+            "key.namelength" : 25,
+            "key.nameoffset" : 1727,
+            "key.offset" : 1723,
+            "key.parsed_declaration" : "internal var usageParameterDescription: String",
+            "key.parsed_scope.end" : 51,
+            "key.parsed_scope.start" : 49,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant8ArgumentV25usageParameterDescriptionSSvp\">usageParameterDescription<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant8ArgumentVAASTRzlE25usageParameterDescriptionSSvp"
+          }
+        ],
+        "key.typename" : "Argument<T>.Type",
+        "key.typeusr" : "$s10Commandant8ArgumentVyxGmD",
+        "key.usr" : "s:10Commandant8ArgumentV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 1835
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 1979,
+        "key.bodyoffset" : 1877,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 2003,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1864,
+        "key.offset" : 1854,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 120,
+        "key.parsed_scope.start" : 56,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2069
+              }
+            ],
+            "key.bodylength" : 518,
+            "key.bodyoffset" : 2212,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given argument in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the argument's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the argument’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"61\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, argument: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given argument in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the argument’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 61,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 189,
+            "key.docoffset" : 1879,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 655,
+            "key.line" : 61,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 79,
+            "key.nameoffset" : 2088,
+            "key.offset" : 2076,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 81,
+            "key.parsed_scope.start" : 61,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 2095
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 61,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2092,
+                "key.offset" : 2092,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 61,
+                "key.parsed_scope.start" : 61,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 61,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 2113,
+                "key.offset" : 2113,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 61,
+                "key.parsed_scope.start" : 61,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Argument<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC8ArgumentVyxGtcAC0F8ProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2929
+              }
+            ],
+            "key.bodylength" : 778,
+            "key.bodyoffset" : 3076,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given argument list in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the argument's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the argument’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Argument.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Argument.swift\" line=\"87\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, argument: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given argument list in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the argument’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 87,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 194,
+            "key.docoffset" : 2734,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 919,
+            "key.line" : 87,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 81,
+            "key.nameoffset" : 2948,
+            "key.offset" : 2936,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 119,
+            "key.parsed_scope.start" : 87,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 2955
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 87,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2952,
+                "key.offset" : 2952,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 87,
+                "key.parsed_scope.start" : 87,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 87,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 2973,
+                "key.offset" : 2973,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 87,
+                "key.parsed_scope.start" : 87,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Argument<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD8ArgumentVyACGtcAD0F8ProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/ArgumentParser.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 4637,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.private",
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:SQ\">Equatable<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.private",
+            "key.length" : 7,
+            "key.offset" : 229
+          }
+        ],
+        "key.bodylength" : 296,
+        "key.bodyoffset" : 266,
+        "key.column" : 14,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 14,
+        "key.doc.comment" : "Represents an argument passed on the command line.",
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"12\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
+        "key.doclength" : 55,
+        "key.docoffset" : 174,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 255
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 326,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "RawArgument",
+        "key.namelength" : 11,
+        "key.nameoffset" : 242,
+        "key.offset" : 237,
+        "key.parsed_declaration" : "private enum RawArgument: Equatable",
+        "key.parsed_scope.end" : 22,
+        "key.parsed_scope.start" : 12,
+        "key.substructure" : [
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 16,
+            "key.offset" : 341,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case key(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A key corresponding to an option (e.g., `verbose` for `--verbose`).",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"14\" column=\"7\"><Name>key(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A key corresponding to an option (e.g., <codeVoice>verbose<\/codeVoice> for <codeVoice>--verbose<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 14,
+                "key.doc.name" : "key(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 72,
+                "key.docoffset" : 268,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>key<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 11,
+                "key.line" : 14,
+                "key.modulename" : "Commandant",
+                "key.name" : "key(_:)",
+                "key.namelength" : 11,
+                "key.nameoffset" : 346,
+                "key.offset" : 346,
+                "key.parsed_declaration" : "case key(String)",
+                "key.parsed_scope.end" : 14,
+                "key.parsed_scope.start" : 14,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO3keyyADSScADmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 18,
+            "key.offset" : 448,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case value(<Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "A value, either associated with an option or passed as a positional\nargument.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"18\" column=\"7\"><Name>value(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueyADSScADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>A value, either associated with an option or passed as a positional argument.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 18,
+                "key.doc.name" : "value(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 87,
+                "key.docoffset" : 360,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>value<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 13,
+                "key.line" : 18,
+                "key.modulename" : "Commandant",
+                "key.name" : "value(_:)",
+                "key.namelength" : 13,
+                "key.nameoffset" : 453,
+                "key.offset" : 453,
+                "key.parsed_declaration" : "case value(String)",
+                "key.parsed_scope.end" : 18,
+                "key.parsed_scope.start" : 18,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (String) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOSScADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO5valueyADSScADmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 32,
+            "key.offset" : 529,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.internal",
+                "key.annotated_decl" : "<Declaration>case flag(<Type usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/Type>&lt;<Type usr=\"s:SJ\">Character<\/Type>&gt;)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "One or more flag arguments (e.g 'r' and 'f' for `-rf`)",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"21\" column=\"7\"><Name>flag(_:)<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagyAdA10OrderedSetVySJGcADmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>One or more flag arguments (e.g ‘r’ and ‘f’ for <codeVoice>-rf<\/codeVoice>)<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 21,
+                "key.doc.name" : "flag(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 59,
+                "key.docoffset" : 469,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:10Commandant10OrderedSetV\">OrderedSet<\/ref.struct>&lt;<ref.struct usr=\"s:SJ\">Character<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 27,
+                "key.line" : 21,
+                "key.modulename" : "Commandant",
+                "key.name" : "flag(_:)",
+                "key.namelength" : 27,
+                "key.nameoffset" : 534,
+                "key.offset" : 534,
+                "key.parsed_declaration" : "case flag(OrderedSet<Character>)",
+                "key.parsed_scope.end" : 21,
+                "key.parsed_scope.start" : 21,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(RawArgument.Type) -> (OrderedSet<Character>) -> RawArgument",
+                "key.typeusr" : "$sy10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOAA10OrderedSetVySJGcADmcD",
+                "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO4flagyAdA10OrderedSetVySJGcADmF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "$s10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>private enum RawArgument : <Type usr=\"s:SQ\">Equatable<\/Type><\/Declaration>",
+        "key.bodylength" : 214,
+        "key.bodyoffset" : 613,
+        "key.column" : 14,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 14,
+        "key.doc.declaration" : "private enum RawArgument : Equatable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"12\" column=\"14\"><Name>RawArgument<\/Name><USR>s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO<\/USR><Declaration>private enum RawArgument : Equatable<\/Declaration><CommentParts><Abstract><Para>Represents an argument passed on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "RawArgument",
+        "key.doc.type" : "Other",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 588
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>RawArgument<\/decl.name> : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 263,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "RawArgument",
+        "key.namelength" : 11,
+        "key.nameoffset" : 575,
+        "key.offset" : 565,
+        "key.parsed_declaration" : "extension RawArgument: CustomStringConvertible",
+        "key.parsed_scope.end" : 37,
+        "key.parsed_scope.start" : 24,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 615
+              }
+            ],
+            "key.bodylength" : 173,
+            "key.bodyoffset" : 652,
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 199,
+            "key.line" : 25,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 631,
+            "key.offset" : 627,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "fileprivate var description: String",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "RawArgument.Type",
+        "key.typeusr" : "$s10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOmD",
+        "key.usr" : "s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class ArgumentParser<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final",
+            "key.length" : 5,
+            "key.offset" : 896
+          },
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 889
+          }
+        ],
+        "key.bodylength" : 3711,
+        "key.bodyoffset" : 924,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Destructively parses a list of command-line arguments.",
+        "key.doc.declaration" : "public final class ArgumentParser",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"40\" column=\"20\"><Name>ArgumentParser<\/Name><USR>s:10Commandant14ArgumentParserC<\/USR><Declaration>public final class ArgumentParser<\/Declaration><CommentParts><Abstract><Para>Destructively parses a list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 40,
+        "key.doc.name" : "ArgumentParser",
+        "key.doc.type" : "Class",
+        "key.doclength" : 59,
+        "key.docoffset" : 830,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>ArgumentParser<\/decl.name><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 3734,
+        "key.line" : 40,
+        "key.modulename" : "Commandant",
+        "key.name" : "ArgumentParser",
+        "key.namelength" : 14,
+        "key.nameoffset" : 908,
+        "key.offset" : 902,
+        "key.parsed_declaration" : "public final class ArgumentParser",
+        "key.parsed_scope.end" : 175,
+        "key.parsed_scope.start" : 40,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private var rawArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 991
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "The remaining arguments to be extracted, in their raw form.",
+            "key.doc.declaration" : "private var rawArguments: [RawArgument]",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"42\" column=\"14\"><Name>rawArguments<\/Name><USR>s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGvp<\/USR><Declaration>private var rawArguments: [RawArgument]<\/Declaration><CommentParts><Abstract><Para>The remaining arguments to be extracted, in their raw form.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 42,
+            "key.doc.name" : "rawArguments",
+            "key.doc.type" : "Other",
+            "key.doclength" : 64,
+            "key.docoffset" : 926,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>rawArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 36,
+            "key.line" : 42,
+            "key.modulename" : "Commandant",
+            "key.name" : "rawArguments",
+            "key.namelength" : 12,
+            "key.nameoffset" : 1003,
+            "key.offset" : 999,
+            "key.parsed_declaration" : "private var rawArguments: [RawArgument] = []",
+            "key.parsed_scope.end" : 42,
+            "key.parsed_scope.start" : 42,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[RawArgument]",
+            "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12rawArguments33_BA859BFBBE9DF3838A11641CB273713ELLSayAA03RawB0AELLOGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(_ arguments: [<Type usr=\"s:SS\">String<\/Type>])<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1115
+              }
+            ],
+            "key.bodylength" : 741,
+            "key.bodyoffset" : 1151,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the generator from a simple list of command-line arguments.",
+            "key.doc.declaration" : "public init(_ arguments: [String])",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"45\" column=\"9\"><Name>init(_:)<\/Name><USR>s:10Commandant14ArgumentParserCyACSaySSGcfc<\/USR><Declaration>public init(_ arguments: [String])<\/Declaration><CommentParts><Abstract><Para>Initializes the generator from a simple list of command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 45,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 76,
+            "key.docoffset" : 1038,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>arguments<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 771,
+            "key.line" : 45,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 27,
+            "key.nameoffset" : 1122,
+            "key.offset" : 1122,
+            "key.parsed_declaration" : "public init(_ arguments: [String])",
+            "key.parsed_scope.end" : 70,
+            "key.parsed_scope.start" : 45,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let params: [<Type usr=\"s:Sa\">Array<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>&gt;.<Type usr=\"s:Sa11SubSequencea\">SubSequence<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>params<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:Sa\">Array<\/ref.struct>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>&gt;.<ref.typealias usr=\"s:Sa11SubSequencea\">SubSequence<\/ref.typealias>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 91,
+                "key.line" : 47,
+                "key.modulename" : "Commandant",
+                "key.name" : "params",
+                "key.namelength" : 6,
+                "key.nameoffset" : 1218,
+                "key.offset" : 1214,
+                "key.parsed_declaration" : "let params = arguments.split(maxSplits: 1, omittingEmptySubsequences: false) { $0 == \"--\" }",
+                "key.parsed_scope.end" : 47,
+                "key.parsed_scope.start" : 47,
+                "key.typename" : "[ArraySlice<String>]",
+                "key.typeusr" : "$sSays10ArraySliceVySSGGD",
+                "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc6paramsL_Says10ArraySliceVySSGGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let options: <Type usr=\"s:Sa\">Array<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>&gt;.<Type usr=\"s:Sa11SubSequencea\">SubSequence<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>options<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sa\">Array<\/ref.struct>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>&gt;.<ref.typealias usr=\"s:Sa11SubSequencea\">SubSequence<\/ref.typealias><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 27,
+                "key.line" : 50,
+                "key.modulename" : "Commandant",
+                "key.name" : "options",
+                "key.namelength" : 7,
+                "key.nameoffset" : 1356,
+                "key.offset" : 1352,
+                "key.parsed_declaration" : "let options = params.first!",
+                "key.parsed_scope.end" : 50,
+                "key.parsed_scope.start" : 50,
+                "key.typename" : "ArraySlice<String>",
+                "key.typeusr" : "$ss10ArraySliceVySSGD",
+                "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc7optionsL_s10ArraySliceVySSGvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser.Type) -> ([String]) -> ArgumentParser",
+            "key.typeusr" : "$sy10Commandant14ArgumentParserCSaySSGcD",
+            "key.usr" : "s:10Commandant14ArgumentParserCyACSaySSGcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal var remainingArguments: [<Type usr=\"s:SS\">String<\/Type>]? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 1934
+              }
+            ],
+            "key.bodylength" : 76,
+            "key.bodyoffset" : 1978,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Returns the remaining arguments.",
+            "key.doc.declaration" : "internal var remainingArguments: [String]? { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"73\" column=\"15\"><Name>remainingArguments<\/Name><USR>s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgvp<\/USR><Declaration>internal var remainingArguments: [String]? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the remaining arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 73,
+            "key.doc.name" : "remainingArguments",
+            "key.doc.type" : "Other",
+            "key.doclength" : 37,
+            "key.docoffset" : 1896,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>remainingArguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 112,
+            "key.line" : 73,
+            "key.modulename" : "Commandant",
+            "key.name" : "remainingArguments",
+            "key.namelength" : 18,
+            "key.nameoffset" : 1947,
+            "key.offset" : 1943,
+            "key.parsed_declaration" : "internal var remainingArguments: [String]?",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 73,
+            "key.typename" : "[String]?",
+            "key.typeusr" : "$sSaySSGSgD",
+            "key.usr" : "s:10Commandant14ArgumentParserC18remainingArgumentsSaySSGSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 2264
+              }
+            ],
+            "key.bodylength" : 281,
+            "key.bodyoffset" : 2323,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was enabled or disabled, or nil if it\nwas not given at all.\n\nIf the key is found, it is then removed from the list of arguments\nremaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the key is found, it is then removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"82\" column=\"16\"><Name>consumeBoolean(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF<\/USR><Declaration>internal func consumeBoolean(forKey key: String) -&gt; Bool?<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was enabled or disabled, or nil if it was not given at all.<\/Para><\/Abstract><Discussion><Para>If the key is found, it is then removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 82,
+            "key.doc.name" : "consumeBoolean(forKey:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 205,
+            "key.docoffset" : 2058,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 332,
+            "key.line" : 82,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeBoolean(forKey:)",
+            "key.namelength" : 34,
+            "key.nameoffset" : 2278,
+            "key.offset" : 2273,
+            "key.parsed_declaration" : "internal func consumeBoolean(forKey key: String) -> Bool?",
+            "key.parsed_scope.end" : 98,
+            "key.parsed_scope.start" : 82,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF\">consumeBoolean(flag:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 83,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 2330,
+                "key.offset" : 2326,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 83,
+                "key.parsed_scope.start" : 83,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var result: <Type usr=\"s:Sb\">Bool<\/Type>?<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>result<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct>?<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 17,
+                "key.line" : 86,
+                "key.modulename" : "Commandant",
+                "key.name" : "result",
+                "key.namelength" : 6,
+                "key.nameoffset" : 2392,
+                "key.offset" : 2388,
+                "key.parsed_declaration" : "var result: Bool?",
+                "key.parsed_scope.end" : 86,
+                "key.parsed_scope.start" : 86,
+                "key.typename" : "Bool?",
+                "key.typeusr" : "$sSbSgD",
+                "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF6resultL_AFvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool?",
+            "key.typeusr" : "$s6forKeySbSgSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeValue(forKey key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:SS\">String<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:s5NeverO\">Never<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 2908
+              }
+            ],
+            "key.bodylength" : 503,
+            "key.bodyoffset" : 2999,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the value associated with the given flag, or nil if the flag was\nnot specified. If the key is presented, but no value was given, an error\nis returned.\n\nIf a value is found, the key and the value are both removed from the\nlist of arguments remaining to be parsed.",
+            "key.doc.declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<Never>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"106\" column=\"16\"><Name>consumeValue(forKey:)<\/Name><USR>s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF<\/USR><Declaration>internal func consumeValue(forKey key: String) -&gt; Result&lt;String?, CommandantError&lt;Never&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Returns the value associated with the given flag, or nil if the flag was not specified. If the key is presented, but no value was given, an error is returned.<\/Para><\/Abstract><Discussion><Para>If a value is found, the key and the value are both removed from the list of arguments remaining to be parsed.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 106,
+            "key.doc.name" : "consumeValue(forKey:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 299,
+            "key.docoffset" : 2608,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeValue<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>forKey<\/decl.var.parameter.argument_label> <decl.var.parameter.name>key<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:SS\">String<\/ref.struct>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 586,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeValue(forKey:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 2922,
+            "key.offset" : 2917,
+            "key.parsed_declaration" : "internal func consumeValue(forKey key: String) -> Result<String?, CommandantError<Never>>",
+            "key.parsed_scope.end" : 131,
+            "key.parsed_scope.start" : 106,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 107,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 3006,
+                "key.offset" : 3002,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 107,
+                "key.parsed_scope.start" : 107,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var foundValue: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>foundValue<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 23,
+                "key.line" : 110,
+                "key.modulename" : "Commandant",
+                "key.name" : "foundValue",
+                "key.namelength" : 10,
+                "key.nameoffset" : 3068,
+                "key.offset" : 3064,
+                "key.parsed_declaration" : "var foundValue: String?",
+                "key.parsed_scope.end" : 110,
+                "key.parsed_scope.start" : 110,
+                "key.typename" : "String?",
+                "key.typeusr" : "$sSSSgD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF05foundE0L_AHvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var index: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>index<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 13,
+                "key.line" : 111,
+                "key.modulename" : "Commandant",
+                "key.name" : "index",
+                "key.namelength" : 5,
+                "key.nameoffset" : 3094,
+                "key.offset" : 3090,
+                "key.parsed_declaration" : "var index = 0",
+                "key.parsed_scope.end" : 111,
+                "key.parsed_scope.start" : 111,
+                "key.related_decls" : [
+                  {
+                    "key.annotated_decl" : "<RelatedName usr=\"c:@F@index\">index(_:_:)<\/RelatedName>"
+                  }
+                ],
+                "key.typename" : "Int",
+                "key.typeusr" : "$sSiD",
+                "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF5indexL_Sivp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Result<String?, CommandantError<Never>>",
+            "key.typeusr" : "$s6forKeys6ResultOySSSg10Commandant0D5ErrorOys5NeverOGGSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC12consumeValue6forKeys6ResultOySSSgAA0A5ErrorOys5NeverOGGSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumePositionalArgument() -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 3634
+              }
+            ],
+            "key.bodylength" : 164,
+            "key.bodyoffset" : 3688,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns the next positional argument that hasn't yet been returned, or\nnil if there are no more positional arguments.",
+            "key.doc.declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"135\" column=\"16\"><Name>consumePositionalArgument()<\/Name><USR>s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF<\/USR><Declaration>internal func consumePositionalArgument() -&gt; String?<\/Declaration><CommentParts><Abstract><Para>Returns the next positional argument that hasn’t yet been returned, or nil if there are no more positional arguments.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 135,
+            "key.doc.name" : "consumePositionalArgument()",
+            "key.doc.type" : "Function",
+            "key.doclength" : 127,
+            "key.docoffset" : 3506,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumePositionalArgument<\/decl.name>() -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 210,
+            "key.line" : 135,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumePositionalArgument()",
+            "key.namelength" : 27,
+            "key.nameoffset" : 3648,
+            "key.offset" : 3643,
+            "key.parsed_declaration" : "internal func consumePositionalArgument() -> String?",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 135,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> () -> String?",
+            "key.typeusr" : "$sSSSgycD",
+            "key.usr" : "s:10Commandant14ArgumentParserC017consumePositionalB0SSSgyF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consume(key: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 3963
+              }
+            ],
+            "key.bodylength" : 143,
+            "key.bodyoffset" : 4007,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given key was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consume(key: String) -> Bool",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"148\" column=\"16\"><Name>consume(key:)<\/Name><USR>s:10Commandant14ArgumentParserC7consume3keySbSS_tF<\/USR><Declaration>internal func consume(key: String) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given key was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 148,
+            "key.doc.name" : "consume(key:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 106,
+            "key.docoffset" : 3856,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consume<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 179,
+            "key.line" : 148,
+            "key.modulename" : "Commandant",
+            "key.name" : "consume(key:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 3977,
+            "key.offset" : 3972,
+            "key.parsed_declaration" : "internal func consume(key: String) -> Bool",
+            "key.parsed_scope.end" : 153,
+            "key.parsed_scope.start" : 148,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let oldArguments: [<Type usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>oldArguments<\/decl.name>: <decl.var.type>[<ref.enum usr=\"s:10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLO\">RawArgument<\/ref.enum>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 31,
+                "key.line" : 149,
+                "key.modulename" : "Commandant",
+                "key.name" : "oldArguments",
+                "key.namelength" : 12,
+                "key.nameoffset" : 4014,
+                "key.offset" : 4010,
+                "key.parsed_declaration" : "let oldArguments = rawArguments",
+                "key.parsed_scope.end" : 149,
+                "key.parsed_scope.start" : 149,
+                "key.typename" : "[RawArgument]",
+                "key.typeusr" : "$sSay10Commandant11RawArgument33_BA859BFBBE9DF3838A11641CB273713ELLOGD",
+                "key.usr" : "s:10Commandant14ArgumentParserC7consume3keySbSS_tF12oldArgumentsL_SayAA03RawB033_BA859BFBBE9DF3838A11641CB273713ELLOGvp"
+              }
+            ],
+            "key.typename" : "(ArgumentParser) -> (String) -> Bool",
+            "key.typeusr" : "$s3keySbSS_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC7consume3keySbSS_tF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>internal func consumeBoolean(flag: <Type usr=\"s:SJ\">Character<\/Type>) -&gt; <Type usr=\"s:Sb\">Bool<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.internal",
+                "key.length" : 8,
+                "key.offset" : 4262
+              }
+            ],
+            "key.bodylength" : 316,
+            "key.bodyoffset" : 4317,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 16,
+            "key.doc.comment" : "Returns whether the given flag was specified and removes it from the\nlist of arguments remaining.",
+            "key.doc.declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentParser.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentParser.swift\" line=\"157\" column=\"16\"><Name>consumeBoolean(flag:)<\/Name><USR>s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF<\/USR><Declaration>internal func consumeBoolean(flag: Character) -&gt; Bool<\/Declaration><CommentParts><Abstract><Para>Returns whether the given flag was specified and removes it from the list of arguments remaining.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 157,
+            "key.doc.name" : "consumeBoolean(flag:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 107,
+            "key.docoffset" : 4154,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>consumeBoolean<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 363,
+            "key.line" : 157,
+            "key.modulename" : "Commandant",
+            "key.name" : "consumeBoolean(flag:)",
+            "key.namelength" : 31,
+            "key.nameoffset" : 4276,
+            "key.offset" : 4271,
+            "key.parsed_declaration" : "internal func consumeBoolean(flag: Character) -> Bool",
+            "key.parsed_scope.end" : 174,
+            "key.parsed_scope.start" : 157,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant14ArgumentParserC14consumeBoolean6forKeySbSgSS_tF\">consumeBoolean(forKey:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(ArgumentParser) -> (Character) -> Bool",
+            "key.typeusr" : "$s4flagSbSJ_tcD",
+            "key.usr" : "s:10Commandant14ArgumentParserC14consumeBoolean4flagSbSJ_tF"
+          }
+        ],
+        "key.typename" : "ArgumentParser.Type",
+        "key.typeusr" : "$s10Commandant14ArgumentParserCmD",
+        "key.usr" : "s:10Commandant14ArgumentParserC"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/ArgumentProtocol.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 1141,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol ArgumentProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 219
+          }
+        ],
+        "key.bodylength" : 189,
+        "key.bodyoffset" : 253,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a value that can be converted from a command-line argument.",
+        "key.doc.declaration" : "public protocol ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"10\" column=\"17\"><Name>ArgumentProtocol<\/Name><USR>s:10Commandant16ArgumentProtocolP<\/USR><Declaration>public protocol ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a value that can be converted from a command-line argument.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 10,
+        "key.doc.name" : "ArgumentProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 75,
+        "key.docoffset" : 144,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>ArgumentProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 217,
+        "key.line" : 10,
+        "key.modulename" : "Commandant",
+        "key.name" : "ArgumentProtocol",
+        "key.namelength" : 16,
+        "key.nameoffset" : 235,
+        "key.offset" : 226,
+        "key.parsed_declaration" : "public protocol ArgumentProtocol",
+        "key.parsed_scope.end" : 16,
+        "key.parsed_scope.start" : 10,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static var name: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 322,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable name for this type.",
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.doclength" : 41,
+            "key.docoffset" : 255,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 31,
+            "key.line" : 12,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 308,
+            "key.offset" : 297,
+            "key.parsed_declaration" : "static var name: String",
+            "key.parsed_scope.end" : 12,
+            "key.parsed_scope.start" : 12,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant16ArgumentProtocolP4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Attempts to parse a value from the given command-line argument.",
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 68,
+            "key.docoffset" : 331,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant16ArgumentProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 41,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 412,
+            "key.offset" : 400,
+            "key.parsed_declaration" : "static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "ArgumentProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant16ArgumentProtocol_pmD",
+        "key.usr" : "s:10Commandant16ArgumentProtocolP"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>@frozen struct Int : <Type usr=\"s:s17FixedWidthIntegerP\">FixedWidthInteger<\/Type>, <Type usr=\"s:SZ\">SignedInteger<\/Type>, <Type usr=\"s:s35_ExpressibleByBuiltinIntegerLiteralP\">_ExpressibleByBuiltinIntegerLiteral<\/Type><\/Declaration>",
+        "key.bodylength" : 113,
+        "key.bodyoffset" : 478,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen struct Int : FixedWidthInteger, SignedInteger, _ExpressibleByBuiltinIntegerLiteral",
+        "key.doc.discussion" : [
+          {
+            "Para" : "On 32-bit platforms, `Int` is the same size as `Int32`, and on 64-bit platforms, `Int` is the same size as `Int64`."
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>Int<\/Name><USR>s:Si<\/USR><Declaration>@frozen struct Int : FixedWidthInteger, SignedInteger, _ExpressibleByBuiltinIntegerLiteral<\/Declaration><CommentParts><Abstract><Para>A signed integer value type.<\/Para><\/Abstract><Discussion><Para>On 32-bit platforms, <codeVoice>Int<\/codeVoice> is the same size as <codeVoice>Int32<\/codeVoice>, and on 64-bit platforms, <codeVoice>Int<\/codeVoice> is the same size as <codeVoice>Int64<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "Int",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 460
+          }
+        ],
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Int<\/decl.name> : <ref.protocol usr=\"s:s17FixedWidthIntegerP\">FixedWidthInteger<\/ref.protocol>, <ref.protocol usr=\"s:SZ\">SignedInteger<\/ref.protocol>, <ref.protocol usr=\"s:s35_ExpressibleByBuiltinIntegerLiteralP\">_ExpressibleByBuiltinIntegerLiteral<\/ref.protocol><\/decl.struct>",
+        "key.groupname" : "Math\/Integers",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ArgumentProtocol"
+          }
+        ],
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 147,
+        "key.modulename" : "Swift",
+        "key.name" : "Int",
+        "key.namelength" : 3,
+        "key.nameoffset" : 455,
+        "key.offset" : 445,
+        "key.parsed_declaration" : "extension Int: ArgumentProtocol",
+        "key.parsed_scope.end" : 24,
+        "key.parsed_scope.start" : 18,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static let name: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 480
+              }
+            ],
+            "key.column" : 20,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 27,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 498,
+            "key.offset" : 487,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static let name = \"integer\"",
+            "key.parsed_scope.end" : 19,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 517
+              }
+            ],
+            "key.bodylength" : 23,
+            "key.bodyoffset" : 566,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 66,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 536,
+            "key.offset" : 524,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func from(string: String) -> Int?",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 21,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(Int.Type) -> (String) -> Int?",
+            "key.typeusr" : "$s6stringSiSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "Int.Type",
+        "key.typeusr" : "$sSimD",
+        "key.usr" : "s:Si"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>@frozen struct String<\/Declaration>",
+        "key.bodylength" : 110,
+        "key.bodyoffset" : 630,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen struct String",
+        "key.doc.discussion" : [
+          {
+            "Para" : "A string is a series of characters, such as `\"Swift\"`, that forms a collection. Strings in Swift are Unicode correct and locale insensitive, and are designed to be efficient. The `String` type bridges with the Objective-C class `NSString` and offers interoperability with C functions that works with strings."
+          },
+          {
+            "Para" : "You can create new strings using string literals or string interpolations. A  is a series of characters enclosed in quotes."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : " are string literals that evaluate any included expressions and convert the results to string form. String interpolations give you an easy way to build a string from multiple pieces. Wrap each expression in a string interpolation in parentheses, prefixed by a backslash."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Combine strings using the concatenation operator (`+`)."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Multiline string literals are enclosed in three double quotation marks (`\"\"\"`), with each delimiter on its own line. Indentation is stripped from each line of a multiline string literal to match the indentation of the closing delimiter."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Strings always have value semantics. Modifying a copy of a string leaves the original unaffected."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Comparing strings for equality using the equal-to operator (`==`) or a relational operator (like `<` or `>=`) is always performed using Unicode canonical representation. As a result, different representations of a string compare as being equal."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The Unicode scalar value `\"\\u{301}\"` modifies the preceding character to include an accent, so `\"e\\u{301}\"` has the same canonical representation as the single Unicode scalar value `\"é\"`."
+          },
+          {
+            "Para" : "Basic string operations are not sensitive to locale settings, ensuring that string comparisons and other operations always have a single, stable result, allowing strings to be used as keys in `Dictionary` instances and for other purposes."
+          },
+          {
+            "Para" : "A string is a collection of , which approximate human-readable characters. Many individual characters, such as “é”, “김”, and “🇮🇳”, can be made up of multiple Unicode scalar values. These scalar values are combined by Unicode’s boundary algorithms into extended grapheme clusters, represented by the Swift `Character` type. Each element of a string is represented by a `Character` instance."
+          },
+          {
+            "Para" : "For example, to retrieve the first word of a longer string, you can search for a space and then create a substring from a prefix of the string up to that point:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `firstName` constant is an instance of the `Substring` type—a type that represents substrings of a string while sharing the original string’s storage. Substrings present the same interface as strings."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "If you need to access the contents of a string as encoded in different Unicode encodings, use one of the string’s `unicodeScalars`, `utf16`, or `utf8` properties. Each property provides access to a view of the string as a series of code units, each encoded in a different Unicode encoding."
+          },
+          {
+            "Para" : "To demonstrate the different views available for every string, the following examples use this `String` instance:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `cafe` string is a collection of the nine characters that are visible when the string is displayed."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "A string’s `unicodeScalars` property is a collection of Unicode scalar values, the 21-bit codes that are the basic unit of Unicode. Each scalar value is represented by a `Unicode.Scalar` instance and is equivalent to a UTF-32 code unit."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The `unicodeScalars` view’s elements comprise each Unicode scalar value in the `cafe` string. In particular, because `cafe` was declared using the decomposed form of the `\"é\"` character, `unicodeScalars` contains the scalar values for both the letter `\"e\"` (101) and the accent character `\"´\"` (769)."
+          },
+          {
+            "Para" : "A string’s `utf16` property is a collection of UTF-16 code units, the 16-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a `UInt16` instance."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The elements of the `utf16` view are the code units for the string when encoded in UTF-16. These elements match those accessed through indexed `NSString` APIs."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "A string’s `utf8` property is a collection of UTF-8 code units, the 8-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a `UInt8` instance."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "The elements of the `utf8` view are the code units for the string when encoded in UTF-8. This representation matches the one used when `String` instances are passed to C APIs."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "When you need to know the length of a string, you must first consider what you’ll use the length for. Are you measuring the number of characters that will be displayed on the screen, or are you measuring the amount of storage needed for the string in a particular encoding? A single string can have greatly differing lengths when measured by its different views."
+          },
+          {
+            "Para" : "For example, an ASCII character like the capital letter  is represented by a single element in each of its four views. The Unicode scalar value of  is `65`, which is small enough to fit in a single code unit in both UTF-16 and UTF-8."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "On the other hand, an emoji flag character is constructed from a pair of Unicode scalar values, like `\"\\u{1F1F5}\"` and `\"\\u{1F1F7}\"`. Each of these scalar values, in turn, is too large to fit into a single UTF-16 or UTF-8 code unit. As a result, each view of the string `\"🇵🇷\"` reports a different length."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "To check whether a string is empty, use its `isEmpty` property instead of comparing the length of one of the views to `0`. Unlike with `isEmpty`, calculating a view’s `count` property requires iterating through the elements of the string."
+          },
+          {
+            "Para" : "To find individual elements of a string, use the appropriate view for your task. For example, to retrieve the first word of a longer string, you can search the string for a space and then create a new string from a prefix of the string up to that point."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Strings and their views share indices, so you can access the UTF-8 view of the `name` string using the same `firstSpace` index."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Note that an index into one view may not have an exact corresponding position in another view. For example, the `flag` string declared above comprises a single character, but is composed of eight code units when encoded as UTF-8. The following code creates constants for the first and second positions in the `flag.utf8` view. Accessing the `utf8` view with these indices yields the first and second code UTF-8 units."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "When used to access the elements of the `flag` string itself, however, the `secondCodeUnit` index does not correspond to the position of a specific character. Instead of only accessing the specific UTF-8 code unit, that index is treated as the position of the character at the index’s encoded offset. In the case of `secondCodeUnit`, that character is still the flag itself."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "If you need to validate that an index from one string’s view corresponds with an exact position in another view, use the index’s `samePosition(in:)` method or the `init(_:within:)` initializer."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Although strings in Swift have value semantics, strings use a copy-on-write strategy to store their data in a buffer. This buffer can then be shared by different copies of a string. A string’s data is only copied lazily, upon mutation, when more than one string instance is using the same buffer. Therefore, the first in any sequence of mutating operations may cost O() time and space."
+          },
+          {
+            "Para" : "When a string’s contiguous storage fills up, a new buffer must be allocated and data must be moved to the new storage. String buffers use an exponential growth strategy that makes appending to a string a constant time operation when averaged over many append operations."
+          },
+          {
+            "Para" : "Any `String` instance can be bridged to `NSString` using the type-cast operator (`as`), and any `String` instance that originates in Objective-C may use an `NSString` instance as its storage. Because any arbitrary subclass of `NSString` can become a `String` instance, there are no guarantees about representation or efficiency when a `String` instance is backed by `NSString` storage. Because `NSString` is immutable, it is just as though the storage was shared by a copy. The first in any sequence of mutating operations causes elements to be copied into unique, contiguous storage which may cost O() time and space, where  is the length of the string’s encoded representation (or more, if the underlying `NSString` has unusual performance characteristics)."
+          },
+          {
+            "Para" : "For more information about the Unicode terms used in this discussion, see the . In particular, this discussion mentions , , and ."
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>String<\/Name><USR>s:SS<\/USR><Declaration>@frozen struct String<\/Declaration><CommentParts><Abstract><Para>A Unicode string value that is a collection of characters.<\/Para><\/Abstract><Discussion><Para>A string is a series of characters, such as <codeVoice>&quot;Swift&quot;<\/codeVoice>, that forms a collection. Strings in Swift are Unicode correct and locale insensitive, and are designed to be efficient. The <codeVoice>String<\/codeVoice> type bridges with the Objective-C class <codeVoice>NSString<\/codeVoice> and offers interoperability with C functions that works with strings.<\/Para><Para>You can create new strings using string literals or string interpolations. A <emphasis>string literal<\/emphasis> is a series of characters enclosed in quotes.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let greeting = \"Welcome!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para><emphasis>String interpolations<\/emphasis> are string literals that evaluate any included expressions and convert the results to string form. String interpolations give you an easy way to build a string from multiple pieces. Wrap each expression in a string interpolation in parentheses, prefixed by a backslash.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Rosa\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let personalizedGreeting = \"Welcome, \\(name)!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ personalizedGreeting == \"Welcome, Rosa!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let price = 2]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let number = 3]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let cookiePrice = \"\\(number) cookies: $\\(price * number).\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ cookiePrice == \"3 cookies: $6.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Combine strings using the concatenation operator (<codeVoice>+<\/codeVoice>).<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let longerGreeting = greeting + \" We're glad you're here!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ longerGreeting == \"Welcome! We're glad you're here!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Multiline string literals are enclosed in three double quotation marks (<codeVoice>&quot;&quot;&quot;<\/codeVoice>), with each delimiter on its own line. Indentation is stripped from each line of a multiline string literal to match the indentation of the closing delimiter.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let banner = \"\"\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[          __,]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[         (           o  \/) _\/_]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[          `.  , , , ,  \/\/  \/]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        (___)(_(_\/_(_ \/\/_ (__]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[                     \/)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[                    (\/]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        \"\"\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Modifying and Comparing Strings<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Strings always have value semantics. Modifying a copy of a string leaves the original unaffected.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var otherGreeting = greeting]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[otherGreeting += \" Have a nice time!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ otherGreeting == \"Welcome! Have a nice time!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(greeting)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Welcome!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Comparing strings for equality using the equal-to operator (<codeVoice>==<\/codeVoice>) or a relational operator (like <codeVoice>&lt;<\/codeVoice> or <codeVoice>&gt;=<\/codeVoice>) is always performed using Unicode canonical representation. As a result, different representations of a string compare as being equal.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cafe1 = \"Cafe\\u{301}\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let cafe2 = \"Café\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe1 == cafe2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"true\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The Unicode scalar value <codeVoice>&quot;\\u{301}&quot;<\/codeVoice> modifies the preceding character to include an accent, so <codeVoice>&quot;e\\u{301}&quot;<\/codeVoice> has the same canonical representation as the single Unicode scalar value <codeVoice>&quot;é&quot;<\/codeVoice>.<\/Para><Para>Basic string operations are not sensitive to locale settings, ensuring that string comparisons and other operations always have a single, stable result, allowing strings to be used as keys in <codeVoice>Dictionary<\/codeVoice> instances and for other purposes.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing String Elements<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>A string is a collection of <emphasis>extended grapheme clusters<\/emphasis>, which approximate human-readable characters. Many individual characters, such as “é”, “김”, and “🇮🇳”, can be made up of multiple Unicode scalar values. These scalar values are combined by Unicode’s boundary algorithms into extended grapheme clusters, represented by the Swift <codeVoice>Character<\/codeVoice> type. Each element of a string is represented by a <codeVoice>Character<\/codeVoice> instance.<\/Para><Para>For example, to retrieve the first word of a longer string, you can search for a space and then create a substring from a prefix of the string up to that point:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Marie Curie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstSpace = name.firstIndex(of: \" \") ?? name.endIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstName = name[..<firstSpace]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ firstName == \"Marie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>firstName<\/codeVoice> constant is an instance of the <codeVoice>Substring<\/codeVoice> type—a type that represents substrings of a string while sharing the original string’s storage. Substrings present the same interface as strings.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(\"\\(name)'s first name has \\(firstName.count) letters.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Marie Curie's first name has 5 letters.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing a String’s Unicode Representation<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>If you need to access the contents of a string as encoded in different Unicode encodings, use one of the string’s <codeVoice>unicodeScalars<\/codeVoice>, <codeVoice>utf16<\/codeVoice>, or <codeVoice>utf8<\/codeVoice> properties. Each property provides access to a view of the string as a series of code units, each encoded in a different Unicode encoding.<\/Para><Para>To demonstrate the different views available for every string, the following examples use this <codeVoice>String<\/codeVoice> instance:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cafe = \"Cafe\\u{301} du 🌍\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Café du 🌍\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>cafe<\/codeVoice> string is a collection of the nine characters that are visible when the string is displayed.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"9\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[\"C\", \"a\", \"f\", \"é\", \" \", \"d\", \"u\", \" \", \"🌍\"]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h2>]]><\/rawHTML>Unicode Scalar View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>unicodeScalars<\/codeVoice> property is a collection of Unicode scalar values, the 21-bit codes that are the basic unit of Unicode. Each scalar value is represented by a <codeVoice>Unicode.Scalar<\/codeVoice> instance and is equivalent to a UTF-32 code unit.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"10\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.unicodeScalars))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[\"C\", \"a\", \"f\", \"e\", \"\\u{0301}\", \" \", \"d\", \"u\", \" \", \"\\u{0001F30D}\"]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cafe.unicodeScalars.map { $0.value })]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 769, 32, 100, 117, 32, 127757]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The <codeVoice>unicodeScalars<\/codeVoice> view’s elements comprise each Unicode scalar value in the <codeVoice>cafe<\/codeVoice> string. In particular, because <codeVoice>cafe<\/codeVoice> was declared using the decomposed form of the <codeVoice>&quot;é&quot;<\/codeVoice> character, <codeVoice>unicodeScalars<\/codeVoice> contains the scalar values for both the letter <codeVoice>&quot;e&quot;<\/codeVoice> (101) and the accent character <codeVoice>&quot;´&quot;<\/codeVoice> (769).<\/Para><rawHTML><![CDATA[<h2>]]><\/rawHTML>UTF-16 View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>utf16<\/codeVoice> property is a collection of UTF-16 code units, the 16-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a <codeVoice>UInt16<\/codeVoice> instance.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"11\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.utf16))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 769, 32, 100, 117, 32, 55356, 57101]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The elements of the <codeVoice>utf16<\/codeVoice> view are the code units for the string when encoded in UTF-16. These elements match those accessed through indexed <codeVoice>NSString<\/codeVoice> APIs.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let nscafe = cafe as NSString]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nscafe.length)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"11\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nscafe.character(at: 3))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"101\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h2>]]><\/rawHTML>UTF-8 View<rawHTML><![CDATA[<\/h2>]]><\/rawHTML><Para>A string’s <codeVoice>utf8<\/codeVoice> property is a collection of UTF-8 code units, the 8-bit encoding form of the string’s Unicode scalar values. Each code unit is stored as a <codeVoice>UInt8<\/codeVoice> instance.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(cafe.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"14\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(Array(cafe.utf8))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[67, 97, 102, 101, 204, 129, 32, 100, 117, 32, 240, 159, 140, 141]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The elements of the <codeVoice>utf8<\/codeVoice> view are the code units for the string when encoded in UTF-8. This representation matches the one used when <codeVoice>String<\/codeVoice> instances are passed to C APIs.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let cLength = strlen(cafe)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(cLength)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"14\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Measuring the Length of a String<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>When you need to know the length of a string, you must first consider what you’ll use the length for. Are you measuring the number of characters that will be displayed on the screen, or are you measuring the amount of storage needed for the string in a particular encoding? A single string can have greatly differing lengths when measured by its different views.<\/Para><Para>For example, an ASCII character like the capital letter <emphasis>A<\/emphasis> is represented by a single element in each of its four views. The Unicode scalar value of <emphasis>A<\/emphasis> is <codeVoice>65<\/codeVoice>, which is small enough to fit in a single code unit in both UTF-16 and UTF-8.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let capitalA = \"A\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(capitalA.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>On the other hand, an emoji flag character is constructed from a pair of Unicode scalar values, like <codeVoice>&quot;\\u{1F1F5}&quot;<\/codeVoice> and <codeVoice>&quot;\\u{1F1F7}&quot;<\/codeVoice>. Each of these scalar values, in turn, is too large to fit into a single UTF-16 or UTF-8 code unit. As a result, each view of the string <codeVoice>&quot;🇵🇷&quot;<\/codeVoice> reports a different length.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let flag = \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"1\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.unicodeScalars.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"2\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.utf16.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"4\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(flag.utf8.count)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"8\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>To check whether a string is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing the length of one of the views to <codeVoice>0<\/codeVoice>. Unlike with <codeVoice>isEmpty<\/codeVoice>, calculating a view’s <codeVoice>count<\/codeVoice> property requires iterating through the elements of the string.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Accessing String View Elements<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>To find individual elements of a string, use the appropriate view for your task. For example, to retrieve the first word of a longer string, you can search the string for a space and then create a new string from a prefix of the string up to that point.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let name = \"Marie Curie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstSpace = name.firstIndex(of: \" \") ?? name.endIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let firstName = name[..<firstSpace]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(firstName)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Marie\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Strings and their views share indices, so you can access the UTF-8 view of the <codeVoice>name<\/codeVoice> string using the same <codeVoice>firstSpace<\/codeVoice> index.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(Array(name.utf8[..<firstSpace]))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[77, 97, 114, 105, 101]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Note that an index into one view may not have an exact corresponding position in another view. For example, the <codeVoice>flag<\/codeVoice> string declared above comprises a single character, but is composed of eight code units when encoded as UTF-8. The following code creates constants for the first and second positions in the <codeVoice>flag.utf8<\/codeVoice> view. Accessing the <codeVoice>utf8<\/codeVoice> view with these indices yields the first and second code UTF-8 units.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let firstCodeUnit = flag.startIndex]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let secondCodeUnit = flag.utf8.index(after: firstCodeUnit)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag.utf8[firstCodeUnit] == 240]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag.utf8[secondCodeUnit] == 159]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>When used to access the elements of the <codeVoice>flag<\/codeVoice> string itself, however, the <codeVoice>secondCodeUnit<\/codeVoice> index does not correspond to the position of a specific character. Instead of only accessing the specific UTF-8 code unit, that index is treated as the position of the character at the index’s encoded offset. In the case of <codeVoice>secondCodeUnit<\/codeVoice>, that character is still the flag itself.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[\/\/ flag[firstCodeUnit] == \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ flag[secondCodeUnit] == \"🇵🇷\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If you need to validate that an index from one string’s view corresponds with an exact position in another view, use the index’s <codeVoice>samePosition(in:)<\/codeVoice> method or the <codeVoice>init(_:within:)<\/codeVoice> initializer.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[if let exactIndex = secondCodeUnit.samePosition(in: flag) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(flag[exactIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"No exact match for this position.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"No exact match for this position.\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Performance Optimizations<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Although strings in Swift have value semantics, strings use a copy-on-write strategy to store their data in a buffer. This buffer can then be shared by different copies of a string. A string’s data is only copied lazily, upon mutation, when more than one string instance is using the same buffer. Therefore, the first in any sequence of mutating operations may cost O(<emphasis>n<\/emphasis>) time and space.<\/Para><Para>When a string’s contiguous storage fills up, a new buffer must be allocated and data must be moved to the new storage. String buffers use an exponential growth strategy that makes appending to a string a constant time operation when averaged over many append operations.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Bridging Between String and NSString<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Any <codeVoice>String<\/codeVoice> instance can be bridged to <codeVoice>NSString<\/codeVoice> using the type-cast operator (<codeVoice>as<\/codeVoice>), and any <codeVoice>String<\/codeVoice> instance that originates in Objective-C may use an <codeVoice>NSString<\/codeVoice> instance as its storage. Because any arbitrary subclass of <codeVoice>NSString<\/codeVoice> can become a <codeVoice>String<\/codeVoice> instance, there are no guarantees about representation or efficiency when a <codeVoice>String<\/codeVoice> instance is backed by <codeVoice>NSString<\/codeVoice> storage. Because <codeVoice>NSString<\/codeVoice> is immutable, it is just as though the storage was shared by a copy. The first in any sequence of mutating operations causes elements to be copied into unique, contiguous storage which may cost O(<emphasis>n<\/emphasis>) time and space, where <emphasis>n<\/emphasis> is the length of the string’s encoded representation (or more, if the underlying <codeVoice>NSString<\/codeVoice> has unusual performance characteristics).<\/Para><Para>For more information about the Unicode terms used in this discussion, see the <Link href=\"http:\/\/www.unicode.org\/glossary\/\">Unicode.org glossary<\/Link>. In particular, this discussion mentions <Link href=\"http:\/\/www.unicode.org\/glossary\/#extended_grapheme_cluster\">extended grapheme clusters<\/Link>, <Link href=\"http:\/\/www.unicode.org\/glossary\/#unicode_scalar_value\">Unicode scalar values<\/Link>, and <Link href=\"http:\/\/www.unicode.org\/glossary\/#canonical_equivalent\">canonical equivalence<\/Link>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "String",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 16,
+            "key.offset" : 612
+          }
+        ],
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>String<\/decl.name><\/decl.struct>",
+        "key.groupname" : "String",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "ArgumentProtocol"
+          }
+        ],
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 147,
+        "key.modulename" : "Swift",
+        "key.name" : "String",
+        "key.namelength" : 6,
+        "key.nameoffset" : 604,
+        "key.offset" : 594,
+        "key.parsed_declaration" : "extension String: ArgumentProtocol",
+        "key.parsed_scope.end" : 32,
+        "key.parsed_scope.start" : 26,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static let name: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 632
+              }
+            ],
+            "key.column" : 20,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.declaration" : "static var name: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"12\" column=\"13\"><Name>name<\/Name><USR>s:10Commandant16ArgumentProtocolP4nameSSvpZ<\/USR><Declaration>static var name: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable name for this type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 12,
+            "key.doc.name" : "name",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>name<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.static>",
+            "key.kind" : "source.lang.swift.decl.var.static",
+            "key.length" : 26,
+            "key.line" : 27,
+            "key.modulename" : "Commandant",
+            "key.name" : "name",
+            "key.namelength" : 4,
+            "key.nameoffset" : 650,
+            "key.offset" : 639,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static let name = \"string\"",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 27,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4nameSSvpZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 668
+              }
+            ],
+            "key.bodylength" : 18,
+            "key.bodyoffset" : 720,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func from(string: String) -> Self?",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/ArgumentProtocol.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/ArgumentProtocol.swift\" line=\"15\" column=\"14\"><Name>from(string:)<\/Name><USR>s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ<\/USR><Declaration>static func from(string: String) -&gt; Self?<\/Declaration><CommentParts><Abstract><Para>Attempts to parse a value from the given command-line argument.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>ArgumentProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "from(string:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 64,
+            "key.line" : 29,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 687,
+            "key.offset" : 675,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func from(string: String) -> String?",
+            "key.parsed_scope.end" : 31,
+            "key.parsed_scope.start" : 29,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(String.Type) -> (String) -> String?",
+            "key.typeusr" : "$s6stringSSSgSS_tcD",
+            "key.usr" : "s:10Commandant16ArgumentProtocolP4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "String.Type",
+        "key.typeusr" : "$sSSmD",
+        "key.usr" : "s:SS"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>protocol RawRepresentable&lt;<Type usr=\"s:SY8RawValueQa\">RawValue<\/Type>&gt;<\/Declaration>",
+        "key.bodylength" : 112,
+        "key.bodyoffset" : 826,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "protocol RawRepresentable<RawValue>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "With a `RawRepresentable` type, you can switch back and forth between a custom type and an associated `RawValue` type without losing the value of the original `RawRepresentable` type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as `Equatable`, `Comparable`, and `Hashable`."
+          },
+          {
+            "Para" : "The `RawRepresentable` protocol is seen mainly in two categories of types: enumerations with raw value types and option sets."
+          },
+          {
+            "Para" : "For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds `RawRepresentable` conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases."
+          },
+          {
+            "Para" : "For example, the `Counter` enumeration defined here has an `Int` raw value type and gives the first case a raw value of `1`:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "You can create a `Counter` instance from an integer value between 1 and 5 by using the `init?(rawValue:)` initializer declared in the `RawRepresentable` protocol. This initializer is failable because although every case of the `Counter` type has a corresponding `Int` value, there are many `Int` values that  correspond to a case of `Counter`."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets all conform to `RawRepresentable` by inheritance using the `OptionSet` protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the `FixedWidthInteger` protocol, such as `UInt8` or `Int`. For example, the `Direction` type defines an option set for the four directions you can move in a game."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Unlike enumerations, option sets provide a nonfailable `init(rawValue:)` initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values."
+          },
+          {
+            "Para" : "In the case of the `Directions` option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the `allowedMoves` instance is the result of the bitwise OR of its three members’ raw values:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the `contains()` method on `allowedMoves` performs a bitwise AND operation to check whether the option set contains an element."
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>RawRepresentable<\/Name><USR>s:SY<\/USR><Declaration>protocol RawRepresentable&lt;RawValue&gt;<\/Declaration><CommentParts><Abstract><Para>A type that can be converted to and from an associated raw value.<\/Para><\/Abstract><Discussion><Para>With a <codeVoice>RawRepresentable<\/codeVoice> type, you can switch back and forth between a custom type and an associated <codeVoice>RawValue<\/codeVoice> type without losing the value of the original <codeVoice>RawRepresentable<\/codeVoice> type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as <codeVoice>Equatable<\/codeVoice>, <codeVoice>Comparable<\/codeVoice>, and <codeVoice>Hashable<\/codeVoice>.<\/Para><Para>The <codeVoice>RawRepresentable<\/codeVoice> protocol is seen mainly in two categories of types: enumerations with raw value types and option sets.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Enumerations with Raw Values<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds <codeVoice>RawRepresentable<\/codeVoice> conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases.<\/Para><Para>For example, the <codeVoice>Counter<\/codeVoice> enumeration defined here has an <codeVoice>Int<\/codeVoice> raw value type and gives the first case a raw value of <codeVoice>1<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[enum Counter: Int {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    case one = 1, two, three, four, five]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can create a <codeVoice>Counter<\/codeVoice> instance from an integer value between 1 and 5 by using the <codeVoice>init?(rawValue:)<\/codeVoice> initializer declared in the <codeVoice>RawRepresentable<\/codeVoice> protocol. This initializer is failable because although every case of the <codeVoice>Counter<\/codeVoice> type has a corresponding <codeVoice>Int<\/codeVoice> value, there are many <codeVoice>Int<\/codeVoice> values that <emphasis>don’t<\/emphasis> correspond to a case of <codeVoice>Counter<\/codeVoice>.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[for i in 3...6 {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(Counter(rawValue: i))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.three)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.four)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.five)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"nil\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Option Sets<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Option sets all conform to <codeVoice>RawRepresentable<\/codeVoice> by inheritance using the <codeVoice>OptionSet<\/codeVoice> protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the <codeVoice>FixedWidthInteger<\/codeVoice> protocol, such as <codeVoice>UInt8<\/codeVoice> or <codeVoice>Int<\/codeVoice>. For example, the <codeVoice>Direction<\/codeVoice> type defines an option set for the four directions you can move in a game.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Directions: OptionSet {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let rawValue: UInt8]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let up    = Directions(rawValue: 1 << 0)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let down  = Directions(rawValue: 1 << 1)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let left  = Directions(rawValue: 1 << 2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let right = Directions(rawValue: 1 << 3)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Unlike enumerations, option sets provide a nonfailable <codeVoice>init(rawValue:)<\/codeVoice> initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values.<\/Para><Para>In the case of the <codeVoice>Directions<\/codeVoice> option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the <codeVoice>allowedMoves<\/codeVoice> instance is the result of the bitwise OR of its three members’ raw values:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let allowedMoves: Directions = [.up, .down, .left]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"7\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the <codeVoice>contains()<\/codeVoice> method on <codeVoice>allowedMoves<\/codeVoice> performs a bitwise AND operation to check whether the option set contains an element.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(allowedMoves.contains(.right))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"false\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue & Directions.right.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"0\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "RawRepresentable",
+        "key.doc.type" : "Class",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>RawRepresentable<\/decl.name>&lt;<decl.generic_type_param usr=\"s:SY8RawValueQa\"><ref.associatedtype usr=\"s:SY8RawValueQa\">RawValue<\/ref.associatedtype><\/decl.generic_type_param>&gt;<\/decl.protocol>",
+        "key.groupname" : "Protocols",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 196,
+        "key.modulename" : "Swift",
+        "key.name" : "RawRepresentable",
+        "key.namelength" : 16,
+        "key.nameoffset" : 753,
+        "key.offset" : 743,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: StringProtocol, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 38,
+        "key.parsed_scope.start" : 34,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 828
+              }
+            ],
+            "key.bodylength" : 58,
+            "key.bodyoffset" : 878,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 102,
+            "key.line" : 35,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 847,
+            "key.offset" : 835,
+            "key.parsed_declaration" : "public static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 35,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4from6stringxSgSS_tFZ\">from(string: String) -&gt; Self?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol, Self : RawRepresentable, Self.RawValue : StringProtocol> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "RawRepresentable.Protocol",
+        "key.typeusr" : "$sSY_pmD",
+        "key.usr" : "s:SY"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>protocol RawRepresentable&lt;<Type usr=\"s:SY8RawValueQa\">RawValue<\/Type>&gt;<\/Declaration>",
+        "key.bodylength" : 112,
+        "key.bodyoffset" : 1027,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "protocol RawRepresentable<RawValue>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "With a `RawRepresentable` type, you can switch back and forth between a custom type and an associated `RawValue` type without losing the value of the original `RawRepresentable` type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as `Equatable`, `Comparable`, and `Hashable`."
+          },
+          {
+            "Para" : "The `RawRepresentable` protocol is seen mainly in two categories of types: enumerations with raw value types and option sets."
+          },
+          {
+            "Para" : "For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds `RawRepresentable` conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases."
+          },
+          {
+            "Para" : "For example, the `Counter` enumeration defined here has an `Int` raw value type and gives the first case a raw value of `1`:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "You can create a `Counter` instance from an integer value between 1 and 5 by using the `init?(rawValue:)` initializer declared in the `RawRepresentable` protocol. This initializer is failable because although every case of the `Counter` type has a corresponding `Int` value, there are many `Int` values that  correspond to a case of `Counter`."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets all conform to `RawRepresentable` by inheritance using the `OptionSet` protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the `FixedWidthInteger` protocol, such as `UInt8` or `Int`. For example, the `Direction` type defines an option set for the four directions you can move in a game."
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Unlike enumerations, option sets provide a nonfailable `init(rawValue:)` initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values."
+          },
+          {
+            "Para" : "In the case of the `Directions` option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the `allowedMoves` instance is the result of the bitwise OR of its three members’ raw values:"
+          },
+          {
+            "CodeListing" : ""
+          },
+          {
+            "Para" : "Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the `contains()` method on `allowedMoves` performs a bitwise AND operation to check whether the option set contains an element."
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.full_as_xml" : "<Class><Name>RawRepresentable<\/Name><USR>s:SY<\/USR><Declaration>protocol RawRepresentable&lt;RawValue&gt;<\/Declaration><CommentParts><Abstract><Para>A type that can be converted to and from an associated raw value.<\/Para><\/Abstract><Discussion><Para>With a <codeVoice>RawRepresentable<\/codeVoice> type, you can switch back and forth between a custom type and an associated <codeVoice>RawValue<\/codeVoice> type without losing the value of the original <codeVoice>RawRepresentable<\/codeVoice> type. Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs and simplifies conformance to other protocols, such as <codeVoice>Equatable<\/codeVoice>, <codeVoice>Comparable<\/codeVoice>, and <codeVoice>Hashable<\/codeVoice>.<\/Para><Para>The <codeVoice>RawRepresentable<\/codeVoice> protocol is seen mainly in two categories of types: enumerations with raw value types and option sets.<\/Para><rawHTML><![CDATA[<h1>]]><\/rawHTML>Enumerations with Raw Values<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>For any enumeration with a string, integer, or floating-point raw type, the Swift compiler automatically adds <codeVoice>RawRepresentable<\/codeVoice> conformance. When defining your own custom enumeration, you give it a raw type by specifying the raw type as the first item in the enumeration’s type inheritance list. You can also use literals to specify values for one or more cases.<\/Para><Para>For example, the <codeVoice>Counter<\/codeVoice> enumeration defined here has an <codeVoice>Int<\/codeVoice> raw value type and gives the first case a raw value of <codeVoice>1<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[enum Counter: Int {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    case one = 1, two, three, four, five]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can create a <codeVoice>Counter<\/codeVoice> instance from an integer value between 1 and 5 by using the <codeVoice>init?(rawValue:)<\/codeVoice> initializer declared in the <codeVoice>RawRepresentable<\/codeVoice> protocol. This initializer is failable because although every case of the <codeVoice>Counter<\/codeVoice> type has a corresponding <codeVoice>Int<\/codeVoice> value, there are many <codeVoice>Int<\/codeVoice> values that <emphasis>don’t<\/emphasis> correspond to a case of <codeVoice>Counter<\/codeVoice>.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[for i in 3...6 {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(Counter(rawValue: i))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.three)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.four)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Optional(Counter.five)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"nil\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><rawHTML><![CDATA[<h1>]]><\/rawHTML>Option Sets<rawHTML><![CDATA[<\/h1>]]><\/rawHTML><Para>Option sets all conform to <codeVoice>RawRepresentable<\/codeVoice> by inheritance using the <codeVoice>OptionSet<\/codeVoice> protocol. Whether using an option set or creating your own, you use the raw value of an option set instance to store the instance’s bitfield. The raw value must therefore be of a type that conforms to the <codeVoice>FixedWidthInteger<\/codeVoice> protocol, such as <codeVoice>UInt8<\/codeVoice> or <codeVoice>Int<\/codeVoice>. For example, the <codeVoice>Direction<\/codeVoice> type defines an option set for the four directions you can move in a game.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Directions: OptionSet {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let rawValue: UInt8]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let up    = Directions(rawValue: 1 << 0)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let down  = Directions(rawValue: 1 << 1)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let left  = Directions(rawValue: 1 << 2)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    static let right = Directions(rawValue: 1 << 3)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Unlike enumerations, option sets provide a nonfailable <codeVoice>init(rawValue:)<\/codeVoice> initializer to convert from a raw value, because option sets don’t have an enumerated list of all possible cases. Option set values have a one-to-one correspondence with their associated raw values.<\/Para><Para>In the case of the <codeVoice>Directions<\/codeVoice> option set, an instance can contain zero, one, or more of the four defined directions. This example declares a constant with three currently allowed moves. The raw value of the <codeVoice>allowedMoves<\/codeVoice> instance is the result of the bitwise OR of its three members’ raw values:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let allowedMoves: Directions = [.up, .down, .left]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"7\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>Option sets use bitwise operations on their associated raw values to implement their mathematical set operations. For example, the <codeVoice>contains()<\/codeVoice> method on <codeVoice>allowedMoves<\/codeVoice> performs a bitwise AND operation to check whether the option set contains an element.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[print(allowedMoves.contains(.right))]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"false\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(allowedMoves.rawValue & Directions.right.rawValue)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"0\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.name" : "RawRepresentable",
+        "key.doc.type" : "Class",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>RawRepresentable<\/decl.name>&lt;<decl.generic_type_param usr=\"s:SY8RawValueQa\"><ref.associatedtype usr=\"s:SY8RawValueQa\">RawValue<\/ref.associatedtype><\/decl.generic_type_param>&gt;<\/decl.protocol>",
+        "key.groupname" : "Protocols",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 199,
+        "key.modulename" : "Swift",
+        "key.name" : "RawRepresentable",
+        "key.namelength" : 16,
+        "key.nameoffset" : 951,
+        "key.offset" : 941,
+        "key.parsed_declaration" : "extension RawRepresentable where RawValue: FixedWidthInteger, Self: ArgumentProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 40,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func from(string: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4Selfxmfp\">Self<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1029
+              }
+            ],
+            "key.bodylength" : 58,
+            "key.bodyoffset" : 1079,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>from<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>string<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4Selfxmfp\">Self<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 102,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "from(string:)",
+            "key.namelength" : 20,
+            "key.nameoffset" : 1048,
+            "key.offset" : 1036,
+            "key.parsed_declaration" : "public static func from(string: String) -> Self?",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 41,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:SY10CommandantAA16ArgumentProtocolRzSy8RawValueSYRpzrlE4from6stringxSgSS_tFZ\">from(string: String) -&gt; Self?<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : ArgumentProtocol, Self : RawRepresentable, Self.RawValue : FixedWidthInteger> (Self.Type) -> (String) -> Self?",
+            "key.typeusr" : "$s6stringxSgSS_tcD",
+            "key.usr" : "s:SY10CommandantAA16ArgumentProtocolRzs17FixedWidthInteger8RawValueSYRpzrlE4from6stringxSgSS_tFZ"
+          }
+        ],
+        "key.typename" : "RawRepresentable.Protocol",
+        "key.typeusr" : "$sSY_pmD",
+        "key.usr" : "s:SY"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Command.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 7522,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol CommandProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 247
+          }
+        ],
+        "key.bodylength" : 483,
+        "key.bodyoffset" : 280,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a subcommand that can be executed with its own set of arguments.",
+        "key.doc.declaration" : "public protocol CommandProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"12\" column=\"17\"><Name>CommandProtocol<\/Name><USR>s:10Commandant15CommandProtocolP<\/USR><Declaration>public protocol CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a subcommand that can be executed with its own set of arguments.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 12,
+        "key.doc.name" : "CommandProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 80,
+        "key.docoffset" : 167,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>CommandProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 510,
+        "key.line" : 12,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandProtocol",
+        "key.namelength" : 15,
+        "key.nameoffset" : 263,
+        "key.offset" : 254,
+        "key.parsed_declaration" : "public protocol CommandProtocol",
+        "key.parsed_scope.end" : 29,
+        "key.parsed_scope.start" : 12,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype Options : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 17,
+            "key.doc.comment" : "The command's options type.",
+            "key.doc.declaration" : "associatedtype Options : Commandant.OptionsProtocol",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"15\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7OptionsQa<\/USR><Declaration>associatedtype Options : Commandant.OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "Options",
+            "key.doc.type" : "Other",
+            "key.doclength" : 32,
+            "key.docoffset" : 283,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>Options<\/decl.name> : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 39,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "Options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 331,
+            "key.offset" : 316,
+            "key.parsed_declaration" : "associatedtype Options: OptionsProtocol",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "Self.Options.Type",
+            "key.typeusr" : "$s7OptionsQzmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype ClientError where <Type usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type> == <Type usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/Type>.<Type usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>ClientError<\/decl.name> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype> == <ref.generic_type_param usr=\"s:10Commandant15CommandProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/ref.associatedtype>.<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 67,
+            "key.line" : 17,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 373,
+            "key.offset" : 358,
+            "key.parsed_declaration" : "associatedtype ClientError where ClientError == Options.ClientError",
+            "key.parsed_scope.end" : 17,
+            "key.parsed_scope.start" : 17,
+            "key.typename" : "Self.ClientError.Type",
+            "key.typeusr" : "$s11ClientErrorQzmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP11ClientErrorQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 532,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.comment" : "The action that users should specify to use this subcommand (e.g.,\n`help`).",
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"21\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSvp<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 21,
+            "key.doc.name" : "verb",
+            "key.doc.type" : "Other",
+            "key.doclength" : 85,
+            "key.docoffset" : 428,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 24,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 518,
+            "key.offset" : 514,
+            "key.parsed_declaration" : "var verb: String",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 21,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>var function: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 5,
+            "key.bodyoffset" : 648,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.comment" : "A human-readable, high-level description of what this command is used\nfor.",
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"25\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSvp<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 25,
+            "key.doc.name" : "function",
+            "key.doc.type" : "Other",
+            "key.doclength" : 84,
+            "key.docoffset" : 541,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 28,
+            "key.line" : 25,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 630,
+            "key.offset" : 626,
+            "key.parsed_declaration" : "var function: String",
+            "key.parsed_scope.end" : 25,
+            "key.parsed_scope.start" : 25,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>func run(_ options: <Type usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 7,
+            "key.doc.comment" : "Runs this subcommand with the given options.",
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"28\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 28,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 49,
+            "key.docoffset" : 657,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.associatedtype usr=\"s:10Commandant15CommandProtocolP7OptionsQa\">Options<\/ref.associatedtype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 55,
+            "key.line" : 28,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 712,
+            "key.offset" : 707,
+            "key.parsed_declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 28,
+            "key.parsed_scope.start" : 28,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : CommandProtocol> (Self) -> (Self.Options) -> Result<(), Self.ClientError>",
+            "key.typeusr" : "$sys6ResultOyyt11ClientErrorQzG7OptionsQzcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "CommandProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant15CommandProtocol_pmD",
+        "key.usr" : "s:10Commandant15CommandProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct CommandWrapper&lt;ClientError&gt; where <Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 793
+          }
+        ],
+        "key.bodylength" : 957,
+        "key.bodyoffset" : 843,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A type-erased command.",
+        "key.doc.declaration" : "public struct CommandWrapper<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"32\" column=\"15\"><Name>CommandWrapper<\/Name><USR>s:10Commandant14CommandWrapperV<\/USR><Declaration>public struct CommandWrapper&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A type-erased command.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 32,
+        "key.doc.name" : "CommandWrapper",
+        "key.doc.type" : "Class",
+        "key.doclength" : 27,
+        "key.docoffset" : 766,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>CommandWrapper<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1001,
+        "key.line" : 32,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandWrapper",
+        "key.namelength" : 14,
+        "key.nameoffset" : 807,
+        "key.offset" : 800,
+        "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error>",
+        "key.parsed_scope.end" : 65,
+        "key.parsed_scope.start" : 32,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 30,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 835
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 32,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 822,
+            "key.offset" : 822,
+            "key.parsed_declaration" : "public struct CommandWrapper<ClientError: Error",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 32,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant14CommandWrapperV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 845
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 16,
+            "key.line" : 33,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 856,
+            "key.offset" : 852,
+            "key.parsed_declaration" : "public let verb: String",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 33,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 870
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 34,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 881,
+            "key.offset" : 877,
+            "key.parsed_declaration" : "public let function: String",
+            "key.parsed_scope.end" : 34,
+            "key.parsed_scope.start" : 34,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant14CommandWrapperV8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let run: (<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 900
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>run<\/decl.name>: <decl.var.type>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 69,
+            "key.line" : 36,
+            "key.modulename" : "Commandant",
+            "key.name" : "run",
+            "key.namelength" : 3,
+            "key.nameoffset" : 911,
+            "key.offset" : 907,
+            "key.parsed_declaration" : "public let run: (ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 36,
+            "key.typename" : "(ArgumentParser) -> Result<(), CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyyt10Commandant0B5ErrorOyxGGAC14ArgumentParserCcD",
+            "key.usr" : "s:10Commandant14CommandWrapperV3runys6ResultOyytAA0A5ErrorOyxGGAA14ArgumentParserCcvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: () -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type>&gt;?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 979
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type>() -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 990,
+            "key.offset" : 986,
+            "key.parsed_declaration" : "public let usage: () -> CommandantError<ClientError>?",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "() -> CommandantError<ClientError>?",
+            "key.typeusr" : "$s10Commandant0A5ErrorOyxGSgycD",
+            "key.usr" : "s:10Commandant14CommandWrapperV5usageAA0A5ErrorOyxGSgycvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate init&lt;C&gt;(_ command: <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>) where <Type usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/Type> == <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>, <Type usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/Type> : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1078
+              }
+            ],
+            "key.bodylength" : 633,
+            "key.bodyoffset" : 1165,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Creates a command that wraps another.",
+            "key.doc.declaration" : "fileprivate init<C>(_ command: C) where ClientError == C.ClientError, C : Commandant.CommandProtocol",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"41\" column=\"14\"><Name>init(_:)<\/Name><USR>s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc<\/USR><Declaration>fileprivate init&lt;C&gt;(_ command: C) where ClientError == C.ClientError, C : Commandant.CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Creates a command that wraps another.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 41,
+            "key.doc.name" : "init(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 42,
+            "key.docoffset" : 1035,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>command<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp\">C<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 709,
+            "key.line" : 41,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 38,
+            "key.nameoffset" : 1090,
+            "key.offset" : 1090,
+            "key.parsed_declaration" : "fileprivate init<C: CommandProtocol>(_ command: C) where C.ClientError == ClientError",
+            "key.parsed_scope.end" : 64,
+            "key.parsed_scope.start" : 41,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+                "key.column" : 19,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 15,
+                    "key.offset" : 1098
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>C<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "CommandProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 18,
+                "key.line" : 41,
+                "key.modulename" : "Commandant",
+                "key.name" : "C",
+                "key.namelength" : 1,
+                "key.nameoffset" : 1095,
+                "key.offset" : 1095,
+                "key.parsed_declaration" : "fileprivate init<C: CommandProtocol",
+                "key.parsed_scope.end" : 41,
+                "key.parsed_scope.start" : 41,
+                "key.typename" : "C.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc1CL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol> (CommandWrapper<ClientError>.Type) -> (C) -> CommandWrapper<ClientError>",
+            "key.typeusr" : "$sy10Commandant14CommandWrapperVyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__luD",
+            "key.usr" : "s:10Commandant14CommandWrapperVyACyxGqd__c11ClientErrorQyd__RszAA0B8ProtocolRd__lu33_1DD6990CD6DFDE28F713A55F8EE2B70ELlfc"
+          }
+        ],
+        "key.typename" : "CommandWrapper<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant14CommandWrapperVyxGmD",
+        "key.usr" : "s:10Commandant14CommandWrapperV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1859
+          }
+        ],
+        "key.bodylength" : 216,
+        "key.bodyoffset" : 1884,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Describes the \"mode\" in which a command should run.",
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.doclength" : 56,
+        "key.docoffset" : 1803,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 235,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1871,
+        "key.offset" : 1866,
+        "key.parsed_declaration" : "public enum CommandMode",
+        "key.parsed_scope.end" : 75,
+        "key.parsed_scope.start" : 68,
+        "key.substructure" : [
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 30,
+            "key.offset" : 1955,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case arguments(<Type usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Options should be parsed from the given command-line arguments.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"70\" column=\"7\"><Name>arguments(_:)<\/Name><USR>s:10Commandant11CommandModeO9argumentsyAcA14ArgumentParserCcACmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Options should be parsed from the given command-line arguments.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 70,
+                "key.doc.name" : "arguments(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 68,
+                "key.docoffset" : 1886,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.class usr=\"s:10Commandant14ArgumentParserC\">ArgumentParser<\/ref.class><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 25,
+                "key.line" : 70,
+                "key.modulename" : "Commandant",
+                "key.name" : "arguments(_:)",
+                "key.namelength" : 25,
+                "key.nameoffset" : 1960,
+                "key.offset" : 1960,
+                "key.parsed_declaration" : "case arguments(ArgumentParser)",
+                "key.parsed_scope.end" : 70,
+                "key.parsed_scope.start" : 70,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "(CommandMode.Type) -> (ArgumentParser) -> CommandMode",
+                "key.typeusr" : "$sy10Commandant11CommandModeOAA14ArgumentParserCcACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO9argumentsyAcA14ArgumentParserCcACmF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 10,
+            "key.offset" : 2089,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case usage<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "Each option should record its usage information in an error, for\npresentation to the user.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"74\" column=\"7\"><Name>usage<\/Name><USR>s:10Commandant11CommandModeO5usageyA2CmF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>Each option should record its usage information in an error, for presentation to the user.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 74,
+                "key.doc.name" : "usage",
+                "key.doc.type" : "Other",
+                "key.doclength" : 100,
+                "key.docoffset" : 1988,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usage<\/decl.name><\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 5,
+                "key.line" : 74,
+                "key.modulename" : "Commandant",
+                "key.name" : "usage",
+                "key.namelength" : 5,
+                "key.nameoffset" : 2094,
+                "key.offset" : 2094,
+                "key.parsed_declaration" : "case usage",
+                "key.parsed_scope.end" : 74,
+                "key.parsed_scope.start" : 74,
+                "key.typename" : "(CommandMode.Type) -> CommandMode",
+                "key.typeusr" : "$sy10Commandant11CommandModeOACmcD",
+                "key.usr" : "s:10Commandant11CommandModeO5usageyA2CmF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.final",
+            "key.length" : 5,
+            "key.offset" : 2163
+          },
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 2156
+          }
+        ],
+        "key.bodylength" : 1204,
+        "key.bodyoffset" : 2212,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.comment" : "Maintains the list of commands available to run.",
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"78\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 78,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.doclength" : 53,
+        "key.docoffset" : 2103,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.class",
+        "key.length" : 1248,
+        "key.line" : 78,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 2175,
+        "key.offset" : 2169,
+        "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error>",
+        "key.parsed_scope.end" : 116,
+        "key.parsed_scope.start" : 78,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 36,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 2204
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 78,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2191,
+            "key.offset" : 2191,
+            "key.parsed_declaration" : "public final class CommandRegistry<ClientError: Error",
+            "key.parsed_scope.end" : 78,
+            "key.parsed_scope.start" : 78,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant15CommandRegistryC11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private var commandsByVerb: [<Type usr=\"s:SS\">String<\/Type> : <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 2214
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commandsByVerb<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct> : <ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 63,
+            "key.line" : 79,
+            "key.modulename" : "Commandant",
+            "key.name" : "commandsByVerb",
+            "key.namelength" : 14,
+            "key.nameoffset" : 2226,
+            "key.offset" : 2222,
+            "key.parsed_declaration" : "private var commandsByVerb: [String: CommandWrapper<ClientError>] = [:]",
+            "key.parsed_scope.end" : 79,
+            "key.parsed_scope.start" : 79,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.private",
+            "key.typename" : "[String : CommandWrapper<ClientError>]",
+            "key.typeusr" : "$sSDySS10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC14commandsByVerb33_1DD6990CD6DFDE28F713A55F8EE2B70ELLSDySSAA0B7WrapperVyxGGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var commands: [<Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;] { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2317
+              }
+            ],
+            "key.bodylength" : 69,
+            "key.bodyoffset" : 2369,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "All available commands.",
+            "key.doc.declaration" : "public var commands: [CommandWrapper<ClientError>] { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"82\" column=\"13\"><Name>commands<\/Name><USR>s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGvp<\/USR><Declaration>public var commands: [CommandWrapper&lt;ClientError&gt;] { get }<\/Declaration><CommentParts><Abstract><Para>All available commands.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 82,
+            "key.doc.name" : "commands",
+            "key.doc.type" : "Other",
+            "key.doclength" : 28,
+            "key.docoffset" : 2288,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>commands<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;]<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 115,
+            "key.line" : 82,
+            "key.modulename" : "Commandant",
+            "key.name" : "commands",
+            "key.namelength" : 8,
+            "key.nameoffset" : 2328,
+            "key.offset" : 2324,
+            "key.parsed_declaration" : "public var commands: [CommandWrapper<ClientError>]",
+            "key.parsed_scope.end" : 84,
+            "key.parsed_scope.start" : 82,
+            "key.typename" : "[CommandWrapper<ClientError>]",
+            "key.typeusr" : "$sSay10Commandant14CommandWrapperVyxGGD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8commandsSayAA0B7WrapperVyxGGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2442
+              }
+            ],
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 2457,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 2449,
+            "key.offset" : 2449,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>.Type) -> () -> CommandRegistry<ClientError>",
+            "key.typeusr" : "$s10Commandant15CommandRegistryCyxGycD",
+            "key.usr" : "s:10Commandant15CommandRegistryCACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>@discardableResult public func register&lt;C&gt;(_ commands: <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type>...) -&gt; <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type> where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> == <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type>.<Type usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/Type>, <Type usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/Type> : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2656
+              },
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult",
+                "key.length" : 18,
+                "key.offset" : 2636
+              }
+            ],
+            "key.bodylength" : 106,
+            "key.bodyoffset" : 2775,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Registers the given commands, making those available to run.\n\nIf another commands were already registered with the same `verb`s, those\nwill be overwritten.",
+            "key.doc.declaration" : "@discardableResult\npublic func register<C>(_ commands: C...) -> CommandRegistry where ClientError == C.ClientError, C : Commandant.CommandProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If another commands were already registered with the same `verb`s, those will be overwritten."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"93\" column=\"14\"><Name>register(_:)<\/Name><USR>s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF<\/USR><Declaration>@discardableResult\npublic func register&lt;C&gt;(_ commands: C...) -&gt; CommandRegistry where ClientError == C.ClientError, C : Commandant.CommandProtocol<\/Declaration><CommentParts><Abstract><Para>Registers the given commands, making those available to run.<\/Para><\/Abstract><Discussion><Para>If another commands were already registered with the same <codeVoice>verb<\/codeVoice>s, those will be overwritten.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 93,
+            "key.doc.name" : "register(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 174,
+            "key.docoffset" : 2461,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>register<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\"><decl.generic_type_param.name>C<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>commands<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param>...<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class><\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:10Commandant15CommandProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp\">C<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 219,
+            "key.line" : 93,
+            "key.modulename" : "Commandant",
+            "key.name" : "register(_:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 2668,
+            "key.offset" : 2663,
+            "key.parsed_declaration" : "public func register<C: CommandProtocol>(_ commands: C...)\n\t-> CommandRegistry\n\twhere C.ClientError == ClientError",
+            "key.parsed_scope.end" : 101,
+            "key.parsed_scope.start" : 93,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>C : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type><\/Declaration>",
+                "key.column" : 23,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 15,
+                    "key.offset" : 2680
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>C<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "CommandProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 18,
+                "key.line" : 93,
+                "key.modulename" : "Commandant",
+                "key.name" : "C",
+                "key.namelength" : 1,
+                "key.nameoffset" : 2677,
+                "key.offset" : 2677,
+                "key.parsed_declaration" : "public func register<C: CommandProtocol",
+                "key.parsed_scope.end" : 93,
+                "key.parsed_scope.start" : 93,
+                "key.typename" : "C.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF1CL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<ClientError, C where ClientError == C.ClientError, C : CommandProtocol> (CommandRegistry<ClientError>) -> (C...) -> CommandRegistry<ClientError>",
+            "key.typeusr" : "$sy10Commandant15CommandRegistryCyxGqd__d_tc11ClientErrorQyd__RszAA0B8ProtocolRd__luD",
+            "key.usr" : "s:10Commandant15CommandRegistryC8registeryACyxGqd__d_t11ClientErrorQyd__RszAA0B8ProtocolRd__lF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(command verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3059
+              }
+            ],
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 3164,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Runs the command corresponding to the given verb, passing it the given\narguments.\n\nReturns the results of the execution, or nil if no such command exists.",
+            "key.doc.declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the results of the execution, or nil if no such command exists."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"107\" column=\"14\"><Name>run(command:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC3run7command9argumentss6ResultOyytAA0A5ErrorOyxGGSgSS_SaySSGtF<\/USR><Declaration>public func run(command verb: String, arguments: [String]) -&gt; Result&lt;(), CommandantError&lt;ClientError&gt;&gt;?<\/Declaration><CommentParts><Abstract><Para>Runs the command corresponding to the given verb, passing it the given arguments.<\/Para><\/Abstract><Discussion><Para>Returns the results of the execution, or nil if no such command exists.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 107,
+            "key.doc.name" : "run(command:arguments:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 173,
+            "key.docoffset" : 2885,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>command<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 153,
+            "key.line" : 107,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(command:arguments:)",
+            "key.namelength" : 46,
+            "key.nameoffset" : 3071,
+            "key.offset" : 3066,
+            "key.parsed_declaration" : "public func run(command verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.parsed_scope.end" : 109,
+            "key.parsed_scope.start" : 107,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, [String]) -> Result<(), CommandantError<ClientError>>?",
+            "key.typeusr" : "$s7command9argumentss6ResultOyyt10Commandant0D5ErrorOyxGGSgSS_SaySSGtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC3run7command9argumentss6ResultOyytAA0A5ErrorOyxGGSgSS_SaySSGtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public subscript(verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/Type>&lt;<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>&gt;? { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 3318
+              }
+            ],
+            "key.bodylength" : 32,
+            "key.bodyoffset" : 3382,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Returns the command matching the given verb, or nil if no such command\nis registered.",
+            "key.doc.declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>? { get }",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"113\" column=\"9\"><Name>subscript(_:)<\/Name><USR>s:10Commandant15CommandRegistryCyAA0B7WrapperVyxGSgSScip<\/USR><Declaration>public subscript(verb: String) -&gt; CommandWrapper&lt;ClientError&gt;? { get }<\/Declaration><CommentParts><Abstract><Para>Returns the command matching the given verb, or nil if no such command is registered.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 113,
+            "key.doc.name" : "subscript(_:)",
+            "key.doc.type" : "Other",
+            "key.doclength" : 95,
+            "key.docoffset" : 3222,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant14CommandWrapperV\">CommandWrapper<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;?<\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
+            "key.kind" : "source.lang.swift.decl.function.subscript",
+            "key.length" : 90,
+            "key.line" : 113,
+            "key.modulename" : "Commandant",
+            "key.name" : "subscript(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 3325,
+            "key.offset" : 3325,
+            "key.parsed_declaration" : "public subscript(verb: String) -> CommandWrapper<ClientError>?",
+            "key.parsed_scope.end" : 115,
+            "key.parsed_scope.start" : 113,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (String) -> CommandWrapper<ClientError>?",
+            "key.typeusr" : "$sy10Commandant14CommandWrapperVyxGSgSScD",
+            "key.usr" : "s:10Commandant15CommandRegistryCyAA0B7WrapperVyxGSgSScip"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public final class CommandRegistry&lt;ClientError&gt; where <Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 4074,
+        "key.bodyoffset" : 3446,
+        "key.column" : 20,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 20,
+        "key.doc.declaration" : "public final class CommandRegistry<ClientError> where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"78\" column=\"20\"><Name>CommandRegistry<\/Name><USR>s:10Commandant15CommandRegistryC<\/USR><Declaration>public final class CommandRegistry&lt;ClientError&gt; where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>Maintains the list of commands available to run.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 78,
+        "key.doc.name" : "CommandRegistry",
+        "key.doc.type" : "Class",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.class><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>final<\/syntaxtype.keyword> <syntaxtype.keyword>class<\/syntaxtype.keyword> <decl.name>CommandRegistry<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.class>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 4102,
+        "key.line" : 78,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandRegistry",
+        "key.namelength" : 15,
+        "key.nameoffset" : 3429,
+        "key.offset" : 3419,
+        "key.parsed_declaration" : "extension CommandRegistry",
+        "key.parsed_scope.end" : 241,
+        "key.parsed_scope.start" : 118,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; <Type usr=\"s:s4Voida\">Void<\/Type>) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 4246
+              }
+            ],
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 4332,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing CommandLine.arguments\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"136\" column=\"14\"><Name>main(defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF<\/USR><Declaration>public func main(defaultVerb: String, errorHandler: (ClientError) -&gt; Void) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing CommandLine.arguments and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 136,
+            "key.doc.name" : "main(defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 797,
+            "key.docoffset" : 3448,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void<\/ref.typealias><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 177,
+            "key.line" : 136,
+            "key.modulename" : "Commandant",
+            "key.name" : "main(defaultVerb:errorHandler:)",
+            "key.namelength" : 62,
+            "key.nameoffset" : 4258,
+            "key.offset" : 4253,
+            "key.parsed_declaration" : "public func main(defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.parsed_scope.end" : 138,
+            "key.parsed_scope.start" : 136,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF\">main(arguments:defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "$s11defaultVerb12errorHandlers5NeverOSS_yxXEtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func main(arguments: [<Type usr=\"s:SS\">String<\/Type>], defaultVerb: <Type usr=\"s:SS\">String<\/Type>, errorHandler: (<Type usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/Type>) -&gt; <Type usr=\"s:s4Voida\">Void<\/Type>) -&gt; <Type usr=\"s:s5NeverO\">Never<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 5221
+              }
+            ],
+            "key.bodylength" : 945,
+            "key.bodyoffset" : 5328,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Hands off execution to the CommandRegistry, by parsing `arguments`\nand then running whichever command has been identified in the argument\nlist.\n\nIf the chosen command executes successfully, the process will exit with\na successful exit code.\n\nIf the chosen command fails, the provided error handler will be invoked,\nthen the process will exit with a failure exit code.\n\nIf a matching command could not be found but there is any `executable-verb`\nstyle subcommand executable in the caller's `$PATH`, the subcommand will\nbe executed.\n\nIf a matching command could not be found or a usage error occurred,\na helpful error message will be written to `stderr`, then the process\nwill exit with a failure error code.",
+            "key.doc.declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the chosen command executes successfully, the process will exit with a successful exit code."
+              },
+              {
+                "Para" : "If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code."
+              },
+              {
+                "Para" : "If a matching command could not be found but there is any `executable-verb` style subcommand executable in the caller’s `$PATH`, the subcommand will be executed."
+              },
+              {
+                "Para" : "If a matching command could not be found or a usage error occurred, a helpful error message will be written to `stderr`, then the process will exit with a failure error code."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"157\" column=\"14\"><Name>main(arguments:defaultVerb:errorHandler:)<\/Name><USR>s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF<\/USR><Declaration>public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -&gt; Void) -&gt; Never<\/Declaration><CommentParts><Abstract><Para>Hands off execution to the CommandRegistry, by parsing <codeVoice>arguments<\/codeVoice> and then running whichever command has been identified in the argument list.<\/Para><\/Abstract><Discussion><Para>If the chosen command executes successfully, the process will exit with a successful exit code.<\/Para><Para>If the chosen command fails, the provided error handler will be invoked, then the process will exit with a failure exit code.<\/Para><Para>If a matching command could not be found but there is any <codeVoice>executable-verb<\/codeVoice> style subcommand executable in the caller’s <codeVoice>$PATH<\/codeVoice>, the subcommand will be executed.<\/Para><Para>If a matching command could not be found or a usage error occurred, a helpful error message will be written to <codeVoice>stderr<\/codeVoice>, then the process will exit with a failure error code.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 157,
+            "key.doc.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 787,
+            "key.docoffset" : 4433,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>main<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultVerb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>errorHandler<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant15CommandRegistryC11ClientErrorxmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void<\/ref.typealias><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never<\/ref.enum><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 1046,
+            "key.line" : 157,
+            "key.modulename" : "Commandant",
+            "key.name" : "main(arguments:defaultVerb:errorHandler:)",
+            "key.namelength" : 83,
+            "key.nameoffset" : 5233,
+            "key.offset" : 5228,
+            "key.parsed_declaration" : "public func main(arguments: [String], defaultVerb: String, errorHandler: (ClientError) -> Void) -> Never",
+            "key.parsed_scope.end" : 196,
+            "key.parsed_scope.start" : 157,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant15CommandRegistryC4main11defaultVerb12errorHandlers5NeverOSS_yxXEtF\">main(defaultVerb:errorHandler:)<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>var arguments: [<Type usr=\"s:SS\">String<\/Type>]<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>arguments<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 25,
+                "key.line" : 160,
+                "key.modulename" : "Commandant",
+                "key.name" : "arguments",
+                "key.namelength" : 9,
+                "key.nameoffset" : 5367,
+                "key.offset" : 5363,
+                "key.parsed_declaration" : "var arguments = arguments",
+                "key.parsed_scope.end" : 160,
+                "key.parsed_scope.start" : 160,
+                "key.typename" : "[String]",
+                "key.typeusr" : "$sSaySSGD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtFAEL0_AJvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let executableName: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>executableName<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 44,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "executableName",
+                "key.namelength" : 14,
+                "key.nameoffset" : 5430,
+                "key.offset" : 5426,
+                "key.parsed_declaration" : "let executableName = arguments.remove(at: 0)",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF14executableNameL_SSvp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>var verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 22,
+                "key.line" : 166,
+                "key.modulename" : "Commandant",
+                "key.name" : "verb",
+                "key.namelength" : 4,
+                "key.nameoffset" : 5536,
+                "key.offset" : 5532,
+                "key.parsed_declaration" : "var verb = defaultVerb",
+                "key.parsed_scope.end" : 166,
+                "key.parsed_scope.start" : 166,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF4verbL_SSvp"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> ([String], String, (ClientError) -> ()) -> Never",
+            "key.typeusr" : "$s9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC4main9arguments11defaultVerb12errorHandlers5NeverOSaySSG_SSyxXEtF"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private func executeSubcommandIfExists(_ executableName: <Type usr=\"s:SS\">String<\/Type>, verb: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 6474
+              }
+            ],
+            "key.bodylength" : 933,
+            "key.bodyoffset" : 6585,
+            "key.column" : 15,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 15,
+            "key.doc.comment" : "Finds and executes a subcommand which exists in your $PATH. The executable\nname must be in the form of `executable-verb`.\n\n- Returns: The exit status of found subcommand or nil.",
+            "key.doc.declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"202\" column=\"15\"><Name>executeSubcommandIfExists(_:verb:arguments:)<\/Name><USR>s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF<\/USR><Declaration>private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -&gt; Int32?<\/Declaration><CommentParts><Abstract><Para>Finds and executes a subcommand which exists in your $PATH. The executable name must be in the form of <codeVoice>executable-verb<\/codeVoice>.<\/Para><\/Abstract><ResultDiscussion><Para>The exit status of found subcommand or nil.<\/Para><\/ResultDiscussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 202,
+            "key.doc.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The exit status of found subcommand or nil."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.doclength" : 196,
+            "key.docoffset" : 6277,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>executeSubcommandIfExists<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>executableName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 1037,
+            "key.line" : 202,
+            "key.modulename" : "Commandant",
+            "key.name" : "executeSubcommandIfExists(_:verb:arguments:)",
+            "key.namelength" : 86,
+            "key.nameoffset" : 6487,
+            "key.offset" : 6482,
+            "key.parsed_declaration" : "private func executeSubcommandIfExists(_ executableName: String, verb: String, arguments: [String]) -> Int32?",
+            "key.parsed_scope.end" : 240,
+            "key.parsed_scope.start" : 202,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let subcommand: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>subcommand<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 80,
+                "key.line" : 203,
+                "key.modulename" : "Commandant",
+                "key.name" : "subcommand",
+                "key.namelength" : 10,
+                "key.nameoffset" : 6592,
+                "key.offset" : 6588,
+                "key.parsed_declaration" : "let subcommand = \"\\(NSString(string: executableName).lastPathComponent)-\\(verb)\"",
+                "key.parsed_scope.end" : 203,
+                "key.parsed_scope.start" : 203,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10subcommandL_SSvp"
+              },
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.private",
+                "key.annotated_decl" : "<Declaration>func launchTask(_ path: <Type usr=\"s:SS\">String<\/Type>, arguments: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:s5Int32V\">Int32<\/Type><\/Declaration>",
+                "key.bodylength" : 603,
+                "key.bodyoffset" : 6735,
+                "key.column" : 8,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>launchTask<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>path<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>arguments<\/decl.var.parameter.argument_label>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32<\/ref.struct><\/decl.function.returntype><\/decl.function.free>",
+                "key.kind" : "source.lang.swift.decl.function.free",
+                "key.length" : 667,
+                "key.line" : 205,
+                "key.modulename" : "Commandant",
+                "key.name" : "launchTask(_:arguments:)",
+                "key.namelength" : 47,
+                "key.nameoffset" : 6677,
+                "key.offset" : 6672,
+                "key.parsed_declaration" : "func launchTask(_ path: String, arguments: [String]) -> Int32",
+                "key.parsed_scope.end" : 233,
+                "key.parsed_scope.start" : 205,
+                "key.substructure" : [
+                  {
+                    "key.annotated_decl" : "<Declaration>let task: <Type usr=\"c:objc(cs)NSTask\">Process<\/Type><\/Declaration>",
+                    "key.column" : 8,
+                    "key.decl_lang" : "source.lang.swift",
+                    "key.filepath" : "",
+                    "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>task<\/decl.name>: <decl.var.type><ref.class usr=\"c:objc(cs)NSTask\">Process<\/ref.class><\/decl.var.type><\/decl.var.local>",
+                    "key.kind" : "source.lang.swift.decl.var.local",
+                    "key.length" : 20,
+                    "key.line" : 206,
+                    "key.modulename" : "Commandant",
+                    "key.name" : "task",
+                    "key.namelength" : 4,
+                    "key.nameoffset" : 6743,
+                    "key.offset" : 6739,
+                    "key.parsed_declaration" : "let task = Process()",
+                    "key.parsed_scope.end" : 206,
+                    "key.parsed_scope.start" : 206,
+                    "key.typename" : "Process",
+                    "key.typeusr" : "$sSo6NSTaskCD",
+                    "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10launchTaskL__AgISS_AKts5ErrorRzlF4taskL_So6NSTaskCvp"
+                  }
+                ],
+                "key.typename" : "<ClientError where ClientError : Error> (String, arguments: [String]) -> Int32",
+                "key.typeusr" : "$s_9argumentss5Int32VSS_SaySSGtcs5ErrorRzluD",
+                "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF10launchTaskL__AgISS_AKts5ErrorRzlF"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (CommandRegistry<ClientError>) -> (String, String, [String]) -> Int32?",
+            "key.typeusr" : "$s_4verb9argumentss5Int32VSgSS_SSSaySSGtcD",
+            "key.usr" : "s:10Commandant15CommandRegistryC25executeSubcommandIfExists33_1DD6990CD6DFDE28F713A55F8EE2B70ELL_4verb9argumentss5Int32VSgSS_SSSaySSGtF"
+          }
+        ],
+        "key.typename" : "CommandRegistry<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant15CommandRegistryCyxGmD",
+        "key.usr" : "s:10Commandant15CommandRegistryC"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Errors.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 5739,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public enum CommandantError&lt;ClientError&gt; : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 323
+          }
+        ],
+        "key.bodylength" : 157,
+        "key.bodyoffset" : 372,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Possible errors that can originate from Commandant.\n\n`ClientError` should be the type of error (if any) that can occur when\nrunning commands.",
+        "key.doc.declaration" : "public enum CommandantError<ClientError> : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "`ClientError` should be the type of error (if any) that can occur when running commands."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"15\" column=\"13\"><Name>CommandantError<\/Name><USR>s:10Commandant0A5ErrorO<\/USR><Declaration>public enum CommandantError&lt;ClientError&gt; : Error<\/Declaration><CommentParts><Abstract><Para>Possible errors that can originate from Commandant.<\/Para><\/Abstract><Discussion><Para><codeVoice>ClientError<\/codeVoice> should be the type of error (if any) that can occur when running commands.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+        "key.doc.line" : 15,
+        "key.doc.name" : "CommandantError",
+        "key.doc.type" : "Other",
+        "key.doclength" : 157,
+        "key.docoffset" : 166,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 5,
+            "key.offset" : 365
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandantError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Error"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.enum",
+        "key.length" : 200,
+        "key.line" : 15,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandantError",
+        "key.namelength" : 15,
+        "key.nameoffset" : 335,
+        "key.offset" : 330,
+        "key.parsed_declaration" : "public enum CommandantError<ClientError>: Error",
+        "key.parsed_scope.end" : 21,
+        "key.parsed_scope.start" : 15,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 29,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 15,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 351,
+            "key.offset" : 351,
+            "key.parsed_declaration" : "public enum CommandantError<ClientError",
+            "key.parsed_scope.end" : 15,
+            "key.parsed_scope.start" : 15,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant0A5ErrorO06ClientB0xmfp"
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 36,
+            "key.offset" : 411,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case usageError(description: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "An option was used incorrectly.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"17\" column=\"7\"><Name>usageError(description:)<\/Name><USR>s:10Commandant0A5ErrorO05usageB0yACyxGSS_tcAEmlF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>An option was used incorrectly.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 17,
+                "key.doc.name" : "usageError(description:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 36,
+                "key.docoffset" : 374,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>usageError<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>description<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 31,
+                "key.line" : 17,
+                "key.modulename" : "Commandant",
+                "key.name" : "usageError(description:)",
+                "key.namelength" : 31,
+                "key.nameoffset" : 416,
+                "key.offset" : 416,
+                "key.parsed_declaration" : "case usageError(description: String)",
+                "key.parsed_scope.end" : 17,
+                "key.parsed_scope.start" : 17,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "<ClientError> (CommandantError<ClientError>.Type) -> (String) -> CommandantError<ClientError>",
+                "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSS_tcADmcluD",
+                "key.usr" : "s:10Commandant0A5ErrorO05usageB0yACyxGSS_tcAEmlF"
+              }
+            ]
+          },
+          {
+            "key.kind" : "source.lang.swift.decl.enumcase",
+            "key.length" : 30,
+            "key.offset" : 498,
+            "key.substructure" : [
+              {
+                "key.accessibility" : "source.lang.swift.accessibility.public",
+                "key.annotated_decl" : "<Declaration>case commandError(<Type usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\">ClientError<\/Type>)<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.doc.column" : 7,
+                "key.doc.comment" : "An error occurred while running a command.",
+                "key.doc.declaration" : "",
+                "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+                "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"20\" column=\"7\"><Name>commandError(_:)<\/Name><USR>s:10Commandant0A5ErrorO07commandB0yACyxGxcAEmlF<\/USR><Declaration><\/Declaration><CommentParts><Abstract><Para>An error occurred while running a command.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+                "key.doc.line" : 20,
+                "key.doc.name" : "commandError(_:)",
+                "key.doc.type" : "Other",
+                "key.doclength" : 47,
+                "key.docoffset" : 450,
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.enumelement><syntaxtype.keyword>case<\/syntaxtype.keyword> <decl.name>commandError<\/decl.name>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\">ClientError<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.enumelement>",
+                "key.kind" : "source.lang.swift.decl.enumelement",
+                "key.length" : 25,
+                "key.line" : 20,
+                "key.modulename" : "Commandant",
+                "key.name" : "commandError(_:)",
+                "key.namelength" : 25,
+                "key.nameoffset" : 503,
+                "key.offset" : 503,
+                "key.parsed_declaration" : "case commandError(ClientError)",
+                "key.parsed_scope.end" : 20,
+                "key.parsed_scope.start" : 20,
+                "key.substructure" : [
+
+                ],
+                "key.typename" : "<ClientError> (CommandantError<ClientError>.Type) -> (ClientError) -> CommandantError<ClientError>",
+                "key.typeusr" : "$sy10Commandant0A5ErrorOyxGxcADmcluD",
+                "key.usr" : "s:10Commandant0A5ErrorO07commandB0yACyxGxcAEmlF"
+              }
+            ]
+          }
+        ],
+        "key.typename" : "CommandantError<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant0A5ErrorOyxGmD",
+        "key.usr" : "s:10Commandant0A5ErrorO"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandantError&lt;ClientError&gt; : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.bodylength" : 187,
+        "key.bodyoffset" : 584,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandantError<ClientError> : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "`ClientError` should be the type of error (if any) that can occur when running commands."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"15\" column=\"13\"><Name>CommandantError<\/Name><USR>s:10Commandant0A5ErrorO<\/USR><Declaration>public enum CommandantError&lt;ClientError&gt; : Error<\/Declaration><CommentParts><Abstract><Para>Possible errors that can originate from Commandant.<\/Para><\/Abstract><Discussion><Para><codeVoice>ClientError<\/codeVoice> should be the type of error (if any) that can occur when running commands.<\/Para><\/Discussion><\/CommentParts><\/Other>",
+        "key.doc.line" : 15,
+        "key.doc.name" : "CommandantError",
+        "key.doc.type" : "Other",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 559
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandantError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant0A5ErrorO06ClientB0xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.enum>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 240,
+        "key.line" : 15,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandantError",
+        "key.namelength" : 15,
+        "key.nameoffset" : 542,
+        "key.offset" : 532,
+        "key.parsed_declaration" : "extension CommandantError: CustomStringConvertible",
+        "key.parsed_scope.end" : 33,
+        "key.parsed_scope.start" : 23,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 586
+              }
+            ],
+            "key.bodylength" : 151,
+            "key.bodyoffset" : 618,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 177,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 597,
+            "key.offset" : 593,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "CommandantError<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant0A5ErrorOyxGmD",
+        "key.usr" : "s:10Commandant0A5ErrorO"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func missingArgumentError&lt;ClientError&gt;(_ argumentName: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 887
+          }
+        ],
+        "key.bodylength" : 105,
+        "key.bodyoffset" : 992,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an `InvalidArgument` error that indicates a missing value for\nthe argument by the given name.",
+        "key.doc.declaration" : "internal func missingArgumentError<ClientError>(_ argumentName: String) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"37\" column=\"15\"><Name>missingArgumentError(_:)<\/Name><USR>s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF<\/USR><Declaration>internal func missingArgumentError&lt;ClientError&gt;(_ argumentName: String) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an <codeVoice>InvalidArgument<\/codeVoice> error that indicates a missing value for the argument by the given name.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 37,
+        "key.doc.name" : "missingArgumentError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 113,
+        "key.docoffset" : 774,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>missingArgumentError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argumentName<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 202,
+        "key.line" : 37,
+        "key.modulename" : "Commandant",
+        "key.name" : "missingArgumentError(_:)",
+        "key.namelength" : 57,
+        "key.nameoffset" : 901,
+        "key.offset" : 896,
+        "key.parsed_declaration" : "internal func missingArgumentError<ClientError>(_ argumentName: String) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 40,
+        "key.parsed_scope.start" : 37,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 36,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 37,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 922,
+            "key.offset" : 922,
+            "key.parsed_declaration" : "internal func missingArgumentError<ClientError",
+            "key.parsed_scope.end" : 37,
+            "key.parsed_scope.start" : 37,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let description: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 56,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 998,
+            "key.offset" : 994,
+            "key.parsed_declaration" : "let description = \"Missing argument for \\(argumentName)\"",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF11descriptionL_SSvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (String) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSScluD",
+        "key.usr" : "s:10Commandant20missingArgumentErroryAA0aD0OyxGSSlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ keyValueExample: <Type usr=\"s:SS\">String<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 1215
+          }
+        ],
+        "key.bodylength" : 179,
+        "key.bodyoffset" : 1339,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error by combining the example of key (and value, if applicable)\nwith the usage description.",
+        "key.doc.declaration" : "internal func informativeUsageError<ClientError>(_ keyValueExample: String, usage: String) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"44\" column=\"15\"><Name>informativeUsageError(_:usage:)<\/Name><USR>s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF<\/USR><Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ keyValueExample: String, usage: String) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error by combining the example of key (and value, if applicable) with the usage description.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 44,
+        "key.doc.name" : "informativeUsageError(_:usage:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 115,
+        "key.docoffset" : 1100,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>keyValueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 295,
+        "key.line" : 44,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:usage:)",
+        "key.namelength" : 76,
+        "key.nameoffset" : 1229,
+        "key.offset" : 1224,
+        "key.parsed_declaration" : "internal func informativeUsageError<ClientError>(_ keyValueExample: String, usage: String) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 50,
+        "key.parsed_scope.start" : 44,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 44,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1251,
+            "key.offset" : 1251,
+            "key.parsed_declaration" : "internal func informativeUsageError<ClientError",
+            "key.parsed_scope.end" : 44,
+            "key.parsed_scope.start" : 44,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let lines: [<Type usr=\"s:SS\">String<\/Type>]<\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>lines<\/decl.name>: <decl.var.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 52,
+            "key.line" : 45,
+            "key.modulename" : "Commandant",
+            "key.name" : "lines",
+            "key.namelength" : 5,
+            "key.nameoffset" : 1345,
+            "key.offset" : 1341,
+            "key.parsed_declaration" : "let lines = usage.components(separatedBy: .newlines)",
+            "key.parsed_scope.end" : 45,
+            "key.parsed_scope.start" : 45,
+            "key.typename" : "[String]",
+            "key.typeusr" : "$sSaySSGD",
+            "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF5linesL_SaySSGvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (String, usage: String) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_5usage10Commandant0B5ErrorOyxGSS_SStcluD",
+        "key.usr" : "s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func combineUsageErrors&lt;ClientError&gt;(_ lhs: <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;, _ rhs: <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 1660
+          }
+        ],
+        "key.bodylength" : 265,
+        "key.bodyoffset" : 1813,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Combines the text of the two errors, if they're both `UsageError`s.\nOtherwise, uses whichever one is not (biased toward the left).",
+        "key.doc.declaration" : "internal func combineUsageErrors<ClientError>(_ lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"54\" column=\"15\"><Name>combineUsageErrors(_:_:)<\/Name><USR>s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF<\/USR><Declaration>internal func combineUsageErrors&lt;ClientError&gt;(_ lhs: CommandantError&lt;ClientError&gt;, _ rhs: CommandantError&lt;ClientError&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Combines the text of the two errors, if they’re both <codeVoice>UsageError<\/codeVoice>s. Otherwise, uses whichever one is not (biased toward the left).<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 54,
+        "key.doc.name" : "combineUsageErrors(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 139,
+        "key.docoffset" : 1521,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>combineUsageErrors<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>lhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>rhs<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 410,
+        "key.line" : 54,
+        "key.modulename" : "Commandant",
+        "key.name" : "combineUsageErrors(_:_:)",
+        "key.namelength" : 105,
+        "key.nameoffset" : 1674,
+        "key.offset" : 1669,
+        "key.parsed_declaration" : "internal func combineUsageErrors<ClientError>(_ lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 66,
+        "key.parsed_scope.start" : 54,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 34,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 54,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1693,
+            "key.offset" : 1693,
+            "key.parsed_declaration" : "internal func combineUsageErrors<ClientError",
+            "key.parsed_scope.end" : 54,
+            "key.parsed_scope.start" : 54,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF06ClientE0L_xmfp"
+          }
+        ],
+        "key.typename" : "<ClientError> (CommandantError<ClientError>, CommandantError<ClientError>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGAD_ADtcluD",
+        "key.usr" : "s:10Commandant18combineUsageErrorsyAA0A5ErrorOyxGAE_AEtlF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func unrecognizedArgumentsError&lt;ClientError&gt;(_ options: [<Type usr=\"s:SS\">String<\/Type>]) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2152
+          }
+        ],
+        "key.bodylength" : 96,
+        "key.bodyoffset" : 2260,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that indicates unrecognized arguments remains.",
+        "key.doc.declaration" : "internal func unrecognizedArgumentsError<ClientError>(_ options: [String]) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"69\" column=\"15\"><Name>unrecognizedArgumentsError(_:)<\/Name><USR>s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF<\/USR><Declaration>internal func unrecognizedArgumentsError&lt;ClientError&gt;(_ options: [String]) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that indicates unrecognized arguments remains.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 69,
+        "key.doc.name" : "unrecognizedArgumentsError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 71,
+        "key.docoffset" : 2081,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>unrecognizedArgumentsError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type>[<ref.struct usr=\"s:SS\">String<\/ref.struct>]<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 196,
+        "key.line" : 69,
+        "key.modulename" : "Commandant",
+        "key.name" : "unrecognizedArgumentsError(_:)",
+        "key.namelength" : 60,
+        "key.nameoffset" : 2166,
+        "key.offset" : 2161,
+        "key.parsed_declaration" : "internal func unrecognizedArgumentsError<ClientError>(_ options: [String]) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 71,
+        "key.parsed_scope.start" : 69,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 42,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 69,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2193,
+            "key.offset" : 2193,
+            "key.parsed_declaration" : "internal func unrecognizedArgumentsError<ClientError",
+            "key.parsed_scope.end" : 69,
+            "key.parsed_scope.start" : 69,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF06ClientD0L_xmfp"
+          }
+        ],
+        "key.typename" : "<ClientError> ([String]) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGSaySSGcluD",
+        "key.usr" : "s:10Commandant26unrecognizedArgumentsErroryAA0aD0OyxGSaySSGlF"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 14,
+        "key.name" : "MARK: Argument",
+        "key.offset" : 2362
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ valueExample: <Type usr=\"s:SS\">String<\/Type>, argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2499
+          }
+        ],
+        "key.bodylength" : 192,
+        "key.bodyoffset" : 2631,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument, with the given\nexample of value usage if applicable.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ valueExample: String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"77\" column=\"15\"><Name>informativeUsageError(_:argument:)<\/Name><USR>s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ valueExample: String, argument: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument, with the given example of value usage if applicable.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 77,
+        "key.doc.name" : "informativeUsageError(_:argument:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 121,
+        "key.docoffset" : 2378,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>valueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>argument<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 316,
+        "key.line" : 77,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:argument:)",
+        "key.namelength" : 84,
+        "key.nameoffset" : 2513,
+        "key.offset" : 2508,
+        "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError>(_ valueExample: String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 83,
+        "key.parsed_scope.start" : 77,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 77,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2535,
+            "key.offset" : 2535,
+            "key.parsed_declaration" : "internal func informativeUsageError<T",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 77,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 40,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 77,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2538,
+            "key.offset" : 2538,
+            "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 77,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError> (String, argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_8argument10Commandant0B5ErrorOyq_GSS_AB8ArgumentVyxGtcr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 2890
+          }
+        ],
+        "key.bodylength" : 378,
+        "key.bodyoffset" : 3018,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ argument: Argument<T>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"86\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 86,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 64,
+        "key.docoffset" : 2826,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 498,
+        "key.line" : 86,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 80,
+        "key.nameoffset" : 2904,
+        "key.offset" : 2899,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ argument: Argument<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 103,
+        "key.parsed_scope.start" : 86,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 2929
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2926,
+            "key.offset" : 2926,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 86,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2947,
+            "key.offset" : 2947,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 86,
+            "key.parsed_scope.start" : 86,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var example: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>example<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 16,
+            "key.line" : 87,
+            "key.modulename" : "Commandant",
+            "key.name" : "example",
+            "key.namelength" : 7,
+            "key.nameoffset" : 3024,
+            "key.offset" : 3020,
+            "key.parsed_declaration" : "var example = \"\"",
+            "key.parsed_scope.end" : 87,
+            "key.parsed_scope.start" : 87,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF7exampleL_SSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var valueExample: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>valueExample<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 21,
+            "key.line" : 89,
+            "key.modulename" : "Commandant",
+            "key.name" : "valueExample",
+            "key.namelength" : 12,
+            "key.nameoffset" : 3043,
+            "key.offset" : 3039,
+            "key.parsed_declaration" : "var valueExample = \"\"",
+            "key.parsed_scope.end" : 89,
+            "key.parsed_scope.start" : 89,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF12valueExampleL_SSvp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Argument<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA8ArgumentVyxGcAA0C8ProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: <Type usr=\"s:10Commandant8ArgumentV\">Argument<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 3468
+          }
+        ],
+        "key.bodylength" : 378,
+        "key.bodyoffset" : 3598,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the argument list.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ argument: Argument<[T]>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"106\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ argument: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the argument list.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 106,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 69,
+        "key.docoffset" : 3399,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>argument<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant8ArgumentV\">Argument<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 500,
+        "key.line" : 106,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 82,
+        "key.nameoffset" : 3482,
+        "key.offset" : 3477,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ argument: Argument<[T]>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 123,
+        "key.parsed_scope.start" : 106,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 3507
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 3504,
+            "key.offset" : 3504,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 106,
+            "key.parsed_scope.start" : 106,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 106,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 3525,
+            "key.offset" : 3525,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 106,
+            "key.parsed_scope.start" : 106,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF06ClientD0L_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var example: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>example<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 16,
+            "key.line" : 107,
+            "key.modulename" : "Commandant",
+            "key.name" : "example",
+            "key.namelength" : 7,
+            "key.nameoffset" : 3604,
+            "key.offset" : 3600,
+            "key.parsed_declaration" : "var example = \"\"",
+            "key.parsed_scope.end" : 107,
+            "key.parsed_scope.start" : 107,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF7exampleL_SSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var valueExample: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>valueExample<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 21,
+            "key.line" : 109,
+            "key.modulename" : "Commandant",
+            "key.name" : "valueExample",
+            "key.namelength" : 12,
+            "key.nameoffset" : 3623,
+            "key.offset" : 3619,
+            "key.parsed_declaration" : "var valueExample = \"\"",
+            "key.parsed_scope.end" : 109,
+            "key.parsed_scope.start" : 109,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF12valueExampleL_SSvp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Argument<[T]>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA8ArgumentVySayxGGcAA0C8ProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 12,
+        "key.name" : "MARK: Option",
+        "key.offset" : 3982
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ keyValueExample: <Type usr=\"s:SS\">String<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4126
+          }
+        ],
+        "key.bodylength" : 76,
+        "key.bodyoffset" : 4257,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option, with the given\nexample of key (and value, if applicable) usage.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ keyValueExample: String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"129\" column=\"15\"><Name>informativeUsageError(_:option:)<\/Name><USR>s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ keyValueExample: String, option: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option, with the given example of key (and value, if applicable) usage.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 129,
+        "key.doc.name" : "informativeUsageError(_:option:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 130,
+        "key.docoffset" : 3996,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>keyValueExample<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>option<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 199,
+        "key.line" : 129,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:option:)",
+        "key.namelength" : 83,
+        "key.nameoffset" : 4140,
+        "key.offset" : 4135,
+        "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError>(_ keyValueExample: String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 131,
+        "key.parsed_scope.start" : 129,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 129,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4162,
+            "key.offset" : 4162,
+            "key.parsed_declaration" : "internal func informativeUsageError<T",
+            "key.parsed_scope.end" : 129,
+            "key.parsed_scope.start" : 129,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 40,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 129,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4165,
+            "key.offset" : 4165,
+            "key.parsed_declaration" : "internal func informativeUsageError<T, ClientError",
+            "key.parsed_scope.end" : 129,
+            "key.parsed_scope.start" : 129,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError> (String, option: Option<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$s_6option10Commandant0B5ErrorOyq_GSS_AB6OptionVyxGtcr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4398
+          }
+        ],
+        "key.bodylength" : 89,
+        "key.bodyoffset" : 4522,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<T>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"134\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 134,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4336,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 205,
+        "key.line" : 134,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 76,
+        "key.nameoffset" : 4412,
+        "key.offset" : 4407,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<T>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 136,
+        "key.parsed_scope.start" : 134,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4437
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 134,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4434,
+            "key.offset" : 4434,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 134,
+            "key.parsed_scope.start" : 134,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 134,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4455,
+            "key.offset" : 4455,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 134,
+            "key.parsed_scope.start" : 134,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<T>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVyxGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4676
+          }
+        ],
+        "key.bodylength" : 78,
+        "key.bodyoffset" : 4801,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<T?>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"139\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 139,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4614,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 195,
+        "key.line" : 139,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 77,
+        "key.nameoffset" : 4690,
+        "key.offset" : 4685,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<T?>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 141,
+        "key.parsed_scope.start" : 139,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4715
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 139,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4712,
+            "key.offset" : 4712,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 139,
+            "key.parsed_scope.start" : 139,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 139,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4733,
+            "key.offset" : 4733,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 139,
+            "key.parsed_scope.start" : 139,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<T?>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVyxSgGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 4944
+          }
+        ],
+        "key.bodylength" : 91,
+        "key.bodyoffset" : 5070,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<[T]>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"144\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 144,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 4882,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 209,
+        "key.line" : 144,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 78,
+        "key.nameoffset" : 4958,
+        "key.offset" : 4953,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<[T]>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 146,
+        "key.parsed_scope.start" : 144,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 4983
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 144,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4980,
+            "key.offset" : 4980,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 144,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 144,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5001,
+            "key.offset" : 5001,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 144,
+            "key.parsed_scope.start" : 144,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<[T]>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVySayxGGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/Type>&gt; where <Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 5226
+          }
+        ],
+        "key.bodylength" : 78,
+        "key.bodyoffset" : 5353,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the option.",
+        "key.doc.declaration" : "internal func informativeUsageError<T, ClientError>(_ option: Option<[T]?>) -> CommandantError<ClientError> where T : Commandant.ArgumentProtocol",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"149\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF<\/USR><Declaration>internal func informativeUsageError&lt;T, ClientError&gt;(_ option: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 149,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 62,
+        "key.docoffset" : 5164,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 197,
+        "key.line" : 149,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 79,
+        "key.nameoffset" : 5240,
+        "key.offset" : 5235,
+        "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError>(_ option: Option<[T]?>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 151,
+        "key.parsed_scope.start" : 149,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF\">informativeUsageError&lt;ClientError&gt;(_: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 16,
+                "key.offset" : 5265
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "ArgumentProtocol"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 19,
+            "key.line" : 149,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 5262,
+            "key.offset" : 5262,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol",
+            "key.parsed_scope.end" : 149,
+            "key.parsed_scope.start" : 149,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 58,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 149,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5283,
+            "key.offset" : 5283,
+            "key.parsed_declaration" : "internal func informativeUsageError<T: ArgumentProtocol, ClientError",
+            "key.parsed_scope.end" : 149,
+            "key.parsed_scope.start" : 149,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF06ClientD0L_q_mfp"
+          }
+        ],
+        "key.typename" : "<T, ClientError where T : ArgumentProtocol> (Option<[T]?>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyq_GAA6OptionVySayxGSgGcAA16ArgumentProtocolRzr0_luD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 5510
+          }
+        ],
+        "key.bodylength" : 121,
+        "key.bodyoffset" : 5616,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Constructs an error that describes how to use the given boolean option.",
+        "key.doc.declaration" : "internal func informativeUsageError<ClientError>(_ option: Option<Bool>) -> CommandantError<ClientError>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Errors.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Errors.swift\" line=\"154\" column=\"15\"><Name>informativeUsageError(_:)<\/Name><USR>s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF<\/USR><Declaration>internal func informativeUsageError&lt;ClientError&gt;(_ option: Option&lt;Bool&gt;) -&gt; CommandantError&lt;ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Constructs an error that describes how to use the given boolean option.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+        "key.doc.line" : 154,
+        "key.doc.name" : "informativeUsageError(_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 76,
+        "key.docoffset" : 5434,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.free><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>informativeUsageError<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.free>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 219,
+        "key.line" : 154,
+        "key.modulename" : "Commandant",
+        "key.name" : "informativeUsageError(_:)",
+        "key.namelength" : 58,
+        "key.nameoffset" : 5524,
+        "key.offset" : 5519,
+        "key.parsed_declaration" : "internal func informativeUsageError<ClientError>(_ option: Option<Bool>) -> CommandantError<ClientError>",
+        "key.parsed_scope.end" : 157,
+        "key.parsed_scope.start" : 154,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_5usageAA0aD0OyxGSS_SStlF\">informativeUsageError(_:usage:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_8argumentAA0aD0Oyq_GSS_AA8ArgumentVyxGtr0_lF\">informativeUsageError(_:argument:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVyxGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA8ArgumentVySayxGGAA0E8ProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Argument&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageError_6optionAA0aD0Oyq_GSS_AA6OptionVyxGtr0_lF\">informativeUsageError(_:option:)<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVyxSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;T?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          },
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant21informativeUsageErroryAA0aD0Oyq_GAA6OptionVySayxGSgGAA16ArgumentProtocolRzr0_lF\">informativeUsageError&lt;T, ClientError&gt;(_: Option&lt;[T]?&gt;) -&gt; CommandantError&lt;ClientError&gt; where T : ArgumentProtocol<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 37,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 154,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 5546,
+            "key.offset" : 5546,
+            "key.parsed_declaration" : "internal func informativeUsageError<ClientError",
+            "key.parsed_scope.end" : 154,
+            "key.parsed_scope.start" : 154,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF06ClientD0L_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 20,
+            "key.line" : 155,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 5622,
+            "key.offset" : 5618,
+            "key.parsed_declaration" : "let key = option.key",
+            "key.parsed_scope.end" : 155,
+            "key.parsed_scope.start" : 155,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF3keyL_SSvp"
+          }
+        ],
+        "key.typename" : "<ClientError> (Option<Bool>) -> CommandantError<ClientError>",
+        "key.typeusr" : "$sy10Commandant0A5ErrorOyxGAA6OptionVySbGcluD",
+        "key.usr" : "s:10Commandant21informativeUsageErroryAA0aD0OyxGAA6OptionVySbGlF"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/HelpCommand.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 2203,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpCommand&lt;ClientError&gt; : <Type usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/Type> where <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 537
+          }
+        ],
+        "key.bodylength" : 1127,
+        "key.bodyoffset" : 601,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "A basic implementation of a `help` command, using information available in a\n`CommandRegistry`.\n\nIf you want to use this command, initialize it with the registry, then add\nit to that same registry:\n\n\tlet commands: CommandRegistry<MyErrorType> = …\n\tlet helpCommand = HelpCommand(registry: commands)\n\tcommands.register(helpCommand)",
+        "key.doc.declaration" : "public struct HelpCommand<ClientError> : CommandProtocol where ClientError : Error",
+        "key.doc.discussion" : [
+          {
+            "Para" : "If you want to use this command, initialize it with the registry, then add it to that same registry:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/HelpCommand.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/HelpCommand.swift\" line=\"20\" column=\"15\"><Name>HelpCommand<\/Name><USR>s:10Commandant11HelpCommandV<\/USR><Declaration>public struct HelpCommand&lt;ClientError&gt; : CommandProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>A basic implementation of a <codeVoice>help<\/codeVoice> command, using information available in a <codeVoice>CommandRegistry<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>If you want to use this command, initialize it with the registry, then add it to that same registry:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let commands: CommandRegistry<MyErrorType> = …]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let helpCommand = HelpCommand(registry: commands)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[commands.register(helpCommand)]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 20,
+        "key.doc.name" : "HelpCommand",
+        "key.doc.type" : "Class",
+        "key.doclength" : 366,
+        "key.docoffset" : 171,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 584
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpCommand<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15CommandProtocolP\">CommandProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CommandProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 1185,
+        "key.line" : 20,
+        "key.modulename" : "Commandant",
+        "key.name" : "HelpCommand",
+        "key.namelength" : 11,
+        "key.nameoffset" : 551,
+        "key.offset" : 544,
+        "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error>: CommandProtocol",
+        "key.parsed_scope.end" : 59,
+        "key.parsed_scope.start" : 20,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 27,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 576
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 20,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 563,
+            "key.offset" : 563,
+            "key.parsed_declaration" : "public struct HelpCommand<ClientError: Error",
+            "key.parsed_scope.end" : 20,
+            "key.parsed_scope.start" : 20,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11HelpCommandV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant11HelpCommandV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public typealias <Type usr=\"s:10Commandant11HelpCommandV\">HelpCommand<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;.Options = <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 603
+              }
+            ],
+            "key.column" : 19,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 17,
+            "key.doc.declaration" : "associatedtype Options : Commandant.OptionsProtocol",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"15\" column=\"17\"><Name>Options<\/Name><USR>s:10Commandant15CommandProtocolP7OptionsQa<\/USR><Declaration>associatedtype Options : Commandant.OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>The command’s options type.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 15,
+            "key.doc.name" : "Options",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.typealias><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>typealias<\/syntaxtype.keyword> <ref.struct usr=\"s:10Commandant11HelpCommandV\">HelpCommand<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;.<decl.name>Options<\/decl.name> = <ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.typealias>",
+            "key.kind" : "source.lang.swift.decl.typealias",
+            "key.length" : 44,
+            "key.line" : 21,
+            "key.modulename" : "Commandant",
+            "key.name" : "Options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 620,
+            "key.offset" : 610,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+              }
+            ],
+            "key.parsed_declaration" : "public typealias Options = HelpOptions<ClientError>",
+            "key.parsed_scope.end" : 21,
+            "key.parsed_scope.start" : 21,
+            "key.typename" : "HelpOptions<ClientError>.Type",
+            "key.typeusr" : "$s10Commandant11HelpOptionsVyxGmD",
+            "key.usr" : "s:10Commandant15CommandProtocolP7OptionsQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let verb: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 657
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var verb: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"21\" column=\"6\"><Name>verb<\/Name><USR>s:10Commandant15CommandProtocolP4verbSSvp<\/USR><Declaration>var verb: String { get }<\/Declaration><CommentParts><Abstract><Para>The action that users should specify to use this subcommand (e.g., <codeVoice>help<\/codeVoice>).<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 21,
+            "key.doc.name" : "verb",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 23,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 668,
+            "key.offset" : 664,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public let verb = \"help\"",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 23,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP4verbSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let function: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 683
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 6,
+            "key.doc.declaration" : "var function: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"25\" column=\"6\"><Name>function<\/Name><USR>s:10Commandant15CommandProtocolP8functionSSvp<\/USR><Declaration>var function: String { get }<\/Declaration><CommentParts><Abstract><Para>A human-readable, high-level description of what this command is used for.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 25,
+            "key.doc.name" : "function",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>function<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 24,
+            "key.modulename" : "Commandant",
+            "key.name" : "function",
+            "key.namelength" : 8,
+            "key.nameoffset" : 694,
+            "key.offset" : 690,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public let function: String",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 24,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant15CommandProtocolP8functionSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private let registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 713
+              }
+            ],
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>registry<\/decl.name>: <decl.var.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 42,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "registry",
+            "key.namelength" : 8,
+            "key.nameoffset" : 725,
+            "key.offset" : 721,
+            "key.parsed_declaration" : "private let registry: CommandRegistry<ClientError>",
+            "key.parsed_scope.end" : 26,
+            "key.parsed_scope.start" : 26,
+            "key.typename" : "CommandRegistry<ClientError>",
+            "key.typeusr" : "$s10Commandant15CommandRegistryCyxGD",
+            "key.usr" : "s:10Commandant11HelpCommandV8registry33_38F61CE0DF9D73793CEDF5D1C3140331LLAA0C8RegistryCyxGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(registry: <Type usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/Type>&lt;<Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;, function: <Type usr=\"s:SS\">String<\/Type>? = nil)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 853
+              }
+            ],
+            "key.bodylength" : 102,
+            "key.bodyoffset" : 931,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 9,
+            "key.doc.comment" : "Initializes the command to provide help from the given registry of\ncommands.",
+            "key.doc.declaration" : "public init(registry: CommandRegistry<ClientError>, function: String? = nil)",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/HelpCommand.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/HelpCommand.swift\" line=\"30\" column=\"9\"><Name>init(registry:function:)<\/Name><USR>s:10Commandant11HelpCommandV8registry8functionACyxGAA0C8RegistryCyxG_SSSgtcfc<\/USR><Declaration>public init(registry: CommandRegistry&lt;ClientError&gt;, function: String? = nil)<\/Declaration><CommentParts><Abstract><Para>Initializes the command to provide help from the given registry of commands.<\/Para><\/Abstract><\/CommentParts><\/Function>",
+            "key.doc.line" : 30,
+            "key.doc.name" : "init(registry:function:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 86,
+            "key.docoffset" : 766,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>registry<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:10Commandant15CommandRegistryC\">CommandRegistry<\/ref.class>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>function<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 174,
+            "key.line" : 30,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(registry:function:)",
+            "key.namelength" : 69,
+            "key.nameoffset" : 860,
+            "key.offset" : 860,
+            "key.parsed_declaration" : "public init(registry: CommandRegistry<ClientError>, function: String? = nil)",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 30,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>.Type) -> (CommandRegistry<ClientError>, String?) -> HelpCommand<ClientError>",
+            "key.typeusr" : "$s8registry8function10Commandant11HelpCommandVyxGAC0E8RegistryCyxG_SSSgtcD",
+            "key.usr" : "s:10Commandant11HelpCommandV8registry8functionACyxGAA0C8RegistryCyxG_SSSgtcfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public func run(_ options: <Type usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;(), <Type usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/Type>&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1037
+              }
+            ],
+            "key.bodylength" : 625,
+            "key.bodyoffset" : 1101,
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 7,
+            "key.doc.declaration" : "func run(_ options: Options) -> Result<(), ClientError>",
+            "key.doc.discussion" : [
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"28\" column=\"7\"><Name>run(_:)<\/Name><USR>s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF<\/USR><Declaration>func run(_ options: Options) -&gt; Result&lt;(), ClientError&gt;<\/Declaration><CommentParts><Abstract><Para>Runs this subcommand with the given options.<\/Para><\/Abstract><Discussion><Note><Para>This documentation comment was inherited from <codeVoice>CommandProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 28,
+            "key.doc.name" : "run(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>run<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>options<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:10Commandant11HelpCommandV7Optionsa\">Options<\/ref.typealias><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>()<\/tuple>, <ref.generic_type_param usr=\"s:10Commandant11HelpCommandV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 683,
+            "key.line" : 35,
+            "key.modulename" : "Commandant",
+            "key.name" : "run(_:)",
+            "key.namelength" : 23,
+            "key.nameoffset" : 1049,
+            "key.offset" : 1044,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+              }
+            ],
+            "key.parsed_declaration" : "public func run(_ options: Options) -> Result<(), ClientError>",
+            "key.parsed_scope.end" : 58,
+            "key.parsed_scope.start" : 35,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>let maxVerbLength: <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>maxVerbLength<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 75,
+                "key.line" : 50,
+                "key.modulename" : "Commandant",
+                "key.name" : "maxVerbLength",
+                "key.namelength" : 13,
+                "key.nameoffset" : 1422,
+                "key.offset" : 1418,
+                "key.parsed_declaration" : "let maxVerbLength = self.registry.commands.map { $0.verb.count }.max() ?? 0",
+                "key.parsed_scope.end" : 50,
+                "key.parsed_scope.start" : 50,
+                "key.typename" : "Int",
+                "key.typeusr" : "$sSiD",
+                "key.usr" : "s:10Commandant11HelpCommandV3runys6ResultOyytxGAA0B7OptionsVyxGF13maxVerbLengthL_Sivp"
+              }
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpCommand<ClientError>) -> (HelpOptions<ClientError>) -> Result<(), ClientError>",
+            "key.typeusr" : "$sys6ResultOyytxG10Commandant11HelpOptionsVyxGcD",
+            "key.usr" : "s:10Commandant15CommandProtocolP3runys6ResultOyyt11ClientErrorQzG7OptionsQzF"
+          }
+        ],
+        "key.typename" : "HelpCommand<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant11HelpCommandVyxGmD",
+        "key.usr" : "s:10Commandant11HelpCommandV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct HelpOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where <Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1731
+          }
+        ],
+        "key.bodylength" : 406,
+        "key.bodyoffset" : 1795,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1778
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>HelpOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 464,
+        "key.line" : 61,
+        "key.modulename" : "Commandant",
+        "key.name" : "HelpOptions",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1745,
+        "key.offset" : 1738,
+        "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 76,
+        "key.parsed_scope.start" : 61,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 27,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 1770
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 61,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1757,
+            "key.offset" : 1757,
+            "key.parsed_declaration" : "public struct HelpOptions<ClientError: Error",
+            "key.parsed_scope.end" : 61,
+            "key.parsed_scope.start" : 61,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11HelpOptionsV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant11HelpOptionsV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate let verb: <Type usr=\"s:SS\">String<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 1797
+              }
+            ],
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>verb<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 62,
+            "key.modulename" : "Commandant",
+            "key.name" : "verb",
+            "key.namelength" : 4,
+            "key.nameoffset" : 1813,
+            "key.offset" : 1809,
+            "key.parsed_declaration" : "fileprivate let verb: String?",
+            "key.parsed_scope.end" : 62,
+            "key.parsed_scope.start" : 62,
+            "key.typename" : "String?",
+            "key.typeusr" : "$sSSSgD",
+            "key.usr" : "s:10Commandant11HelpOptionsV4verb33_38F61CE0DF9D73793CEDF5D1C3140331LLSSSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private init(verb: <Type usr=\"s:SS\">String<\/Type>?)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 1829
+              }
+            ],
+            "key.bodylength" : 21,
+            "key.bodyoffset" : 1858,
+            "key.column" : 10,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>verb<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct>?<\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 43,
+            "key.line" : 64,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(verb:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 1837,
+            "key.offset" : 1837,
+            "key.parsed_declaration" : "private init(verb: String?)",
+            "key.parsed_scope.end" : 66,
+            "key.parsed_scope.start" : 64,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String?) -> HelpOptions<ClientError>",
+            "key.typeusr" : "$s4verb10Commandant11HelpOptionsVyxGSSSg_tcD",
+            "key.usr" : "s:10Commandant11HelpOptionsV4verbACyxGSSSg_tc33_38F61CE0DF9D73793CEDF5D1C3140331Llfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.private",
+            "key.annotated_decl" : "<Declaration>private static func create(_ verb: <Type usr=\"s:SS\">String<\/Type>) -&gt; <Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.private",
+                "key.length" : 7,
+                "key.offset" : 1883
+              }
+            ],
+            "key.bodylength" : 54,
+            "key.bodyoffset" : 1942,
+            "key.column" : 22,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>private<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>create<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>verb<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct><\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 106,
+            "key.line" : 68,
+            "key.modulename" : "Commandant",
+            "key.name" : "create(_:)",
+            "key.namelength" : 22,
+            "key.nameoffset" : 1903,
+            "key.offset" : 1891,
+            "key.parsed_declaration" : "private static func create(_ verb: String) -> HelpOptions",
+            "key.parsed_scope.end" : 70,
+            "key.parsed_scope.start" : 68,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (String) -> HelpOptions<ClientError>",
+            "key.typeusr" : "$sy10Commandant11HelpOptionsVyxGSScD",
+            "key.usr" : "s:10Commandant11HelpOptionsV6create33_38F61CE0DF9D73793CEDF5D1C3140331LLyACyxGSSFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2000
+              }
+            ],
+            "key.bodylength" : 99,
+            "key.bodyoffset" : 2100,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>OptionsProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant11HelpOptionsV\">HelpOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11HelpOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 193,
+            "key.line" : 72,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 2019,
+            "key.offset" : 2007,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 75,
+            "key.parsed_scope.start" : 72,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (HelpOptions<ClientError>.Type) -> (CommandMode) -> Result<HelpOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOy10Commandant11HelpOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "HelpOptions<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant11HelpOptionsVyxGmD",
+        "key.usr" : "s:10Commandant11HelpOptionsV"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Option.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 9661,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public protocol OptionsProtocol<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1388
+          }
+        ],
+        "key.bodylength" : 233,
+        "key.bodyoffset" : 1421,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "Represents a record of options for a command, which can be parsed from\na list of command-line arguments.\n\nThis is most helpful when used in conjunction with the `Option` and `Switch`\ntypes, and `<*>` and `<|` combinators.\n\nExample:\n\n\tstruct LogOptions: OptionsProtocol {\n\t\tlet verbosity: Int\n\t\tlet outputFilename: String\n\t\tlet shouldDelete: Bool\n\t\tlet logName: String\n\n\t\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {\n\t\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }\n\t\t}\n\n\t\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {\n\t\t\treturn create\n\t\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")\n\t\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")\n\t\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")\n\t\t\t\t<*> m <| Argument(usage: \"the log to read\")\n\t\t}\n\t}",
+        "key.doc.declaration" : "public protocol OptionsProtocol",
+        "key.doc.discussion" : [
+          {
+            "Para" : "This is most helpful when used in conjunction with the `Option` and `Switch` types, and `<*>` and `<|` combinators."
+          },
+          {
+            "Para" : "Example:"
+          },
+          {
+            "CodeListing" : ""
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"37\" column=\"17\"><Name>OptionsProtocol<\/Name><USR>s:10Commandant15OptionsProtocolP<\/USR><Declaration>public protocol OptionsProtocol<\/Declaration><CommentParts><Abstract><Para>Represents a record of options for a command, which can be parsed from a list of command-line arguments.<\/Para><\/Abstract><Discussion><Para>This is most helpful when used in conjunction with the <codeVoice>Option<\/codeVoice> and <codeVoice>Switch<\/codeVoice> types, and <codeVoice>&lt;*&gt;<\/codeVoice> and <codeVoice>&lt;|<\/codeVoice> combinators.<\/Para><Para>Example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct LogOptions: OptionsProtocol {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet verbosity: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet outputFilename: String]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet shouldDelete: Bool]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tlet logName: String]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func create(_ verbosity: Int) -> (String) -> (Bool) -> (String) -> LogOptions {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn { outputFilename in { shouldDelete in { logName in LogOptions(verbosity: verbosity, outputFilename: outputFilename, shouldDelete: shouldDelete, logName: logName) } } }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\tstatic func evaluate(_ m: CommandMode) -> Result<LogOptions, CommandantError<YourErrorType>> {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\treturn create]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"verbose\", defaultValue: 0, usage: \"the verbosity level with which to read the logs\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Option(key: \"outputFilename\", defaultValue: \"\", usage: \"a file to print output to, instead of stdout\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Switch(flag: \"d\", key: \"delete\", usage: \"delete the logs when finished\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t\t\t<*> m <| Argument(usage: \"the log to read\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\t}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 37,
+        "key.doc.name" : "OptionsProtocol",
+        "key.doc.type" : "Class",
+        "key.doclength" : 1222,
+        "key.docoffset" : 166,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.protocol><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>protocol<\/syntaxtype.keyword> <decl.name>OptionsProtocol<\/decl.name><\/decl.protocol>",
+        "key.kind" : "source.lang.swift.decl.protocol",
+        "key.length" : 260,
+        "key.line" : 37,
+        "key.modulename" : "Commandant",
+        "key.name" : "OptionsProtocol",
+        "key.namelength" : 15,
+        "key.nameoffset" : 1404,
+        "key.offset" : 1395,
+        "key.parsed_declaration" : "public protocol OptionsProtocol",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 37,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>associatedtype ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 17,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.associatedtype><syntaxtype.keyword>associatedtype<\/syntaxtype.keyword> <decl.name>ClientError<\/decl.name> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.associatedtype>",
+            "key.kind" : "source.lang.swift.decl.associatedtype",
+            "key.length" : 33,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1438,
+            "key.offset" : 1423,
+            "key.parsed_declaration" : "associatedtype ClientError: Error",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "Self.ClientError.Type",
+            "key.typeusr" : "$s11ClientErrorQzmD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP11ClientErrorQa"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.column" : 14,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.comment" : "Evaluates this set of options in the given mode.\n\nReturns the parsed options or a `UsageError`.",
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 109,
+            "key.docoffset" : 1459,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant15OptionsProtocolP4Selfxmfp\">Self<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.associatedtype usr=\"s:10Commandant15OptionsProtocolP11ClientErrorQa\">ClientError<\/ref.associatedtype>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 84,
+            "key.line" : 43,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1581,
+            "key.offset" : 1569,
+            "key.parsed_declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 43,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<Self where Self : OptionsProtocol> (Self.Type) -> (CommandMode) -> Result<Self, CommandantError<Self.ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOy06ClientC0QzGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "OptionsProtocol.Protocol",
+        "key.typeusr" : "$s10Commandant15OptionsProtocol_pmD",
+        "key.usr" : "s:10Commandant15OptionsProtocolP"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct NoOptions&lt;ClientError&gt; : <Type usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/Type> where <Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1703
+          }
+        ],
+        "key.bodylength" : 154,
+        "key.bodyoffset" : 1765,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "An `OptionsProtocol` that has no options.",
+        "key.doc.declaration" : "public struct NoOptions<ClientError> : OptionsProtocol where ClientError : Error",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"47\" column=\"15\"><Name>NoOptions<\/Name><USR>s:10Commandant9NoOptionsV<\/USR><Declaration>public struct NoOptions&lt;ClientError&gt; : OptionsProtocol where ClientError : Error<\/Declaration><CommentParts><Abstract><Para>An <codeVoice>OptionsProtocol<\/codeVoice> that has no options.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 47,
+        "key.doc.name" : "NoOptions",
+        "key.doc.type" : "Class",
+        "key.doclength" : 46,
+        "key.docoffset" : 1657,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 15,
+            "key.offset" : 1748
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>NoOptions<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:10Commandant15OptionsProtocolP\">OptionsProtocol<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "OptionsProtocol"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 210,
+        "key.line" : 47,
+        "key.modulename" : "Commandant",
+        "key.name" : "NoOptions",
+        "key.namelength" : 9,
+        "key.nameoffset" : 1717,
+        "key.offset" : 1710,
+        "key.parsed_declaration" : "public struct NoOptions<ClientError: Error>: OptionsProtocol",
+        "key.parsed_scope.end" : 53,
+        "key.parsed_scope.start" : 47,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>ClientError : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+            "key.column" : 25,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 5,
+                "key.offset" : 1740
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Error"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 18,
+            "key.line" : 47,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1727,
+            "key.offset" : 1727,
+            "key.parsed_declaration" : "public struct NoOptions<ClientError: Error",
+            "key.parsed_scope.end" : 47,
+            "key.parsed_scope.start" : 47,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant9NoOptionsV11ClientErrora\">ClientError<\/RelatedName>"
+              }
+            ],
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant9NoOptionsV11ClientErrorxmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init()<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1767
+              }
+            ],
+            "key.bodylength" : 0,
+            "key.bodyoffset" : 1782,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>()<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 9,
+            "key.line" : 48,
+            "key.modulename" : "Commandant",
+            "key.name" : "init()",
+            "key.namelength" : 6,
+            "key.nameoffset" : 1774,
+            "key.offset" : 1774,
+            "key.parsed_declaration" : "public init()",
+            "key.parsed_scope.end" : 48,
+            "key.parsed_scope.start" : 48,
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> () -> NoOptions<ClientError>",
+            "key.typeusr" : "$s10Commandant9NoOptionsVyxGycD",
+            "key.usr" : "s:10Commandant9NoOptionsVACyxGycfc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func evaluate(_ m: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1786
+              }
+            ],
+            "key.bodylength" : 33,
+            "key.bodyoffset" : 1884,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 14,
+            "key.doc.declaration" : "static func evaluate(_ m: CommandMode) -> Result<Self, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Returns the parsed options or a `UsageError`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"43\" column=\"14\"><Name>evaluate(_:)<\/Name><USR>s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ<\/USR><Declaration>static func evaluate(_ m: CommandMode) -&gt; Result&lt;Self, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates this set of options in the given mode.<\/Para><\/Abstract><Discussion><Para>Returns the parsed options or a <codeVoice>UsageError<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>OptionsProtocol<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 43,
+            "key.doc.name" : "evaluate(_:)",
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.static><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>evaluate<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>m<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:10Commandant9NoOptionsV\">NoOptions<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant9NoOptionsV11ClientErrorxmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.method.static>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 125,
+            "key.line" : 50,
+            "key.modulename" : "Commandant",
+            "key.name" : "evaluate(_:)",
+            "key.namelength" : 26,
+            "key.nameoffset" : 1805,
+            "key.offset" : 1793,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+              }
+            ],
+            "key.parsed_declaration" : "public static func evaluate(_ m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 52,
+            "key.parsed_scope.start" : 50,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<ClientError where ClientError : Error> (NoOptions<ClientError>.Type) -> (CommandMode) -> Result<NoOptions<ClientError>, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOy10Commandant9NoOptionsVyxGAC0B5ErrorOyxGGAC11CommandModeOcD",
+            "key.usr" : "s:10Commandant15OptionsProtocolP8evaluateys6ResultOyxAA0A5ErrorOy06ClientF0QzGGAA11CommandModeOFZ"
+          }
+        ],
+        "key.typename" : "NoOptions<ClientError>.Type",
+        "key.typeusr" : "$s10Commandant9NoOptionsVyxGmD",
+        "key.usr" : "s:10Commandant9NoOptionsV"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 1988
+          }
+        ],
+        "key.bodylength" : 786,
+        "key.bodyoffset" : 2013,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes an option that can be provided on the command line.",
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"56\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 56,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.doclength" : 66,
+        "key.docoffset" : 1922,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 805,
+        "key.line" : 56,
+        "key.modulename" : "Commandant",
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2002,
+        "key.offset" : 1995,
+        "key.parsed_declaration" : "public struct Option<T>",
+        "key.parsed_scope.end" : 78,
+        "key.parsed_scope.start" : 56,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 22,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 56,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 2009,
+            "key.offset" : 2009,
+            "key.parsed_declaration" : "public struct Option<T",
+            "key.parsed_scope.end" : 56,
+            "key.parsed_scope.start" : 56,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant6OptionV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2132
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The key that controls this option. For example, a key of `verbose` would\nbe used for a `--verbose` option.",
+            "key.doc.declaration" : "public let key: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"59\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6OptionV3keySSvp<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that controls this option. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 59,
+            "key.doc.name" : "key",
+            "key.doc.type" : "Other",
+            "key.doclength" : 116,
+            "key.docoffset" : 2015,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 15,
+            "key.line" : 59,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 2143,
+            "key.offset" : 2139,
+            "key.parsed_declaration" : "public let key: String",
+            "key.parsed_scope.end" : 59,
+            "key.parsed_scope.start" : 59,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6OptionV3keySSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2303
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The default value for this option. This is the value that will be used\nif the option is never explicitly specified on the command line.",
+            "key.doc.declaration" : "public let defaultValue: T",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"63\" column=\"13\"><Name>defaultValue<\/Name><USR>s:10Commandant6OptionV12defaultValuexvp<\/USR><Declaration>public let defaultValue: T<\/Declaration><CommentParts><Abstract><Para>The default value for this option. This is the value that will be used if the option is never explicitly specified on the command line.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 63,
+            "key.doc.name" : "defaultValue",
+            "key.doc.type" : "Other",
+            "key.doclength" : 145,
+            "key.docoffset" : 2157,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>defaultValue<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 19,
+            "key.line" : 63,
+            "key.modulename" : "Commandant",
+            "key.name" : "defaultValue",
+            "key.namelength" : 12,
+            "key.nameoffset" : 2314,
+            "key.offset" : 2310,
+            "key.parsed_declaration" : "public let defaultValue: T",
+            "key.parsed_scope.end" : 63,
+            "key.parsed_scope.start" : 63,
+            "key.typename" : "T",
+            "key.typeusr" : "$sxD",
+            "key.usr" : "s:10Commandant6OptionV12defaultValuexvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2637
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.\n\nFor boolean operations, this should describe the effect of _not_ using\nthe default value (i.e., what will happen if you disable\/enable the flag\ndifferently from the default).",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.discussion" : [
+              {
+                "Para" : "For boolean operations, this should describe the effect of  using the default value (i.e., what will happen if you disable\/enable the flag differently from the default)."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"71\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6OptionV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><Discussion><Para>For boolean operations, this should describe the effect of <emphasis>not<\/emphasis> using the default value (i.e., what will happen if you disable\/enable the flag differently from the default).<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 71,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 304,
+            "key.docoffset" : 2332,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 71,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 2648,
+            "key.offset" : 2644,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 71,
+            "key.parsed_scope.start" : 71,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6OptionV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(key: <Type usr=\"s:SS\">String<\/Type>, defaultValue: <Type usr=\"s:10Commandant6OptionV1Txmfp\">T<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2664
+              }
+            ],
+            "key.bodylength" : 75,
+            "key.bodyoffset" : 2722,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>defaultValue<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 127,
+            "key.line" : 73,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(key:defaultValue:usage:)",
+            "key.namelength" : 49,
+            "key.nameoffset" : 2671,
+            "key.offset" : 2671,
+            "key.parsed_declaration" : "public init(key: String, defaultValue: T, usage: String)",
+            "key.parsed_scope.end" : 77,
+            "key.parsed_scope.start" : 73,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T> (Option<T>.Type) -> (String, T, String) -> Option<T>",
+            "key.typeusr" : "$s3key12defaultValue5usage10Commandant6OptionVyxGSS_xSStcD",
+            "key.usr" : "s:10Commandant6OptionV3key12defaultValue5usageACyxGSS_xSStcfc"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "$s10Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Option&lt;T&gt;<\/Declaration>",
+        "key.bodylength" : 58,
+        "key.bodyoffset" : 2845,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Option<T>",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"56\" column=\"15\"><Name>Option<\/Name><USR>s:10Commandant6OptionV<\/USR><Declaration>public struct Option&lt;T&gt;<\/Declaration><CommentParts><Abstract><Para>Describes an option that can be provided on the command line.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 56,
+        "key.doc.name" : "Option",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 2820
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Option<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant6OptionV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;<\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 102,
+        "key.line" : 56,
+        "key.modulename" : "Commandant",
+        "key.name" : "Option",
+        "key.namelength" : 6,
+        "key.nameoffset" : 2812,
+        "key.offset" : 2802,
+        "key.parsed_declaration" : "extension Option: CustomStringConvertible",
+        "key.parsed_scope.end" : 84,
+        "key.parsed_scope.start" : 80,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 2847
+              }
+            ],
+            "key.bodylength" : 22,
+            "key.bodyoffset" : 2879,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 48,
+            "key.line" : 81,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 2858,
+            "key.offset" : 2854,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 83,
+            "key.parsed_scope.start" : 81,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          }
+        ],
+        "key.typename" : "Option<T>.Type",
+        "key.typeusr" : "$s10Commandant6OptionVyxGmD",
+        "key.usr" : "s:10Commandant6OptionV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 2909
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: (<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, value: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4404
+          }
+        ],
+        "key.bodylength" : 22,
+        "key.bodyoffset" : 4545,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"122\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: (T) -&gt; U, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 122,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 211,
+        "key.docoffset" : 4193,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt; <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 157,
+        "key.line" : 122,
+        "key.modulename" : "Commandant",
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 84,
+        "key.nameoffset" : 4416,
+        "key.offset" : 4411,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: (T) -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 124,
+        "key.parsed_scope.start" : 122,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF\">&lt;*&gt; &lt;T, U, ClientError&gt;(_: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4421,
+            "key.offset" : 4421,
+            "key.parsed_declaration" : "public func <*> <T",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "U",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4424,
+            "key.offset" : 4424,
+            "key.parsed_declaration" : "public func <*> <T, U",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "U.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF1UL_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 122,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4427,
+            "key.offset" : 4427,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError",
+            "key.parsed_scope.end" : 122,
+            "key.parsed_scope.start" : 122,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq0_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF06ClientD0L_q0_mfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> ((T) -> U, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "$sys6ResultOyq_10Commandant0B5ErrorOyq0_GGq_xXE_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF"
+      },
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;((<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>), <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;, value: <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 4797
+          }
+        ],
+        "key.bodylength" : 346,
+        "key.bodyoffset" : 4978,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.comment" : "Applies the function in `f` to the value in the given result.\n\nIn the context of command-line option parsing, this is used to chain\ntogether the parsing of multiple arguments. See OptionsProtocol for an example.",
+        "key.doc.declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.doc.discussion" : [
+          {
+            "Para" : "In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+        "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"130\" column=\"13\"><Name>&lt;*&gt;(_:_:)<\/Name><USR>s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF<\/USR><Declaration>public func &lt;*&gt; &lt;T, U, ClientError&gt;(f: Result&lt;((T) -&gt; U), CommandantError&lt;ClientError&gt;&gt;, value: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Applies the function in <codeVoice>f<\/codeVoice> to the value in the given result.<\/Para><\/Abstract><Discussion><Para>In the context of command-line option parsing, this is used to chain together the parsing of multiple arguments. See OptionsProtocol for an example.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+        "key.doc.line" : 130,
+        "key.doc.name" : "<*>(_:_:)",
+        "key.doc.type" : "Function",
+        "key.doclength" : 227,
+        "key.docoffset" : 4570,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;*&gt; <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\"><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>f<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<tuple>(<tuple.element><tuple.element.type>(<decl.var.parameter><decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param><\/decl.function.returntype><\/tuple.element.type><\/tuple.element>)<\/tuple>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>value<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp\">U<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+        "key.kind" : "source.lang.swift.decl.function.free",
+        "key.length" : 521,
+        "key.line" : 130,
+        "key.modulename" : "Commandant",
+        "key.name" : "<*>(_:_:)",
+        "key.namelength" : 124,
+        "key.nameoffset" : 4809,
+        "key.offset" : 4804,
+        "key.parsed_declaration" : "public func <*> <T, U, ClientError>(f: Result<((T) -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.parsed_scope.end" : 145,
+        "key.parsed_scope.start" : 130,
+        "key.related_decls" : [
+          {
+            "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGq_xXE_ADyxAGGtr1_lF\">&lt;*&gt; &lt;T, U, ClientError&gt;(_: (T) -&gt; U, _: Result&lt;T, CommandantError&lt;ClientError&gt;&gt;) -&gt; Result&lt;U, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+          }
+        ],
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T<\/Declaration>",
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4814,
+            "key.offset" : 4814,
+            "key.parsed_declaration" : "public func <*> <T",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1TL_xmfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>U<\/Declaration>",
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>U<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 1,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "U",
+            "key.namelength" : 1,
+            "key.nameoffset" : 4817,
+            "key.offset" : 4817,
+            "key.parsed_declaration" : "public func <*> <T, U",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "U.Type",
+            "key.typeusr" : "$sq_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF1UL_q_mfp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+            "key.column" : 24,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 130,
+            "key.modulename" : "Commandant",
+            "key.name" : "ClientError",
+            "key.namelength" : 11,
+            "key.nameoffset" : 4820,
+            "key.offset" : 4820,
+            "key.parsed_declaration" : "public func <*> <T, U, ClientError",
+            "key.parsed_scope.end" : 130,
+            "key.parsed_scope.start" : 130,
+            "key.typename" : "ClientError.Type",
+            "key.typeusr" : "$sq0_mD",
+            "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF06ClientD0L_q0_mfp"
+          }
+        ],
+        "key.typename" : "<T, U, ClientError> (Result<((T) -> U), CommandantError<ClientError>>, Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>>",
+        "key.typeusr" : "$sys6ResultOyq_10Commandant0B5ErrorOyq0_GGAByq_xcAFG_AByxAFGtcr1_luD",
+        "key.usr" : "s:10Commandant3lmgoiys6ResultOyq_AA0A5ErrorOyq0_GGADyq_xcAGG_ADyxAGGtr1_lF"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 4309,
+        "key.bodyoffset" : 5350,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 4333,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 5337,
+        "key.offset" : 5327,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 273,
+        "key.parsed_scope.start" : 147,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 5538
+              }
+            ],
+            "key.bodylength" : 230,
+            "key.bodyoffset" : 5677,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"152\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 152,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 185,
+            "key.docoffset" : 5352,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 363,
+            "key.line" : 152,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 75,
+            "key.nameoffset" : 5557,
+            "key.offset" : 5545,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 157,
+            "key.parsed_scope.start" : 152,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 5564
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 152,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 5561,
+                "key.offset" : 5561,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 152,
+                "key.parsed_scope.start" : 152,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 152,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 5582,
+                "key.offset" : 5582,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 152,
+                "key.parsed_scope.start" : 152,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let wrapped: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>wrapped<\/decl.name>: <decl.var.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 97,
+                "key.line" : 153,
+                "key.modulename" : "Commandant",
+                "key.name" : "wrapped",
+                "key.namelength" : 7,
+                "key.nameoffset" : 5684,
+                "key.offset" : 5680,
+                "key.parsed_declaration" : "let wrapped = Option<T?>(key: option.key, defaultValue: option.defaultValue, usage: option.usage)",
+                "key.parsed_scope.end" : 153,
+                "key.parsed_scope.start" : 153,
+                "key.typename" : "Option<T?>",
+                "key.typeusr" : "$s10Commandant6OptionVyxSgGD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ7wrappedL_ALyxSgGvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T>) -> Result<T, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyx10Commandant0B5ErrorOyq_GGAC11CommandModeO_AC6OptionVyxGtcAC16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 6075
+              }
+            ],
+            "key.bodylength" : 852,
+            "key.bodyoffset" : 6216,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"163\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 163,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 163,
+            "key.docoffset" : 5911,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 987,
+            "key.line" : 163,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 76,
+            "key.nameoffset" : 6094,
+            "key.offset" : 6082,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 196,
+            "key.parsed_scope.start" : 163,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 6101
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 6098,
+                "key.offset" : 6098,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 163,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 6119,
+                "key.offset" : 6119,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 163,
+                "key.parsed_scope.start" : 163,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 20,
+                "key.line" : 164,
+                "key.modulename" : "Commandant",
+                "key.name" : "key",
+                "key.namelength" : 3,
+                "key.nameoffset" : 6223,
+                "key.offset" : 6219,
+                "key.parsed_declaration" : "let key = option.key",
+                "key.parsed_scope.end" : 164,
+                "key.parsed_scope.start" : 164,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ3keyL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<T?>) -> Result<T?, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOyxSg10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>], <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 7258
+              }
+            ],
+            "key.bodylength" : 232,
+            "key.bodyoffset" : 7401,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"202\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 202,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 185,
+            "key.docoffset" : 7072,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>], <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 369,
+            "key.line" : 202,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 77,
+            "key.nameoffset" : 7277,
+            "key.offset" : 7265,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 207,
+            "key.parsed_scope.start" : 202,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 7284
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 202,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 7281,
+                "key.offset" : 7281,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 202,
+                "key.parsed_scope.start" : 202,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 202,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 7302,
+                "key.offset" : 7302,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 202,
+                "key.parsed_scope.start" : 202,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let wrapped: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;<\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>wrapped<\/decl.name>: <decl.var.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 99,
+                "key.line" : 203,
+                "key.modulename" : "Commandant",
+                "key.name" : "wrapped",
+                "key.namelength" : 7,
+                "key.nameoffset" : 7408,
+                "key.offset" : 7404,
+                "key.parsed_declaration" : "let wrapped = Option<[T]?>(key: option.key, defaultValue: option.defaultValue, usage: option.usage)",
+                "key.parsed_scope.end" : 203,
+                "key.parsed_scope.start" : 203,
+                "key.typename" : "Option<[T]?>",
+                "key.typeusr" : "$s10Commandant6OptionVySayxGSgGD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ7wrappedL_AMyAGSgGvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]>) -> Result<[T], CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxG10Commandant0B5ErrorOyq_GGAD11CommandModeO_AD6OptionVyACGtcAD16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;[<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type>]?, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/Type>&gt;&gt; where <Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/Type> : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 7801
+              }
+            ],
+            "key.bodylength" : 1117,
+            "key.bodyoffset" : 7946,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, `nil` is used.",
+            "key.doc.declaration" : "public static func <| <T, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>> where T : Commandant.ArgumentProtocol",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, `nil` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"213\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ<\/USR><Declaration>public static func &lt;| &lt;T, ClientError&gt;(mode: CommandMode, option: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : Commandant.ArgumentProtocol<\/Declaration><CommentParts><Abstract><Para>Evaluates the given option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, <codeVoice>nil<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 213,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 163,
+            "key.docoffset" : 7637,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;[<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param>]?, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 1256,
+            "key.line" : 213,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 78,
+            "key.nameoffset" : 7820,
+            "key.offset" : 7808,
+            "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError>(mode: CommandMode, option: Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 254,
+            "key.parsed_scope.start" : 213,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/Type><\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 16,
+                    "key.offset" : 7827
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:10Commandant16ArgumentProtocolP\">ArgumentProtocol<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "ArgumentProtocol"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 19,
+                "key.line" : 213,
+                "key.modulename" : "Commandant",
+                "key.name" : "T",
+                "key.namelength" : 1,
+                "key.nameoffset" : 7824,
+                "key.offset" : 7824,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol",
+                "key.parsed_scope.end" : 213,
+                "key.parsed_scope.start" : 213,
+                "key.typename" : "T.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ1TL_xmfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 46,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 213,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 7845,
+                "key.offset" : 7845,
+                "key.parsed_declaration" : "public static func <| <T: ArgumentProtocol, ClientError",
+                "key.parsed_scope.end" : 213,
+                "key.parsed_scope.start" : 213,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sq_mD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ06ClientF0L_q_mfp"
+              },
+              {
+                "key.annotated_decl" : "<Declaration>let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+                "key.kind" : "source.lang.swift.decl.var.local",
+                "key.length" : 20,
+                "key.line" : 214,
+                "key.modulename" : "Commandant",
+                "key.name" : "key",
+                "key.namelength" : 3,
+                "key.nameoffset" : 7953,
+                "key.offset" : 7949,
+                "key.parsed_declaration" : "let key = option.key",
+                "key.parsed_scope.end" : 214,
+                "key.parsed_scope.start" : 214,
+                "key.typename" : "String",
+                "key.typeusr" : "$sSSD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ3keyL_SSvp"
+              }
+            ],
+            "key.typename" : "<T, ClientError where T : ArgumentProtocol> (CommandMode.Type) -> (CommandMode, Option<[T]?>) -> Result<[T]?, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySayxGSg10Commandant0B5ErrorOyq_GGAE11CommandModeO_AE6OptionVyADGtcAE16ArgumentProtocolRzr0_luD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6OptionV\">Option<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>&gt;) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 9261
+              }
+            ],
+            "key.bodylength" : 272,
+            "key.bodyoffset" : 9385,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given boolean option in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Option.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Option.swift\" line=\"260\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ<\/USR><Declaration>public static func &lt;| &lt;ClientError&gt;(mode: CommandMode, option: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean option in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 260,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 193,
+            "key.docoffset" : 9067,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6OptionV\">Option<\/ref.struct>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>&gt;<\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 390,
+            "key.line" : 260,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 57,
+            "key.nameoffset" : 9280,
+            "key.offset" : 9268,
+            "key.parsed_declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 272,
+            "key.parsed_scope.start" : 260,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 260,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 9284,
+                "key.offset" : 9284,
+                "key.parsed_declaration" : "public static func <| <ClientError",
+                "key.parsed_scope.end" : 260,
+                "key.parsed_scope.start" : 260,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ06ClientF0L_xmfp"
+              }
+            ],
+            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Option<Bool>) -> Result<Bool, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6OptionVySbGtcluD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/OrderedSet.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 800,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; : <Type usr=\"s:SQ\">Equatable<\/Type> where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 30
+          }
+        ],
+        "key.bodylength" : 348,
+        "key.bodyoffset" : 82,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.comment" : "A poor man's ordered set.",
+        "key.doc.declaration" : "internal struct OrderedSet<T> : Equatable where T : Hashable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; : Equatable where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.doclength" : 30,
+        "key.docoffset" : 0,
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 9,
+            "key.offset" : 71
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Equatable"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 392,
+        "key.line" : 2,
+        "key.modulename" : "Commandant",
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 46,
+        "key.offset" : 39,
+        "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable>: Equatable",
+        "key.parsed_scope.end" : 19,
+        "key.parsed_scope.start" : 2,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>T : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+            "key.column" : 28,
+            "key.decl_lang" : "source.lang.swift",
+            "key.elements" : [
+              {
+                "key.kind" : "source.lang.swift.structure.elem.typeref",
+                "key.length" : 8,
+                "key.offset" : 60
+              }
+            ],
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>T<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+            "key.inheritedtypes" : [
+              {
+                "key.name" : "Hashable"
+              }
+            ],
+            "key.kind" : "source.lang.swift.decl.generic_type_param",
+            "key.length" : 11,
+            "key.line" : 2,
+            "key.modulename" : "Commandant",
+            "key.name" : "T",
+            "key.namelength" : 1,
+            "key.nameoffset" : 57,
+            "key.offset" : 57,
+            "key.parsed_declaration" : "internal struct OrderedSet<T: Hashable",
+            "key.parsed_scope.end" : 2,
+            "key.parsed_scope.start" : 2,
+            "key.typename" : "T.Type",
+            "key.typeusr" : "$sxmD",
+            "key.usr" : "s:10Commandant10OrderedSetV1Txmfp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.annotated_decl" : "<Declaration>fileprivate var values: [<Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>]<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.fileprivate",
+                "key.length" : 11,
+                "key.offset" : 84
+              }
+            ],
+            "key.column" : 18,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>fileprivate<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>values<\/decl.name>: <decl.var.type>[<ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>]<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 3,
+            "key.modulename" : "Commandant",
+            "key.name" : "values",
+            "key.namelength" : 6,
+            "key.nameoffset" : 100,
+            "key.offset" : 96,
+            "key.parsed_declaration" : "fileprivate var values: [T] = []",
+            "key.parsed_scope.end" : 3,
+            "key.parsed_scope.start" : 3,
+            "key.setter_accessibility" : "source.lang.swift.accessibility.fileprivate",
+            "key.typename" : "[T]",
+            "key.typeusr" : "$sSayxGD",
+            "key.usr" : "s:10Commandant10OrderedSetV6values33_E700A43BE27995F7283A44882E2B4A42LLSayxGvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>init&lt;S&gt;(_ sequence: <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type>) where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> == <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type>.<Type usr=\"s:ST7ElementQa\">Element<\/Type>, <Type usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/Type> : <Type usr=\"s:ST\">Sequence<\/Type><\/Declaration>",
+            "key.bodylength" : 74,
+            "key.bodyoffset" : 174,
+            "key.column" : 2,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>init<\/syntaxtype.keyword>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\"><decl.generic_type_param.name>S<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>sequence<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> == <ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param>.<ref.associatedtype usr=\"s:ST7ElementQa\">Element<\/ref.associatedtype><\/decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp\">S<\/ref.generic_type_param> : <ref.protocol usr=\"s:ST\">Sequence<\/ref.protocol><\/decl.generic_type_requirement><\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 130,
+            "key.line" : 5,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(_:)",
+            "key.namelength" : 32,
+            "key.nameoffset" : 119,
+            "key.offset" : 119,
+            "key.parsed_declaration" : "init<S: Sequence>(_ sequence: S) where S.Element == T",
+            "key.parsed_scope.end" : 9,
+            "key.parsed_scope.start" : 5,
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>S : <Type usr=\"s:ST\">Sequence<\/Type><\/Declaration>",
+                "key.column" : 7,
+                "key.decl_lang" : "source.lang.swift",
+                "key.elements" : [
+                  {
+                    "key.kind" : "source.lang.swift.structure.elem.typeref",
+                    "key.length" : 8,
+                    "key.offset" : 127
+                  }
+                ],
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>S<\/decl.generic_type_param.name> : <decl.generic_type_param.constraint><ref.protocol usr=\"s:ST\">Sequence<\/ref.protocol><\/decl.generic_type_param.constraint><\/decl.generic_type_param>",
+                "key.inheritedtypes" : [
+                  {
+                    "key.name" : "Sequence"
+                  }
+                ],
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 5,
+                "key.modulename" : "Commandant",
+                "key.name" : "S",
+                "key.namelength" : 1,
+                "key.nameoffset" : 124,
+                "key.offset" : 124,
+                "key.parsed_declaration" : "init<S: Sequence",
+                "key.parsed_scope.end" : 5,
+                "key.parsed_scope.start" : 5,
+                "key.typename" : "S.Type",
+                "key.typeusr" : "$sqd__mD",
+                "key.usr" : "s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc1SL_qd__mfp"
+              }
+            ],
+            "key.typename" : "<T, S where T : Hashable, T == S.Element, S : Sequence> (OrderedSet<T>.Type) -> (S) -> OrderedSet<T>",
+            "key.typeusr" : "$sy10Commandant10OrderedSetVyxGqd__c7ElementQyd__RszSTRd__luD",
+            "key.usr" : "s:10Commandant10OrderedSetVyACyxGqd__c7ElementQyd__RszSTRd__lufc"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>@discardableResult mutating func remove(_ member: <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.mutating",
+                "key.length" : 8,
+                "key.offset" : 272
+              },
+              {
+                "key.attribute" : "source.decl.attribute.discardableResult",
+                "key.length" : 18,
+                "key.offset" : 252
+              }
+            ],
+            "key.bodylength" : 115,
+            "key.bodyoffset" : 313,
+            "key.column" : 16,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>remove<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_<\/decl.var.parameter.argument_label> <decl.var.parameter.name>member<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param>?<\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 148,
+            "key.line" : 12,
+            "key.modulename" : "Commandant",
+            "key.name" : "remove(_:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 286,
+            "key.offset" : 281,
+            "key.parsed_declaration" : "mutating func remove(_ member: T) -> T?",
+            "key.parsed_scope.end" : 18,
+            "key.parsed_scope.start" : 12,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (inout OrderedSet<T>) -> (T) -> T?",
+            "key.typeusr" : "$syxSgxcD",
+            "key.usr" : "s:10Commandant10OrderedSetV6removeyxSgxF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "$s10Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>internal struct OrderedSet&lt;T&gt; : <Type usr=\"s:SQ\">Equatable<\/Type> where <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> : <Type usr=\"s:SH\">Hashable<\/Type><\/Declaration>",
+        "key.bodylength" : 331,
+        "key.bodyoffset" : 467,
+        "key.column" : 17,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 17,
+        "key.doc.declaration" : "internal struct OrderedSet<T> : Equatable where T : Hashable",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/OrderedSet.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/OrderedSet.swift\" line=\"2\" column=\"17\"><Name>OrderedSet<\/Name><USR>s:10Commandant10OrderedSetV<\/USR><Declaration>internal struct OrderedSet&lt;T&gt; : Equatable where T : Hashable<\/Declaration><CommentParts><Abstract><Para>A poor man’s ordered set.<\/Para><\/Abstract><\/CommentParts><\/Class>",
+        "key.doc.line" : 2,
+        "key.doc.name" : "OrderedSet",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 10,
+            "key.offset" : 455
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>internal<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>OrderedSet<\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\"><decl.generic_type_param.name>T<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; : <ref.protocol usr=\"s:SQ\">Equatable<\/ref.protocol> <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param> : <ref.protocol usr=\"s:SH\">Hashable<\/ref.protocol><\/decl.generic_type_requirement><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "Collection"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 366,
+        "key.line" : 2,
+        "key.modulename" : "Commandant",
+        "key.name" : "OrderedSet",
+        "key.namelength" : 10,
+        "key.nameoffset" : 443,
+        "key.offset" : 433,
+        "key.parsed_declaration" : "extension OrderedSet: Collection",
+        "key.parsed_scope.end" : 45,
+        "key.parsed_scope.start" : 21,
+        "key.substructure" : [
+          {
+            "key.annotated_decl" : "<Declaration>subscript(position: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 28,
+            "key.bodyoffset" : 500,
+            "key.column" : 2,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "subscript(position: Self.Index) -> Self.Element { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "The following example accesses an element of an array through its subscript to print its value:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "You can subscript a collection with any valid index other than the collection’s end index. The end index refers to the position one past the last element of a collection, so it doesn’t correspond with an element."
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>subscript(_:)<\/Name><USR>s:Sly7ElementQz5IndexQzcip<\/USR><Declaration>subscript(position: Self.Index) -&gt; Self.Element { get }<\/Declaration><CommentParts><Abstract><Para>Accesses the element at the specified position.<\/Para><\/Abstract><Parameters><Parameter><Name>position<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>The position of the element to access. <codeVoice>position<\/codeVoice> must be a valid index of the collection that is not equal to the <codeVoice>endIndex<\/codeVoice> property.<\/Para><\/Discussion><\/Parameter><\/Parameters><Discussion><Para>The following example accesses an element of an array through its subscript to print its value:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var streets = [\"Adams\", \"Bryant\", \"Channing\", \"Douglas\", \"Evarts\"]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(streets[1])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Bryant\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>You can subscript a collection with any valid index other than the collection’s end index. The end index refers to the position one past the last element of a collection, so it doesn’t correspond with an element.<\/Para><Complexity><Para>O(1)<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "subscript(_:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "The position of the element to access. `position` must be a valid index of the collection that is not equal to the `endIndex` property."
+                  }
+                ],
+                "name" : "position"
+              }
+            ],
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.subscript><syntaxtype.keyword>subscript<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>position<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr=\"s:10Commandant10OrderedSetV1Txmfp\">T<\/ref.generic_type_param><\/decl.function.returntype> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.function.subscript>",
+            "key.kind" : "source.lang.swift.decl.function.subscript",
+            "key.length" : 60,
+            "key.line" : 22,
+            "key.modulename" : "Commandant",
+            "key.name" : "subscript(_:)",
+            "key.namelength" : 24,
+            "key.nameoffset" : 469,
+            "key.offset" : 469,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sly7ElementQz5IndexQzcip"
+              }
+            ],
+            "key.parsed_declaration" : "subscript(position: Int) -> T",
+            "key.parsed_scope.end" : 24,
+            "key.parsed_scope.start" : 22,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (Int) -> T",
+            "key.typeusr" : "$syxSicD",
+            "key.usr" : "s:Sly7ElementQz5IndexQzcip"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var count: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 24,
+            "key.bodyoffset" : 548,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var count: Int { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "To check whether a collection is empty, use its `isEmpty` property instead of comparing `count` to zero. Unless the collection guarantees random-access performance, calculating `count` can be an O() operation."
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>count<\/Name><USR>s:Sl5countSivp<\/USR><Declaration>var count: Int { get }<\/Declaration><CommentParts><Abstract><Para>The number of elements in the collection.<\/Para><\/Abstract><Discussion><Para>To check whether a collection is empty, use its <codeVoice>isEmpty<\/codeVoice> property instead of comparing <codeVoice>count<\/codeVoice> to zero. Unless the collection guarantees random-access performance, calculating <codeVoice>count<\/codeVoice> can be an O(<emphasis>n<\/emphasis>) operation.<\/Para><Complexity><Para>O(1) if the collection conforms to <codeVoice>RandomAccessCollection<\/codeVoice>; otherwise, O(<emphasis>n<\/emphasis>), where <emphasis>n<\/emphasis> is the length of the collection.<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "count",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>count<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 41,
+            "key.line" : 26,
+            "key.modulename" : "Commandant",
+            "key.name" : "count",
+            "key.namelength" : 5,
+            "key.nameoffset" : 536,
+            "key.offset" : 532,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl5countSivp"
+              }
+            ],
+            "key.parsed_declaration" : "var count: Int",
+            "key.parsed_scope.end" : 28,
+            "key.parsed_scope.start" : 26,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl5countSivp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var isEmpty: <Type usr=\"s:Sb\">Bool<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 26,
+            "key.bodyoffset" : 595,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var isEmpty: Bool { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need to check whether your collection is empty, use the `isEmpty` property instead of checking that the `count` property is equal to zero. For collections that don’t conform to `RandomAccessCollection`, accessing the `count` property iterates through the elements of the collection."
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Complexity" : ""
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>isEmpty<\/Name><USR>s:Sl7isEmptySbvp<\/USR><Declaration>var isEmpty: Bool { get }<\/Declaration><CommentParts><Abstract><Para>A Boolean value indicating whether the collection is empty.<\/Para><\/Abstract><Discussion><Para>When you need to check whether your collection is empty, use the <codeVoice>isEmpty<\/codeVoice> property instead of checking that the <codeVoice>count<\/codeVoice> property is equal to zero. For collections that don’t conform to <codeVoice>RandomAccessCollection<\/codeVoice>, accessing the <codeVoice>count<\/codeVoice> property iterates through the elements of the collection.<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let horseName = \"Silver\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if horseName.isEmpty {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"My horse has no name.\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[} else {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Hi ho, \\(horseName)!\")]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"Hi ho, Silver!\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Complexity><Para>O(1)<\/Para><\/Complexity><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "isEmpty",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>isEmpty<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 46,
+            "key.line" : 30,
+            "key.modulename" : "Commandant",
+            "key.name" : "isEmpty",
+            "key.namelength" : 7,
+            "key.nameoffset" : 580,
+            "key.offset" : 576,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl7isEmptySbvp"
+              }
+            ],
+            "key.parsed_declaration" : "var isEmpty: Bool",
+            "key.parsed_scope.end" : 32,
+            "key.parsed_scope.start" : 30,
+            "key.typename" : "Bool",
+            "key.typeusr" : "$sSbD",
+            "key.usr" : "s:Sl7isEmptySbvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var startIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 29,
+            "key.bodyoffset" : 646,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var startIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If the collection is empty, `startIndex` is equal to `endIndex`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>startIndex<\/Name><USR>s:Sl10startIndex0B0Qzvp<\/USR><Declaration>var startIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The position of the first element in a nonempty collection.<\/Para><\/Abstract><Discussion><Para>If the collection is empty, <codeVoice>startIndex<\/codeVoice> is equal to <codeVoice>endIndex<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "startIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>startIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 51,
+            "key.line" : 34,
+            "key.modulename" : "Commandant",
+            "key.name" : "startIndex",
+            "key.namelength" : 10,
+            "key.nameoffset" : 629,
+            "key.offset" : 625,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl10startIndex0B0Qzvp"
+              }
+            ],
+            "key.parsed_declaration" : "var startIndex: Int",
+            "key.parsed_scope.end" : 36,
+            "key.parsed_scope.start" : 34,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl10startIndex0B0Qzvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var endIndex: <Type usr=\"s:Si\">Int<\/Type> { get }<\/Declaration>",
+            "key.bodylength" : 27,
+            "key.bodyoffset" : 698,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var endIndex: Self.Index { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "When you need a range that includes the last element of a collection, use the half-open range operator (`..<`) with `endIndex`. The `..<` operator creates a range that doesn’t include the upper bound, so it’s always safe to use with `endIndex`. For example:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "If the collection is empty, `endIndex` is equal to `startIndex`."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>endIndex<\/Name><USR>s:Sl8endIndex0B0Qzvp<\/USR><Declaration>var endIndex: Self.Index { get }<\/Declaration><CommentParts><Abstract><Para>The collection’s “past the end” position—that is, the position one greater than the last valid subscript argument.<\/Para><\/Abstract><Discussion><Para>When you need a range that includes the last element of a collection, use the half-open range operator (<codeVoice>..&lt;<\/codeVoice>) with <codeVoice>endIndex<\/codeVoice>. The <codeVoice>..&lt;<\/codeVoice> operator creates a range that doesn’t include the upper bound, so it’s always safe to use with <codeVoice>endIndex<\/codeVoice>. For example:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let numbers = [10, 20, 30, 40, 50]]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[if let index = numbers.firstIndex(of: 30) {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(numbers[index ..< numbers.endIndex])]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"[30, 40, 50]\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>If the collection is empty, <codeVoice>endIndex<\/codeVoice> is equal to <codeVoice>startIndex<\/codeVoice>.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "endIndex",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>endIndex<\/decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 47,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "endIndex",
+            "key.namelength" : 8,
+            "key.nameoffset" : 683,
+            "key.offset" : 679,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl8endIndex0B0Qzvp"
+              }
+            ],
+            "key.parsed_declaration" : "var endIndex: Int",
+            "key.parsed_scope.end" : 40,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "Int",
+            "key.typeusr" : "$sSiD",
+            "key.usr" : "s:Sl8endIndex0B0Qzvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>func index(after i: <Type usr=\"s:Si\">Int<\/Type>) -&gt; <Type usr=\"s:Si\">Int<\/Type><\/Declaration>",
+            "key.bodylength" : 34,
+            "key.bodyoffset" : 762,
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "func index(after i: Self.Index) -> Self.Index",
+            "key.doc.discussion" : [
+              {
+                "Para" : "The successor of an index must be well defined. For an index `i` into a collection `c`, calling `c.index(after: i)` returns the same index every time."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Function><Name>index(after:)<\/Name><USR>s:Sl5index5after5IndexQzAD_tF<\/USR><Declaration>func index(after i: Self.Index) -&gt; Self.Index<\/Declaration><CommentParts><Abstract><Para>Returns the position immediately after the given index.<\/Para><\/Abstract><Parameters><Parameter><Name>i<\/Name><Direction isExplicit=\"0\">in<\/Direction><Discussion><Para>A valid index of the collection. <codeVoice>i<\/codeVoice> must be less than <codeVoice>endIndex<\/codeVoice>.<\/Para><\/Discussion><\/Parameter><\/Parameters><ResultDiscussion><Para>The index value immediately after <codeVoice>i<\/codeVoice>.<\/Para><\/ResultDiscussion><Discussion><Para>The successor of an index must be well defined. For an index <codeVoice>i<\/codeVoice> into a collection <codeVoice>c<\/codeVoice>, calling <codeVoice>c.index(after: i)<\/codeVoice> returns the same index every time.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>Collection<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.name" : "index(after:)",
+            "key.doc.parameters" : [
+              {
+                "discussion" : [
+                  {
+                    "Para" : "A valid index of the collection. `i` must be less than `endIndex`."
+                  }
+                ],
+                "name" : "i"
+              }
+            ],
+            "key.doc.result_discussion" : [
+              {
+                "Para" : "The index value immediately after `i`."
+              }
+            ],
+            "key.doc.type" : "Function",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.method.instance><syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>index<\/decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>after<\/decl.var.parameter.argument_label> <decl.var.parameter.name>i<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int<\/ref.struct><\/decl.function.returntype><\/decl.function.method.instance>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 68,
+            "key.line" : 42,
+            "key.modulename" : "Commandant",
+            "key.name" : "index(after:)",
+            "key.namelength" : 19,
+            "key.nameoffset" : 734,
+            "key.offset" : 729,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:Sl5index5after5IndexQzAD_tF"
+              }
+            ],
+            "key.parsed_declaration" : "func index(after i: Int) -> Int",
+            "key.parsed_scope.end" : 44,
+            "key.parsed_scope.start" : 42,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "<T where T : Hashable> (OrderedSet<T>) -> (Int) -> Int",
+            "key.typeusr" : "$s5afterS2i_tcD",
+            "key.usr" : "s:Sl5index5after5IndexQzAD_tF"
+          }
+        ],
+        "key.typename" : "OrderedSet<T>.Type",
+        "key.typeusr" : "$s10Commandant10OrderedSetVyxGmD",
+        "key.usr" : "s:10Commandant10OrderedSetV"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Result+Additions.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 421,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.internal",
+        "key.annotated_decl" : "<Declaration>@frozen enum Result&lt;Success, Failure&gt; where <Type usr=\"s:s6ResultO7Failureq_mfp\">Failure<\/Type> : <Type usr=\"s:s5ErrorP\">Error<\/Type><\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.internal",
+            "key.length" : 8,
+            "key.offset" : 148
+          }
+        ],
+        "key.bodylength" : 244,
+        "key.bodyoffset" : 175,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.declaration" : "@frozen enum Result<Success, Failure> where Failure : Error",
+        "key.doc.full_as_xml" : "<Other><Name>Result<\/Name><USR>s:s6ResultO<\/USR><Declaration>@frozen enum Result&lt;Success, Failure&gt; where Failure : Error<\/Declaration><CommentParts><Abstract><Para>A value that represents either a success or a failure, including an associated value in each case.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.name" : "Result",
+        "key.doc.type" : "Other",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@frozen<\/syntaxtype.attribute.name><\/syntaxtype.attribute.builtin> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>Result<\/decl.name>&lt;<decl.generic_type_param usr=\"s:s6ResultO7Successxmfp\"><decl.generic_type_param.name>Success<\/decl.generic_type_param.name><\/decl.generic_type_param>, <decl.generic_type_param usr=\"s:s6ResultO7Failureq_mfp\"><decl.generic_type_param.name>Failure<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt; <syntaxtype.keyword>where<\/syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:s6ResultO7Failureq_mfp\">Failure<\/ref.generic_type_param> : <ref.protocol usr=\"s:s5ErrorP\">Error<\/ref.protocol><\/decl.generic_type_requirement><\/decl.enum>",
+        "key.groupname" : "Result",
+        "key.is_system" : true,
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 263,
+        "key.modulename" : "Swift",
+        "key.name" : "Result",
+        "key.namelength" : 6,
+        "key.nameoffset" : 167,
+        "key.offset" : 157,
+        "key.parsed_declaration" : "internal extension Result",
+        "key.parsed_scope.end" : 27,
+        "key.parsed_scope.start" : 9,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var value: <Type usr=\"s:s6ResultO10CommandantE7Successxmfp\">Success<\/Type>? { get }<\/Declaration>",
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 198,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>value<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:s6ResultO10CommandantE7Successxmfp\">Success<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 119,
+            "key.line" : 10,
+            "key.modulename" : "Commandant",
+            "key.name" : "value",
+            "key.namelength" : 5,
+            "key.nameoffset" : 181,
+            "key.offset" : 177,
+            "key.parsed_declaration" : "var value: Success?",
+            "key.parsed_scope.end" : 17,
+            "key.parsed_scope.start" : 10,
+            "key.typename" : "Success?",
+            "key.typeusr" : "$sxSgD",
+            "key.usr" : "s:s6ResultO10CommandantE5valuexSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.internal",
+            "key.annotated_decl" : "<Declaration>var error: <Type usr=\"s:s6ResultO10CommandantE7Failureq_mfp\">Failure<\/Type>? { get }<\/Declaration>",
+            "key.bodylength" : 97,
+            "key.bodyoffset" : 320,
+            "key.column" : 6,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>error<\/decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:s6ResultO10CommandantE7Failureq_mfp\">Failure<\/ref.generic_type_param>?<\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 119,
+            "key.line" : 19,
+            "key.modulename" : "Commandant",
+            "key.name" : "error",
+            "key.namelength" : 5,
+            "key.nameoffset" : 303,
+            "key.offset" : 299,
+            "key.parsed_declaration" : "var error: Failure?",
+            "key.parsed_scope.end" : 26,
+            "key.parsed_scope.start" : 19,
+            "key.typename" : "Failure?",
+            "key.typeusr" : "$sq_SgD",
+            "key.usr" : "s:s6ResultO10CommandantE5errorq_Sgvp"
+          }
+        ],
+        "key.typename" : "Result<Success, Failure>.Type",
+        "key.typeusr" : "$ss6ResultOyxq_GmD",
+        "key.usr" : "s:s6ResultO"
+      }
+    ]
+  }
+}, {
+  "\/Sources\/Commandant\/Switch.swift" : {
+    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
+    "key.length" : 2007,
+    "key.offset" : 0,
+    "key.substructure" : [
+      {
+        "key.accessibility" : "source.lang.swift.accessibility.public",
+        "key.annotated_decl" : "<Declaration>public struct Switch<\/Declaration>",
+        "key.attributes" : [
+          {
+            "key.attribute" : "source.decl.attribute.public",
+            "key.length" : 6,
+            "key.offset" : 375
+          }
+        ],
+        "key.bodylength" : 724,
+        "key.bodyoffset" : 397,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.comment" : "Describes a parameterless command line flag that defaults to false and can only\nbe switched on. Canonical examples include `--force` and `--recurse`.\n\nFor a boolean toggle that can be enabled and disabled use `Option<Bool>`.",
+        "key.doc.declaration" : "public struct Switch",
+        "key.doc.discussion" : [
+          {
+            "Para" : "For a boolean toggle that can be enabled and disabled use `Option<Bool>`."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"13\" column=\"15\"><Name>Switch<\/Name><USR>s:10Commandant6SwitchV<\/USR><Declaration>public struct Switch<\/Declaration><CommentParts><Abstract><Para>Describes a parameterless command line flag that defaults to false and can only be switched on. Canonical examples include <codeVoice>--force<\/codeVoice> and <codeVoice>--recurse<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>For a boolean toggle that can be enabled and disabled use <codeVoice>Option&lt;Bool&gt;<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "Switch",
+        "key.doc.type" : "Class",
+        "key.doclength" : 240,
+        "key.docoffset" : 135,
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Switch<\/decl.name><\/decl.struct>",
+        "key.kind" : "source.lang.swift.decl.struct",
+        "key.length" : 740,
+        "key.line" : 13,
+        "key.modulename" : "Commandant",
+        "key.name" : "Switch",
+        "key.namelength" : 6,
+        "key.nameoffset" : 389,
+        "key.offset" : 382,
+        "key.parsed_declaration" : "public struct Switch",
+        "key.parsed_scope.end" : 34,
+        "key.parsed_scope.start" : 13,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let key: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 515
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "The key that enables this switch. For example, a key of `verbose` would be\nused for a `--verbose` option.",
+            "key.doc.declaration" : "public let key: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"16\" column=\"13\"><Name>key<\/Name><USR>s:10Commandant6SwitchV3keySSvp<\/USR><Declaration>public let key: String<\/Declaration><CommentParts><Abstract><Para>The key that enables this switch. For example, a key of <codeVoice>verbose<\/codeVoice> would be used for a <codeVoice>--verbose<\/codeVoice> option.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 16,
+            "key.doc.name" : "key",
+            "key.doc.type" : "Other",
+            "key.doclength" : 115,
+            "key.docoffset" : 399,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>key<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 15,
+            "key.line" : 16,
+            "key.modulename" : "Commandant",
+            "key.name" : "key",
+            "key.namelength" : 3,
+            "key.nameoffset" : 526,
+            "key.offset" : 522,
+            "key.parsed_declaration" : "public let key: String",
+            "key.parsed_scope.end" : 16,
+            "key.parsed_scope.start" : 16,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV3keySSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let flag: <Type usr=\"s:SJ\">Character<\/Type>?<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 828
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "Optional single letter flag that enables this switch. For example, `-v` would\nbe used as a shorthand for `--verbose`.\n\nMultiple flags can be grouped together as a single argument and will split\nwhen parsing (e.g. `rm -rf` treats 'r' and 'f' as inidividual flags).",
+            "key.doc.declaration" : "public let flag: Character?",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Multiple flags can be grouped together as a single argument and will split when parsing (e.g. `rm -rf` treats ‘r’ and ‘f’ as inidividual flags)."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"23\" column=\"13\"><Name>flag<\/Name><USR>s:10Commandant6SwitchV4flagSJSgvp<\/USR><Declaration>public let flag: Character?<\/Declaration><CommentParts><Abstract><Para>Optional single letter flag that enables this switch. For example, <codeVoice>-v<\/codeVoice> would be used as a shorthand for <codeVoice>--verbose<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>Multiple flags can be grouped together as a single argument and will split when parsing (e.g. <codeVoice>rm -rf<\/codeVoice> treats ‘r’ and ‘f’ as inidividual flags).<\/Para><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.line" : 23,
+            "key.doc.name" : "flag",
+            "key.doc.type" : "Other",
+            "key.doclength" : 287,
+            "key.docoffset" : 540,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>flag<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct>?<\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 20,
+            "key.line" : 23,
+            "key.modulename" : "Commandant",
+            "key.name" : "flag",
+            "key.namelength" : 4,
+            "key.nameoffset" : 839,
+            "key.offset" : 835,
+            "key.parsed_declaration" : "public let flag: Character?",
+            "key.parsed_scope.end" : 23,
+            "key.parsed_scope.start" : 23,
+            "key.typename" : "Character?",
+            "key.typeusr" : "$sSJSgD",
+            "key.usr" : "s:10Commandant6SwitchV4flagSJSgvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public let usage: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 968
+              }
+            ],
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 13,
+            "key.doc.comment" : "A human-readable string describing the purpose of this option. This will\nbe shown in help messages.",
+            "key.doc.declaration" : "public let usage: String",
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"27\" column=\"13\"><Name>usage<\/Name><USR>s:10Commandant6SwitchV5usageSSvp<\/USR><Declaration>public let usage: String<\/Declaration><CommentParts><Abstract><Para>A human-readable string describing the purpose of this option. This will be shown in help messages.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+            "key.doc.line" : 27,
+            "key.doc.name" : "usage",
+            "key.doc.type" : "Other",
+            "key.doclength" : 109,
+            "key.docoffset" : 858,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>let<\/syntaxtype.keyword> <decl.name>usage<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 17,
+            "key.line" : 27,
+            "key.modulename" : "Commandant",
+            "key.name" : "usage",
+            "key.namelength" : 5,
+            "key.nameoffset" : 979,
+            "key.offset" : 975,
+            "key.parsed_declaration" : "public let usage: String",
+            "key.parsed_scope.end" : 27,
+            "key.parsed_scope.start" : 27,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV5usageSSvp"
+          },
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public init(flag: <Type usr=\"s:SJ\">Character<\/Type>? = nil, key: <Type usr=\"s:SS\">String<\/Type>, usage: <Type usr=\"s:SS\">String<\/Type>)<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 995
+              }
+            ],
+            "key.bodylength" : 59,
+            "key.bodyoffset" : 1060,
+            "key.column" : 9,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.constructor><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>init<\/syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>flag<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SJ\">Character<\/ref.struct>?<\/decl.var.parameter.type> = nil<\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>key<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>usage<\/decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>)<\/decl.function.constructor>",
+            "key.kind" : "source.lang.swift.decl.function.method.instance",
+            "key.length" : 118,
+            "key.line" : 29,
+            "key.modulename" : "Commandant",
+            "key.name" : "init(flag:key:usage:)",
+            "key.namelength" : 56,
+            "key.nameoffset" : 1002,
+            "key.offset" : 1002,
+            "key.parsed_declaration" : "public init(flag: Character? = nil, key: String, usage: String)",
+            "key.parsed_scope.end" : 33,
+            "key.parsed_scope.start" : 29,
+            "key.substructure" : [
+
+            ],
+            "key.typename" : "(Switch.Type) -> (Character?, String, String) -> Switch",
+            "key.typeusr" : "$s4flag3key5usage10Commandant6SwitchVSJSg_S2StcD",
+            "key.usr" : "s:10Commandant6SwitchV4flag3key5usageACSJSg_S2Stcfc"
+          }
+        ],
+        "key.typename" : "Switch.Type",
+        "key.typeusr" : "$s10Commandant6SwitchVmD",
+        "key.usr" : "s:10Commandant6SwitchV"
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public struct Switch<\/Declaration>",
+        "key.bodylength" : 140,
+        "key.bodyoffset" : 1167,
+        "key.column" : 15,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 15,
+        "key.doc.declaration" : "public struct Switch",
+        "key.doc.discussion" : [
+          {
+            "Para" : "For a boolean toggle that can be enabled and disabled use `Option<Bool>`."
+          }
+        ],
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+        "key.doc.full_as_xml" : "<Class file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"13\" column=\"15\"><Name>Switch<\/Name><USR>s:10Commandant6SwitchV<\/USR><Declaration>public struct Switch<\/Declaration><CommentParts><Abstract><Para>Describes a parameterless command line flag that defaults to false and can only be switched on. Canonical examples include <codeVoice>--force<\/codeVoice> and <codeVoice>--recurse<\/codeVoice>.<\/Para><\/Abstract><Discussion><Para>For a boolean toggle that can be enabled and disabled use <codeVoice>Option&lt;Bool&gt;<\/codeVoice>.<\/Para><\/Discussion><\/CommentParts><\/Class>",
+        "key.doc.line" : 13,
+        "key.doc.name" : "Switch",
+        "key.doc.type" : "Class",
+        "key.elements" : [
+          {
+            "key.kind" : "source.lang.swift.structure.elem.typeref",
+            "key.length" : 23,
+            "key.offset" : 1142
+          }
+        ],
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.struct><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>struct<\/syntaxtype.keyword> <decl.name>Switch<\/decl.name><\/decl.struct>",
+        "key.inheritedtypes" : [
+          {
+            "key.name" : "CustomStringConvertible"
+          }
+        ],
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 184,
+        "key.line" : 13,
+        "key.modulename" : "Commandant",
+        "key.name" : "Switch",
+        "key.namelength" : 6,
+        "key.nameoffset" : 1134,
+        "key.offset" : 1124,
+        "key.parsed_declaration" : "extension Switch: CustomStringConvertible",
+        "key.parsed_scope.end" : 44,
+        "key.parsed_scope.start" : 36,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public var description: <Type usr=\"s:SS\">String<\/Type> { get }<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1169
+              }
+            ],
+            "key.bodylength" : 104,
+            "key.bodyoffset" : 1201,
+            "key.column" : 13,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.declaration" : "var description: String { get }",
+            "key.doc.discussion" : [
+              {
+                "Para" : "Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the `String(describing:)` initializer. This initializer works with any type, and uses the custom `description` property for types that conform to `CustomStringConvertible`:"
+              },
+              {
+                "CodeListing" : ""
+              },
+              {
+                "Para" : "The conversion of `p` to a string in the assignment to `s` uses the `Point` type’s `description` property."
+              },
+              {
+                "Note" : ""
+              }
+            ],
+            "key.doc.full_as_xml" : "<Other><Name>description<\/Name><USR>s:s23CustomStringConvertibleP11descriptionSSvp<\/USR><Declaration>var description: String { get }<\/Declaration><CommentParts><Abstract><Para>A textual representation of this instance.<\/Para><\/Abstract><Discussion><Para>Calling this property directly is discouraged. Instead, convert an instance of any type to a string by using the <codeVoice>String(describing:)<\/codeVoice> initializer. This initializer works with any type, and uses the custom <codeVoice>description<\/codeVoice> property for types that conform to <codeVoice>CustomStringConvertible<\/codeVoice>:<\/Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[struct Point: CustomStringConvertible {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    let x: Int, y: Int]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    var description: String {]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[        return \"(\\(x), \\(y))\"]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[    }]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let p = Point(x: 21, y: 30)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[let s = String(describing: p)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(s)]]><\/zCodeLineNumbered><zCodeLineNumbered><![CDATA[\/\/ Prints \"(21, 30)\"]]><\/zCodeLineNumbered><zCodeLineNumbered><\/zCodeLineNumbered><\/CodeListing><Para>The conversion of <codeVoice>p<\/codeVoice> to a string in the assignment to <codeVoice>s<\/codeVoice> uses the <codeVoice>Point<\/codeVoice> type’s <codeVoice>description<\/codeVoice> property.<\/Para><Note><Para>This documentation comment was inherited from <codeVoice>CustomStringConvertible<\/codeVoice>.<\/Para><\/Note><\/Discussion><\/CommentParts><\/Other>",
+            "key.doc.name" : "description",
+            "key.doc.type" : "Other",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.instance><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>description<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type> { <syntaxtype.keyword>get<\/syntaxtype.keyword> }<\/decl.var.instance>",
+            "key.kind" : "source.lang.swift.decl.var.instance",
+            "key.length" : 130,
+            "key.line" : 37,
+            "key.modulename" : "Commandant",
+            "key.name" : "description",
+            "key.namelength" : 11,
+            "key.nameoffset" : 1180,
+            "key.offset" : 1176,
+            "key.overrides" : [
+              {
+                "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+              }
+            ],
+            "key.parsed_declaration" : "public var description: String",
+            "key.parsed_scope.end" : 43,
+            "key.parsed_scope.start" : 37,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:s23CustomStringConvertibleP11descriptionSSvp"
+          },
+          {
+            "key.annotated_decl" : "<Declaration>var options: <Type usr=\"s:SS\">String<\/Type><\/Declaration>",
+            "key.column" : 7,
+            "key.decl_lang" : "source.lang.swift",
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.var.local><syntaxtype.keyword>var<\/syntaxtype.keyword> <decl.name>options<\/decl.name>: <decl.var.type><ref.struct usr=\"s:SS\">String<\/ref.struct><\/decl.var.type><\/decl.var.local>",
+            "key.kind" : "source.lang.swift.decl.var.local",
+            "key.length" : 24,
+            "key.line" : 38,
+            "key.modulename" : "Commandant",
+            "key.name" : "options",
+            "key.namelength" : 7,
+            "key.nameoffset" : 1208,
+            "key.offset" : 1204,
+            "key.parsed_declaration" : "var options = \"--\\(key)\"",
+            "key.parsed_scope.end" : 38,
+            "key.parsed_scope.start" : 38,
+            "key.typename" : "String",
+            "key.typeusr" : "$sSSD",
+            "key.usr" : "s:10Commandant6SwitchV11descriptionSSvg7optionsL_SSvp"
+          }
+        ],
+        "key.typename" : "Switch.Type",
+        "key.typeusr" : "$s10Commandant6SwitchVmD",
+        "key.usr" : "s:10Commandant6SwitchV"
+      },
+      {
+        "key.kind" : "source.lang.swift.syntaxtype.comment.mark",
+        "key.length" : 17,
+        "key.name" : "MARK: - Operators",
+        "key.offset" : 1313
+      },
+      {
+        "key.annotated_decl" : "<Declaration>public enum CommandMode<\/Declaration>",
+        "key.bodylength" : 650,
+        "key.bodyoffset" : 1355,
+        "key.column" : 13,
+        "key.decl_lang" : "source.lang.swift",
+        "key.doc.column" : 13,
+        "key.doc.declaration" : "public enum CommandMode",
+        "key.doc.file" : "\/private\/Sources\/Commandant\/Command.swift",
+        "key.doc.full_as_xml" : "<Other file=\"\/private\/Sources\/Commandant\/Command.swift\" line=\"68\" column=\"13\"><Name>CommandMode<\/Name><USR>s:10Commandant11CommandModeO<\/USR><Declaration>public enum CommandMode<\/Declaration><CommentParts><Abstract><Para>Describes the “mode” in which a command should run.<\/Para><\/Abstract><\/CommentParts><\/Other>",
+        "key.doc.line" : 68,
+        "key.doc.name" : "CommandMode",
+        "key.doc.type" : "Other",
+        "key.filepath" : "",
+        "key.fully_annotated_decl" : "<decl.enum><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>enum<\/syntaxtype.keyword> <decl.name>CommandMode<\/decl.name><\/decl.enum>",
+        "key.kind" : "source.lang.swift.decl.extension",
+        "key.length" : 674,
+        "key.line" : 68,
+        "key.modulename" : "Commandant",
+        "key.name" : "CommandMode",
+        "key.namelength" : 11,
+        "key.nameoffset" : 1342,
+        "key.offset" : 1332,
+        "key.parsed_declaration" : "extension CommandMode",
+        "key.parsed_scope.end" : 67,
+        "key.parsed_scope.start" : 48,
+        "key.substructure" : [
+          {
+            "key.accessibility" : "source.lang.swift.accessibility.public",
+            "key.annotated_decl" : "<Declaration>public static func &lt;| &lt;ClientError&gt;(mode: <Type usr=\"s:10Commandant11CommandModeO\">CommandMode<\/Type>, option: <Type usr=\"s:10Commandant6SwitchV\">Switch<\/Type>) -&gt; <Type usr=\"s:s6ResultO\">Result<\/Type>&lt;<Type usr=\"s:Sb\">Bool<\/Type>, <Type usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/Type>&lt;<Type usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\">ClientError<\/Type>&gt;&gt;<\/Declaration>",
+            "key.attributes" : [
+              {
+                "key.attribute" : "source.decl.attribute.public",
+                "key.length" : 6,
+                "key.offset" : 1551
+              }
+            ],
+            "key.bodylength" : 333,
+            "key.bodyoffset" : 1670,
+            "key.column" : 21,
+            "key.decl_lang" : "source.lang.swift",
+            "key.doc.column" : 21,
+            "key.doc.comment" : "Evaluates the given boolean switch in the given mode.\n\nIf parsing command line arguments, and no value was specified on the command\nline, the option's `defaultValue` is used.",
+            "key.doc.declaration" : "public static func <| <ClientError>(mode: CommandMode, option: Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.doc.discussion" : [
+              {
+                "Para" : "If parsing command line arguments, and no value was specified on the command line, the option’s `defaultValue` is used."
+              }
+            ],
+            "key.doc.file" : "\/private\/Sources\/Commandant\/Switch.swift",
+            "key.doc.full_as_xml" : "<Function file=\"\/private\/Sources\/Commandant\/Switch.swift\" line=\"53\" column=\"21\"><Name>&lt;|(_:_:)<\/Name><USR>s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ<\/USR><Declaration>public static func &lt;| &lt;ClientError&gt;(mode: CommandMode, option: Switch) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/Declaration><CommentParts><Abstract><Para>Evaluates the given boolean switch in the given mode.<\/Para><\/Abstract><Discussion><Para>If parsing command line arguments, and no value was specified on the command line, the option’s <codeVoice>defaultValue<\/codeVoice> is used.<\/Para><\/Discussion><\/CommentParts><\/Function>",
+            "key.doc.line" : 53,
+            "key.doc.name" : "<|(_:_:)",
+            "key.doc.type" : "Function",
+            "key.doclength" : 193,
+            "key.docoffset" : 1357,
+            "key.filepath" : "",
+            "key.fully_annotated_decl" : "<decl.function.operator.infix><syntaxtype.keyword>public<\/syntaxtype.keyword> <syntaxtype.keyword>static<\/syntaxtype.keyword> <syntaxtype.keyword>func<\/syntaxtype.keyword> <decl.name>&lt;| <\/decl.name>&lt;<decl.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\"><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.name>mode<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:10Commandant11CommandModeO\">CommandMode<\/ref.enum><\/decl.var.parameter.type><\/decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>option<\/decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:10Commandant6SwitchV\">Switch<\/ref.struct><\/decl.var.parameter.type><\/decl.var.parameter>) -&gt; <decl.function.returntype><ref.enum usr=\"s:s6ResultO\">Result<\/ref.enum>&lt;<ref.struct usr=\"s:Sb\">Bool<\/ref.struct>, <ref.enum usr=\"s:10Commandant0A5ErrorO\">CommandantError<\/ref.enum>&lt;<ref.generic_type_param usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp\">ClientError<\/ref.generic_type_param>&gt;&gt;<\/decl.function.returntype><\/decl.function.operator.infix>",
+            "key.kind" : "source.lang.swift.decl.function.method.static",
+            "key.length" : 446,
+            "key.line" : 53,
+            "key.modulename" : "Commandant",
+            "key.name" : "<|(_:_:)",
+            "key.namelength" : 52,
+            "key.nameoffset" : 1570,
+            "key.offset" : 1558,
+            "key.parsed_declaration" : "public static func <| <ClientError> (mode: CommandMode, option: Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.parsed_scope.end" : 66,
+            "key.parsed_scope.start" : 53,
+            "key.related_decls" : [
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA8ArgumentVyxGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA8ArgumentVyAGGtAA0G8ProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Argument&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxAA0A5ErrorOyq_GGAC_AA6OptionVyxGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T&gt;) -&gt; Result&lt;T, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOyxSgAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;T?&gt;) -&gt; Result&lt;T?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGAA0A5ErrorOyq_GGAC_AA6OptionVyAGGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]&gt;) -&gt; Result&lt;[T], CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySayxGSgAA0A5ErrorOyq_GGAC_AA6OptionVyAHGtAA16ArgumentProtocolRzr0_lFZ\">&lt;| &lt;T, ClientError&gt;(_: CommandMode, _: Option&lt;[T]?&gt;) -&gt; Result&lt;[T]?, CommandantError&lt;ClientError&gt;&gt; where T : ArgumentProtocol<\/RelatedName>"
+              },
+              {
+                "key.annotated_decl" : "<RelatedName usr=\"s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6OptionVySbGtlFZ\">&lt;| &lt;ClientError&gt;(_: CommandMode, _: Option&lt;Bool&gt;) -&gt; Result&lt;Bool, CommandantError&lt;ClientError&gt;&gt;<\/RelatedName>"
+              }
+            ],
+            "key.substructure" : [
+              {
+                "key.annotated_decl" : "<Declaration>ClientError<\/Declaration>",
+                "key.column" : 25,
+                "key.decl_lang" : "source.lang.swift",
+                "key.filepath" : "",
+                "key.fully_annotated_decl" : "<decl.generic_type_param><decl.generic_type_param.name>ClientError<\/decl.generic_type_param.name><\/decl.generic_type_param>",
+                "key.kind" : "source.lang.swift.decl.generic_type_param",
+                "key.length" : 11,
+                "key.line" : 53,
+                "key.modulename" : "Commandant",
+                "key.name" : "ClientError",
+                "key.namelength" : 11,
+                "key.nameoffset" : 1574,
+                "key.offset" : 1574,
+                "key.parsed_declaration" : "public static func <| <ClientError",
+                "key.parsed_scope.end" : 53,
+                "key.parsed_scope.start" : 53,
+                "key.typename" : "ClientError.Type",
+                "key.typeusr" : "$sxmD",
+                "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ06ClientF0L_xmfp"
+              }
+            ],
+            "key.typename" : "<ClientError> (CommandMode.Type) -> (CommandMode, Switch) -> Result<Bool, CommandantError<ClientError>>",
+            "key.typeusr" : "$sys6ResultOySb10Commandant0B5ErrorOyxGGAC11CommandModeO_AC6SwitchVtcluD",
+            "key.usr" : "s:10Commandant11CommandModeO2looiys6ResultOySbAA0A5ErrorOyxGGAC_AA6SwitchVtlFZ"
+          }
+        ],
+        "key.typename" : "CommandMode.Type",
+        "key.typeusr" : "$s10Commandant11CommandModeOmD",
+        "key.usr" : "s:10Commandant11CommandModeO"
+      }
+    ]
+  }
+}]

--- a/Tests/SourceKittenFrameworkTests/ModuleTests.swift
+++ b/Tests/SourceKittenFrameworkTests/ModuleTests.swift
@@ -45,6 +45,13 @@ class ModuleTests: XCTestCase {
             return
         }
 
+        let pbxprojURL = URL(fileURLWithPath: "\(commandantPath)/Commandant.xcodeproj/project.pbxproj")
+        let originalPbxproj = try String(contentsOf: pbxprojURL)
+        let newPbxproj = originalPbxproj.replacingOccurrences(
+            of: "MACOSX_DEPLOYMENT_TARGET = 10.9",
+            with: "MACOSX_DEPLOYMENT_TARGET = 10.13"
+        )
+        try newPbxproj.data(using: .utf8)?.write(to: pbxprojURL)
         let arguments = ["-workspace", "Commandant.xcworkspace", "-scheme", "Commandant"]
         let commandantModule = try XCTUnwrap(Module(xcodeBuildArguments: arguments, name: nil, inPath: commandantPath))
         compareJSONString(withFixtureNamed: "Commandant", jsonString: commandantModule.docs,

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -79,11 +79,15 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func disabled_testSyntaxKinds() {
+    func testSyntaxKinds() {
+#if compiler(>=5.8)
         let expected = SyntaxKind.allCases
+#else
+        let expected = Set(SyntaxKind.allCases).subtracting([.operator])
+#endif
 
         let actual = sourcekitStrings(startingWith: "source.lang.swift.syntaxtype.")
-        let expectedStrings = Set(expected.map { $0.rawValue })
+        let expectedStrings = Set(expected.map(\.rawValue))
         XCTAssertEqual(
             actual,
             expectedStrings
@@ -94,7 +98,7 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func disabled_testSwiftDeclarationKind() {
+    func testSwiftDeclarationKind() {
         var expected = Set(SwiftDeclarationKind.allCases)
         let actual = sourcekitStrings(startingWith: "source.lang.swift.decl.")
 #if swift(>=2.2)
@@ -118,7 +122,7 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func disabled_testSwiftDeclarationAttributeKind() { // swiftlint:disable:this function_body_length
+    func testSwiftDeclarationAttributeKind() { // swiftlint:disable:this function_body_length
         var expected = Set(SwiftDeclarationAttributeKind.allCases)
         let attributesFoundInSwift5ButWeIgnore = [
             "source.decl.attribute.GKInspectable",

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -135,6 +135,16 @@ class SourceKitTests: XCTestCase {
         let actual = sourcekitStrings(startingWith: "source.decl.attribute.")
             .subtracting(attributesFoundInSwift5ButWeIgnore)
 
+#if compiler(>=5.8)
+        // removed in Swift 5.8
+        expected.subtract([._typeSequence, ._backDeploy])
+#else
+        // added in Swift 5.8
+        expected.subtract([.backDeployed, ._noEagerMove, .typeWrapperIgnored, ._spiOnly, ._moveOnly,
+                           ._noMetadata, ._alwaysEmitConformanceMetadata, .runtimeMetadata,
+                           ._objcImplementation, ._eagerMove, .typeWrapper, ._expose, ._documentation])
+#endif
+
 #if compiler(>=5.6)
         // removed in Swift 5.6
         expected.subtract([.asyncHandler, .actorIndependent, .spawn, ._unsafeMainActor, ._unsafeSendable])

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -257,7 +257,7 @@ class SourceKitTests: XCTestCase {
         let actualStructure = Structure(sourceKitResponse: output)
         XCTAssertEqual(expectedStructure, actualStructure)
     }
-#if compiler(<5.9)
+#if compiler(<5.8)
     func testSyntaxTree() throws {
         let file = File(path: "\(fixturesDirectory)Bicycle.swift")!
         let request = Request.syntaxTree(file: file, byteTree: false)

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -111,7 +111,10 @@ class SourceKitTests: XCTestCase {
 #if !compiler(>=5.1)
         expected.remove(.opaqueType)
 #endif
-        let expectedStrings = Set(expected.map { $0.rawValue })
+#if compiler(<5.8)
+        expected.remove(.macro)
+#endif
+        let expectedStrings = Set(expected.map(\.rawValue))
         XCTAssertEqual(
             actual,
             expectedStrings

--- a/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitTests.swift
@@ -79,7 +79,7 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func testSyntaxKinds() {
+    func disabled_testSyntaxKinds() {
         let expected = SyntaxKind.allCases
 
         let actual = sourcekitStrings(startingWith: "source.lang.swift.syntaxtype.")
@@ -94,7 +94,7 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func testSwiftDeclarationKind() {
+    func disabled_testSwiftDeclarationKind() {
         var expected = Set(SwiftDeclarationKind.allCases)
         let actual = sourcekitStrings(startingWith: "source.lang.swift.decl.")
 #if swift(>=2.2)
@@ -118,7 +118,7 @@ class SourceKitTests: XCTestCase {
         }
     }
 
-    func testSwiftDeclarationAttributeKind() { // swiftlint:disable:this function_body_length
+    func disabled_testSwiftDeclarationAttributeKind() { // swiftlint:disable:this function_body_length
         var expected = Set(SwiftDeclarationAttributeKind.allCases)
         let attributesFoundInSwift5ButWeIgnore = [
             "source.decl.attribute.GKInspectable",

--- a/Tests/SourceKittenFrameworkTests/StructureTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StructureTests.swift
@@ -57,12 +57,12 @@ class StructureTests: XCTestCase {
                                     "key.length": 5,
                                     "key.nameoffset": 19,
                                     "key.namelength": 5
-                                ] as [String : Any]
+                                ] as [String: Any]
                             ]
-                        ] as [String : Any]
+                        ] as [String: Any]
                     ],
                     "key.name": "MyEnum"
-                ] as [String : Any]
+                ] as [String: Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
@@ -132,12 +132,12 @@ class StructureTests: XCTestCase {
                             "key.kind": "source.lang.swift.structure.elem.typeref",
                             "key.offset": 11,
                             "key.length": 3
-                        ] as [String : Any]
+                        ] as [String: Any]
                     ],
                     "key.inheritedtypes": [
                         ["key.name": "Bar"]
                     ]
-                ] as [String : Any]
+                ] as [String: Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
@@ -201,10 +201,10 @@ class StructureTests: XCTestCase {
                             "key.bodylength": 0,
                             "key.length": 11,
                             "key.name": "b()"
-                        ] as [String : Any]
+                        ] as [String: Any]
                     ],
                     "key.name": "A"
-                ] as [String : Any]
+                ] as [String: Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",

--- a/Tests/SourceKittenFrameworkTests/StructureTests.swift
+++ b/Tests/SourceKittenFrameworkTests/StructureTests.swift
@@ -9,7 +9,7 @@ class StructureTests: XCTestCase {
             "key.offset": 0,
             "key.length": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
-            "key.substructure": []
+            "key.substructure": [] as NSArray
         ]
         let structure = try Structure(file: File(contents: ""))
         XCTAssertEqual(toNSDictionary(structure.dictionary), expected, "should generate expected structure")
@@ -57,12 +57,12 @@ class StructureTests: XCTestCase {
                                     "key.length": 5,
                                     "key.nameoffset": 19,
                                     "key.namelength": 5
-                                ]
+                                ] as [String : Any]
                             ]
-                        ]
+                        ] as [String : Any]
                     ],
                     "key.name": "MyEnum"
-                ]
+                ] as [String : Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
@@ -132,12 +132,12 @@ class StructureTests: XCTestCase {
                             "key.kind": "source.lang.swift.structure.elem.typeref",
                             "key.offset": 11,
                             "key.length": 3
-                        ]
+                        ] as [String : Any]
                     ],
                     "key.inheritedtypes": [
                         ["key.name": "Bar"]
                     ]
-                ]
+                ] as [String : Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",
@@ -201,10 +201,10 @@ class StructureTests: XCTestCase {
                             "key.bodylength": 0,
                             "key.length": 11,
                             "key.name": "b()"
-                        ]
+                        ] as [String : Any]
                     ],
                     "key.name": "A"
-                ]
+                ] as [String : Any]
             ],
             "key.offset": 0,
             "key.diagnostic_stage": "source.diagnostic.stage.swift.parse",

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -157,7 +157,7 @@ class SwiftDocsTests: XCTestCase {
             "key.doc.parameters": [[
                 "name": "param1",
                 "discussion": [["Para": "param1_discussion"]]
-            ]],
+            ] as [String : Any]],
             "key.doc.result_discussion": [["Para": "result_discussion"]]
         ]
         XCTAssertEqual(toNSDictionary(parsedPreSwift32), expected)

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -60,7 +60,8 @@ private func compareDocs(withFixtureNamed name: String, file: StaticString = #fi
 
 private func versionedExpectedFilename(for name: String) -> String {
 #if compiler(>=5.9)
-    let versions = ["swift-5.9", "swift-5.8", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
+    let versions = ["swift-5.9", "swift-5.8", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1",
+                    "swift-5.0"]
 #elseif compiler(>=5.8)
     let versions = ["swift-5.8", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
 #elseif compiler(>=5.6)
@@ -163,7 +164,7 @@ class SwiftDocsTests: XCTestCase {
             "key.doc.parameters": [[
                 "name": "param1",
                 "discussion": [["Para": "param1_discussion"]]
-            ] as [String : Any]],
+            ] as [String: Any]],
             "key.doc.result_discussion": [["Para": "result_discussion"]]
         ]
         XCTAssertEqual(toNSDictionary(parsedPreSwift32), expected)

--- a/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SwiftDocsTests.swift
@@ -60,7 +60,9 @@ private func compareDocs(withFixtureNamed name: String, file: StaticString = #fi
 
 private func versionedExpectedFilename(for name: String) -> String {
 #if compiler(>=5.9)
-    let versions = ["swift-5.9", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
+    let versions = ["swift-5.9", "swift-5.8", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
+#elseif compiler(>=5.8)
+    let versions = ["swift-5.8", "swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
 #elseif compiler(>=5.6)
     let versions = ["swift-5.6", "swift-5.5.2", "swift-5.5", "swift-5.4", "swift-5.3.1", "swift-5.3", "swift-5.2", "swift-5.1", "swift-5.0"]
 #elseif compiler(>=5.5.2)
@@ -110,7 +112,11 @@ private func diff(original: String, modified: String) -> String {
 }
 
 private let buildingSwiftVersion: String = {
-#if compiler(>=5.6)
+#if compiler(>=5.9)
+    return "swift-5.9"
+#elseif compiler(>=5.8)
+    return "swift-5.8"
+#elseif compiler(>=5.6)
     return "swift-5.6"
 #elseif compiler(>=5.5.0)
     return "swift-5.5"


### PR DESCRIPTION
- Add type hints to resolve Swift 5.8 warnings
- Add 5.8 test fixtures
- Adjust compiler versions in tests
- Add `source.lang.swift.syntaxtype.operator` syntax kind
- Add `source.lang.swift.decl.macro` declaration kind
- Add new declaration attribute kinds