### PR TITLE
Tests: escape the path separator for Windows

### DIFF
--- a/Tests/SourceKittenFrameworkTests/SourceKitObjectTests.swift
+++ b/Tests/SourceKittenFrameworkTests/SourceKitObjectTests.swift
@@ -1,10 +1,13 @@
+import Foundation
 import SourceKittenFramework
 import XCTest
 
 class SourceKitObjectTests: XCTestCase {
 
     func testExample() {
-        let path = #file
+        let path =
+            URL(fileURLWithPath: #file)
+                .withUnsafeFileSystemRepresentation { String(cString: $0!) }
         let object: SourceKitObject = [
             "key.request": UID("source.request.editor.open"),
             "key.name": path,
@@ -13,8 +16,8 @@ class SourceKitObjectTests: XCTestCase {
         let expected = """
             {
               key.request: source.request.editor.open,
-              key.name: \"\(#file)\",
-              key.sourcefile: \"\(#file)\"
+              key.name: \"\((#file).replacingOccurrences(of: "\\", with: "\\\\"))\",
+              key.sourcefile: \"\((#file).replacingOccurrences(of: "\\", with: "\\\\"))\"
             }
             """
         XCTAssertEqual(object.description, expected)


### PR DESCRIPTION
`\` must be escaped for valid JSON.  Ensure that we properly escape the character and form the reference string with the proper representation of the path.