### PR TITLE
fix(linux): detect swift symlinked to bin dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ##### Bug Fixes
 
+* Fix an issue where the path to the SourceKit library would not be properly
+  detected on Linux, when the swift executable was symlinked into a directory
+  in PATH from its actual install tree.  
+  [Julia DeMille](https://github.com/judemille)
+
 * Fix a crash when a file cannot be read as UTF-8.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#765](https://github.com/jpsim/SourceKitten/issues/765)

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -69,6 +69,10 @@ private extension String {
             .reduce(URL(fileURLWithPath: self)) { url, _ in url.deletingLastPathComponent() }
             .path
     }
+
+    func resolvingSymlinksInPath() -> String {
+        return URL(fileURLWithPath: self).resolvingSymlinksInPath().path
+    }
 }
 
 #if os(Linux)
@@ -111,7 +115,7 @@ internal let linuxFindSwiftInstallationLibPath: String? = {
     }
 
     /// .../bin/swift -> .../lib
-    return swiftPath.deleting(lastPathComponents: 2).appending(pathComponent: "/lib")
+    return swiftPath.resolvingSymlinksInPath().deleting(lastPathComponents: 2).appending(pathComponent: "/lib")
 }()
 
 /// Fallback path on Linux if no better option is available.


### PR DESCRIPTION
Currently, if Swift is installed in, say `/usr/lib/swift`, but `/usr/bin/swift`
has been symlinked to `/usr/lib/swift/bin/swift`, then SourceKitten will fail
to detect Swift's install directory. This PR fixes that, by reading symlinks
on the detected Swift executable.
