### PR TITLE
Surface dlerror/GetLastError reason on Loader load failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * New syntax, attribute and declaration kinds introduced in Swift 6.1-6.3.  
   [John Fairhurst](https://github.com/johnfairh)
+* Improve reporting of `sourcekitdInProc` loading failures.  
+  [Daniel Sunarjo](https://github.com/sunarjodaniel)
 
 #### Bug Fixes
 

--- a/Source/SourceKittenFramework/library_wrapper.swift
+++ b/Source/SourceKittenFramework/library_wrapper.swift
@@ -43,19 +43,36 @@ struct Loader {
 
         // try all fullPaths that contains target file,
         // then try loading with simple path that depends resolving to DYLD
+        var attemptFailures: [String] = []
         for fullPath in fullPaths + [path] {
 #if os(Windows)
             if let handle = fullPath.withCString(encodedAs: UTF16.self, LoadLibraryW) {
                 return DynamicLinkLibrary(handle: handle)
             }
+            attemptFailures.append("  \(fullPath): GetLastError=\(GetLastError())")
 #else
             if let handle = dlopen(fullPath, RTLD_LAZY) {
                 return DynamicLinkLibrary(handle: handle)
             }
+            // dlerror() must be read immediately after a failed dlopen; it clears on read.
+            let reason = dlerror().flatMap { String(validatingUTF8: $0) } ?? "<no error reported by dlerror>"
+            attemptFailures.append("  \(fullPath): \(reason)")
 #endif
         }
 
-        fatalError("Loading \(path) failed")
+        fatalError(Loader.failureMessage(path: path, attemptFailures: attemptFailures))
+    }
+
+    /// Builds the diagnostic emitted when no candidate path could be loaded.
+    /// Extracted so the message can be exercised in tests without triggering a fatal error.
+    static func failureMessage(path: String, attemptFailures: [String]) -> String {
+        guard !attemptFailures.isEmpty else {
+            return "Loading \(path) failed: no candidate paths were attempted (check searchPaths configuration)."
+        }
+        return """
+        Loading \(path) failed. Tried:
+        \(attemptFailures.joined(separator: "\n"))
+        """
     }
 }
 

--- a/Tests/SourceKittenFrameworkTests/LoaderTests.swift
+++ b/Tests/SourceKittenFrameworkTests/LoaderTests.swift
@@ -1,0 +1,30 @@
+@testable import SourceKittenFramework
+import XCTest
+
+final class LoaderTests: XCTestCase {
+
+    func testFailureMessageIncludesEveryAttemptAndItsReason() {
+        let message = Loader.failureMessage(
+            path: "sourcekitdInProc.framework/Versions/A/sourcekitdInProc",
+            attemptFailures: [
+                "  /Xcode.app/.../usr/lib/sourcekitdInProc.framework/Versions/A/sourcekitdInProc: " +
+                    "mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')",
+                "  sourcekitdInProc.framework/Versions/A/sourcekitdInProc: image not found"
+            ]
+        )
+
+        // The path being loaded is named.
+        XCTAssertTrue(message.contains("sourcekitdInProc.framework/Versions/A/sourcekitdInProc"))
+        // Every attempt's dlerror() reason survives into the final message.
+        XCTAssertTrue(message.contains("incompatible architecture"))
+        XCTAssertTrue(message.contains("image not found"))
+    }
+
+    func testFailureMessageWhenNoCandidatesWereTried() {
+        // Empty searchPaths *and* an empty bare path attempt should produce an actionable hint
+        // rather than a bare "Loading X failed" with no further detail.
+        let message = Loader.failureMessage(path: "libfoo.so", attemptFailures: [])
+        XCTAssertTrue(message.contains("libfoo.so"))
+        XCTAssertTrue(message.contains("searchPaths"))
+    }
+}


### PR DESCRIPTION
## Summary

Today, when `Loader.load(path:)` cannot dlopen `sourcekitdInProc` it traps with the bare message `Loading <path> failed`. That message discards the actual OS error and forces downstream users (SwiftLint, jazzy, sourcekitten itself) to guess at the root cause. Users hitting this — e.g. [realm/SwiftLint#6475](https://github.com/realm/SwiftLint/issues/6475) — end up chasing red herrings (sandboxing, Xcode versions, mise pinning) before the actual cause is found.

This PR collects `dlerror()` (POSIX) / `GetLastError()` (Windows) for **every** candidate path attempted, and includes them in the fatalError message. Successful-load paths are unchanged.

## Why it matters

The motivating case is Xcode 26 shipping `sourcekitdInProc.framework` as **arm64-only**. When SwiftLint is invoked from an x86_64-rooted process tree (e.g. an x86_64 Ruby running fastlane on an Apple Silicon machine), the universal SwiftLint binary launches x86_64 to match its parent, and dlopen fails with:

> mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')

Before this PR users see `Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed` and have no idea what to do. After this PR they see the actual reason and can immediately rebuild Ruby as arm64 (or run through `arch -arm64`) instead.

## Changes
- `Loader.load` collects per-attempt errors and feeds them into a new `Loader.failureMessage(path:attemptFailures:)` helper.
- The helper is `static` so it can be tested without triggering `fatalError`.
- New `LoaderTests` covers both the populated-attempts path and the empty-attempts edge case.
- `CHANGELOG.md` entry under a new `## Main` section.

## Test plan
- [x] `swift build` — clean
- [x] `swift test --filter LoaderTests` — 2/2 pass
- [x] Full `swift test` — no new failures (6 pre-existing `SourceKitTests` failures are Swift-toolchain-version drift on Xcode 26.4, unrelated to this change)
- [x] Manually verified the new message format reads well with real dyld errors

Refs realm/SwiftLint#6475
