### PR TITLE
Adds support for rules_swift 2.x.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -10,7 +10,7 @@ jobs:
   MacOS:
     strategy:
       matrix:
-        xcode_version: ['14.3.1', '15.2', '15.3']
+        xcode_version: ['15.2', '15.3']
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v2

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,10 +6,11 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.8", dev_dependency = True)
 bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_swift", version = "1.15.1", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
-bazel_dep(name = "swxmlhash", version = "7.0.2", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
-bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
+bazel_dep(name = "rules_swift", version = "2.0.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
+bazel_dep(name = "swxmlhash", version = "7.0.2.1", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
+bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
+bazel_dep(name = "rules_cc", version = "0.0.2")
 
 apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")

--- a/Source/BUILD
+++ b/Source/BUILD
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_c_module")
+load("@build_bazel_rules_swift//swift:swift_interop_hint.bzl", "swift_interop_hint")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 exports_files(glob(["SourceKittenFramework/**/*.swift"]))
 
@@ -11,12 +12,17 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-swift_c_module(
+cc_library(
     name = "Clang_C",
-    module_map = "Clang_C/Clang_C.modulemap",
-    module_name = "Clang_C",
+    aspect_hints = [":Clang_C_SwiftInterop"],
     visibility = ["//visibility:public"],
     deps = [":Clang_CLibrary"],
+)
+
+swift_interop_hint(
+    name = "Clang_C_SwiftInterop",
+    module_map = "Clang_C/Clang_C.modulemap",
+    module_name = "Clang_C",
 )
 
 cc_library(
@@ -28,12 +34,17 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-swift_c_module(
+cc_library(
     name = "SourceKit",
-    module_map = "SourceKit/SourceKit.modulemap",
-    module_name = "SourceKit",
+    aspect_hints = [":SourceKit_SwiftInterop"],
     visibility = ["//visibility:public"],
     deps = [":SourceKitLibrary"],
+)
+
+swift_interop_hint(
+    name = "SourceKit_SwiftInterop",
+    module_map = "SourceKit/SourceKit.modulemap",
+    module_name = "SourceKit",
 )
 
 filegroup(


### PR DESCRIPTION
This does force users using this version of sourcekitten to also use rules_swift because of the `swift_c_module` removal.

Outstanding issues:

- [x] `max_compatibility_level` needs to be updated for deps that use rules_swift 
- [x] Need a real `2.0.0` release before we can move of the release candidate

Requires the following:

- https://github.com/jpsim/Yams/pull/420