### PR TITLE
Handle key.educational_note_paths in SourceKit output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Main
+
+#### Breaking
+
+* None.
+
+#### Enhancements
+
+* Build without warnings with Swift 6 compiler.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
+* Generate docs cleanly with Swift 6 compiler.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#821]((https://github.com/realm/SourceKitten/issues/821)
+
+#### Bug Fixes
+
+* None.
+
 ## 0.36.0
 
 ##### Breaking

--- a/Source/SourceKittenFramework/JSONOutput.swift
+++ b/Source/SourceKittenFramework/JSONOutput.swift
@@ -43,28 +43,28 @@ public func toJSON(_ object: Any, options: JSONSerialization.WritingOptions? = n
  - returns: JSON-serializable value.
  */
 public func toNSDictionary(_ dictionary: [String: SourceKitRepresentable]) -> NSDictionary {
-    var anyDictionary = [String: Any]()
-    for (key, object) in dictionary {
+    func toNSDictionaryValue(_ object: SourceKitRepresentable) -> Any {
         switch object {
         case let object as [SourceKitRepresentable]:
-            anyDictionary[key] = object.map { toNSDictionary($0 as! [String: SourceKitRepresentable]) }
+            return object.map { toNSDictionaryValue($0) }
         case let object as [[String: SourceKitRepresentable]]:
-            anyDictionary[key] = object.map { toNSDictionary($0) }
+            return object.map { toNSDictionary($0) }
         case let object as [String: SourceKitRepresentable]:
-            anyDictionary[key] = toNSDictionary(object)
+            return toNSDictionary(object)
         case let object as String:
-            anyDictionary[key] = object
+            return object
         case let object as Int64:
-            anyDictionary[key] = NSNumber(value: object)
+            return NSNumber(value: object)
         case let object as Bool:
-            anyDictionary[key] = NSNumber(value: object)
+            return NSNumber(value: object)
         case let object as Any:
-            anyDictionary[key] = object
+            return object
         default:
             fatalError("Should never happen because we've checked all SourceKitRepresentable types")
         }
     }
-    return anyDictionary.bridge()
+
+    return dictionary.mapValues(toNSDictionaryValue).bridge()
 }
 
 #if !os(Linux)


### PR DESCRIPTION
We've never had straight arrays of strings before, this is new in Swift 6 (`"key.educational_note_paths"`):
```json
{
  "\/Users\/johnf\/project\/JazzyEx\/JazzyEx\/JazzyEx.swift" : {
    "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
    "key.diagnostics" : [
      {
        "key.column" : 12,
        "key.description" : "extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode",
        "key.diagnostic_stage" : "source.diagnostic.stage.swift.parse",
        "key.educational_note_paths" : [
          "error-in-future-swift-version.md"
        ],
        "key.id" : "error_in_future_swift_version",
        "key.line" : 2,
        "key.severity" : "source.diagnostic.severity.warning"
      }
    ],
    "key.length" : 43,
...
```

Attempt refactor to remove the assumption causing the force-unwrap fail.  New version runs the breaking code cleanly, passes the tests here, and also passes the full jazzy spec suite without breaking anything.

Fixes #821.