### PR TITLE
Update Xcode versions used on actions

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,7 +10,7 @@ jobs:
   MacOS:
     strategy:
       matrix:
-        xcode_version: ['14.1', '14.3.1']
+        xcode_version: ['14.3.1', '15.2']
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app

--- a/.github/workflows/pod_lib_lint.yml
+++ b/.github/workflows/pod_lib_lint.yml
@@ -10,6 +10,8 @@ jobs:
   pod_lib_lint:
     name: pod lib lint
     runs-on: macos-13
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v3
       - run: bundle install --path vendor/bundle

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -10,7 +10,7 @@ jobs:
   Xcode:
     strategy:
       matrix:
-        xcode_version: ['14.1', '14.3.1']
+        xcode_version: ['14.3.1', '15.2']
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -10,7 +10,7 @@ jobs:
   Xcode:
     strategy:
       matrix:
-        xcode_version: ['14.1', '14.3.1']
+        xcode_version: ['14.3.1', '15.2']
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app


### PR DESCRIPTION
- [x] Update the Xcode versions used in GitHub Actions.
- [x] Add an explicit version to the `pod lib lint` action to prevent image runner updates from breaking the job (https://github.com/jpsim/SourceKitten/pull/808)