### PR TITLE
Introduce `UncheckedSendable` type for wrapping non-sendable types

### DIFF
--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -110,11 +110,11 @@ public final class SourceKitObject {
     }
 
     func sendAsync() async throws -> sourcekitd_response_t {
-        let handle = UnsafeMutablePointer<sourcekitd_request_handle_t?>.allocate(capacity: 1)
+        let handle = UncheckedSendable(UnsafeMutablePointer<sourcekitd_request_handle_t?>.allocate(capacity: 1))
 
         return try await withTaskCancellationHandler {
             try await withUnsafeThrowingContinuation { continuation in
-                sourcekitd_send_request(sourcekitdObject, handle) { response in
+                sourcekitd_send_request(sourcekitdObject, handle.value) { response in
                     enum SourceKitSendError: Error { case error, noResponse }
 
                     guard let response else {
@@ -130,7 +130,7 @@ public final class SourceKitObject {
                 }
             }
         } onCancel: {
-            sourcekitd_cancel_request(handle)
+            sourcekitd_cancel_request(handle.value)
         }
     }
 }

--- a/Source/SourceKittenFramework/UncheckedSendable.swift
+++ b/Source/SourceKittenFramework/UncheckedSendable.swift
@@ -1,0 +1,11 @@
+struct UncheckedSendable<Value>: @unchecked Sendable {
+    /// The unchecked value.
+    var value: Value
+
+    /// Initializes unchecked sendability around a value.
+    ///
+    /// - Parameter value: A value to make sendable in an unchecked way.
+    init(_ value: Value) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
Fixes #805

Introduce an [`UncheckedSendable`](https://github.com/pointfreeco/swift-concurrency-extras?tab=readme-ov-file#uncheckedsendable) type for wrapping non-sendable types in a `@Sendable` context. 

More context on why unsafe pointer types are no longer Sendable: https://forums.swift.org/t/unsafepointer-sendable-should-be-revoked/51926

The [change was merged](https://github.com/apple/swift/pull/39218) some time ago and only the warning is new in Xcode 15.3 betas so the behavior shouldn't be affected by this change.

`extension UnsafeMutablePointer: @unchecked Sendable {}` would've also silenced the warning but would go against the points made in the forums discussion. Keeping the `UncheckedSendable` wrapper forces to acknowledge the context and solution.

Open to try different approaches but this is the one I'm familiar with.