### PR TITLE
Support rules_swift 3.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,15 +1,15 @@
 module(
     name = "sourcekitten",
-    version = "0.37.0",
+    version = "0.37.1",
     compatibility_level = 1,
 )
 
 bazel_dep(name = "platforms", version = "0.0.8", dev_dependency = True)
 bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_swift", version = "2.0.0", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
-bazel_dep(name = "swxmlhash", version = "7.0.2.1", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
-bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
+bazel_dep(name = "rules_swift", version = "2.0.0", max_compatibility_level = 3, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "swift_argument_parser", version = "1.3.1.2", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
+bazel_dep(name = "swxmlhash", version = "7.0.2.2", repo_name = "sourcekitten_com_github_drmohundro_SWXMLHash")
+bazel_dep(name = "yams", version = "6.0.1", repo_name = "sourcekitten_com_github_jpsim_yams")
 bazel_dep(name = "rules_cc", version = "0.0.2")
 
 apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")


### PR DESCRIPTION
Update `max_compatibility_level` for rules_swift and update dependencies to do the same.