### PR TITLE
Avoid getcwd when the path is already absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [John Fairhurst](https://github.com/johnfairh)
 * Improve reporting of `sourcekitdInProc` loading failures.  
   [Daniel Sunarjo](https://github.com/sunarjodaniel)
+* Avoid `getcwd` in `absolutePathRepresentation()` for absolute paths.  
+  [Brett Best](https://github.com/Brett-Best)
 
 #### Bug Fixes
 

--- a/Source/SourceKittenFramework/String+SourceKitten.swift
+++ b/Source/SourceKittenFramework/String+SourceKitten.swift
@@ -170,9 +170,12 @@ extension NSString {
      Returns self represented as an absolute path.
 
      - parameter rootDirectory: Absolute parent path if not already an absolute path.
+                                Uses the current directory by default, evaluated only
+                                if this path is relative.
      */
-    public func absolutePathRepresentation(rootDirectory: String = FileManager.default.currentDirectoryPath) -> String {
+    public func absolutePathRepresentation(rootDirectory: String? = nil) -> String {
         if isAbsolutePath { return expandingTildeInPath }
+        let rootDirectory = rootDirectory ?? FileManager.default.currentDirectoryPath
         #if os(Linux)
         return NSURL(fileURLWithPath: NSURL.fileURL(withPathComponents: [rootDirectory, bridge()])!.path).standardizingPath!.path
         #else


### PR DESCRIPTION
# Avoid `getcwd` when the path is already absolute

## What

`NSString.absolutePathRepresentation(rootDirectory:)` has an early return for already-absolute paths, but its default argument runs a `getcwd` syscall on **every** call regardless — even when that early return means the value is never used.

```diff
-    public func absolutePathRepresentation(rootDirectory: String = FileManager.default.currentDirectoryPath) -> String {
+    public func absolutePathRepresentation(rootDirectory: String? = nil) -> String {
         if isAbsolutePath { return expandingTildeInPath }
+        let rootDirectory = rootDirectory ?? FileManager.default.currentDirectoryPath
```

This makes `rootDirectory` optional and resolves the working directory lazily, only on the relative-path branch that actually uses it.

## Why it's not as cheap as it looks

Swift evaluates a default argument **at the call site, before the callee body runs**. So `absolutePathRepresentation()` on an absolute path still computes `FileManager.default.currentDirectoryPath` and then discards it.

`FileManager.default` is a singleton, but `.currentDirectoryPath` is **not a cached value** — it does real work on every access. In swift-foundation it allocates a buffer, issues a `getcwd(2)` syscall, and constructs a fresh `String`:

https://github.com/swiftlang/swift-foundation/blob/96d4094612d02bdc6f474f73efa0695196e786e9/Sources/FoundationEssentials/FileManager/FileManager+Directories.swift#L512-L529

(On Darwin the ObjC Foundation implementation is at least as expensive.)

## Impact

`File(pathDeferringReading:)` calls this once per file, always with an absolute path. Tools that enumerate large projects therefore make one pointless `getcwd` per file during file discovery.

Profiling SwiftLint linting a ~7,000-file project (Instruments Time Profiler, release build): `currentDirectoryPath` accounts for **~0.8 s of CPU (≈2.7 % of the run)**, and it sits on the *serial* pre-lint file-discovery path, so it is a proportionally larger share of warm/incremental runs where little else executes. An isolated before/after A/B of the same lint measured **~3 %** off both cold and warm wall-clock (the wall figure is smaller than the CPU figure because the directory walk is parallelized).

## Correctness

Behavior-preserving by construction: the resolved working directory is only ever *used* on the relative-path branch, which is unchanged; the absolute-path branch never read it. Verified end-to-end by linting a large project with all rules enabled — identical violation output (same count, files, lines, columns) before and after.
