### PR TITLE
Allow Swift Argument Parser versions from 1.2.1 to 2.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "4ad606ba5d7673ea60679a61ff867cc1ff8c8e86",
-        "version" : "1.2.1"
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .library(name: "SourceKittenFramework", targets: ["SourceKittenFramework"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.3.0")),
-        .package(url: "https://github.com/drmohundro/SWXMLHash.git", .upToNextMinor(from: "7.0.2")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.1"),
+        .package(url: "https://github.com/drmohundro/SWXMLHash.git", from: "7.0.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.5"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "SourceKittenFramework", targets: ["SourceKittenFramework"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.3.0")),
         .package(url: "https://github.com/drmohundro/SWXMLHash.git", .upToNextMinor(from: "7.0.2")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.5"),
     ],


### PR DESCRIPTION
This lower version number is preventing packages from using [SwiftLint](https://github.com/realm/SwiftLint) and the [Swift OpenAPI Generator](https://github.com/apple/swift-openapi-generator) in the same package.