### PR TITLE
SPM: Explicit declarations for external dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Main
+
+#### Breaking
+
+* None.
+
+#### Enhancements
+
+* Fully specify package dependencies for wider compatibility.  
+  [Anthony Ilinykh](https://github.com/ailinykh)
+
+#### Bug Fixes
+
+* None.
+
 ## 0.37.0
 
 #### Breaking

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,8 @@ let package = Package(
             dependencies: [
                 "Clang_C",
                 "SourceKit",
-                "SWXMLHash",
-                "Yams",
+                .product(name: "SWXMLHash", package: "SWXMLHash"),
+                .product(name: "Yams", package: "Yams"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
When I tried to build my project using Xcode 16, I got an error:
```bash
error: 'sourcekitten': dependency 'Yams' in target 'SourceKittenFramework' requires explicit declaration; reference the package in the target dependency with '.product(name: "Yams", package: "yams")'
make: *** [build] Error 1
```