### PR TITLE
Support Musl C standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 #### Enhancements
 
+* Support compilation with Musl C standard library.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Build without warnings with Swift 6 compiler.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
 * Generate docs cleanly with Swift 6 compiler.  
   [John Fairhurst](https://github.com/johnfairh)
-  [#821]((https://github.com/realm/SourceKitten/issues/821)
+  [#821](https://github.com/realm/SourceKitten/issues/821)
 
 * Added new syntax, attribute and declaration kinds introduced in Swift 6.0.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SourceKittenFramework/SourceKitObject.swift
+++ b/Source/SourceKittenFramework/SourceKitObject.swift
@@ -1,14 +1,21 @@
 import Foundation
+
 #if SWIFT_PACKAGE
 import SourceKit
 #endif
 
-#if os(Linux)
+#if os(macOS)
+import Darwin
+#elseif os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif os(Windows)
 import ucrt
 #else
-import Darwin
+#error("Unsupported platform")
 #endif
 
 // MARK: - SourceKitObjectConvertible
@@ -86,7 +93,7 @@ public final class SourceKitObject {
     ///
     /// - Parameters:
     ///   - value: The new value to add to the dictionary.
-    ///   - key: The key to associate with value. If key already exists in the dictionary, 
+    ///   - key: The key to associate with value. If key already exists in the dictionary,
     ///     value replaces the existing associated value. If key isn't already a key of the dictionary
     public func updateValue(_ value: SourceKitObjectConvertible, forKey key: UID) {
         precondition(value.sourceKitObject != nil)

--- a/Source/SourceKittenFramework/SwiftDocs.swift
+++ b/Source/SourceKittenFramework/SwiftDocs.swift
@@ -4,12 +4,18 @@ import Foundation
 import SourceKit
 #endif
 
-#if os(Linux)
-import Glibc
-#elseif os(Windows)
-import CRT
-#else
+#if os(macOS)
 import Darwin
+#elseif os(Linux)
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+#elseif os(Windows)
+import ucrt
+#else
+#error("Unsupported platform")
 #endif
 
 /// Represents docs for a Swift file.

--- a/Source/sourcekitten/main.swift
+++ b/Source/sourcekitten/main.swift
@@ -1,14 +1,19 @@
 import ArgumentParser
-#if canImport(Darwin)
+import Dispatch
+
+#if os(macOS)
 import Darwin
-#elseif canImport(Glibc)
+#elseif os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 #elseif os(Windows)
 import ucrt
 #else
 #error("Unsupported platform")
 #endif
-import Dispatch
 
 // `sourcekitd_set_notification_handler()` sets the handler to be executed on main thread queue.
 // So, we vacate main thread to `dispatchMain()`.


### PR DESCRIPTION
This allows compilation with the [static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) in project consuming SourceKitten as a dependency.